### PR TITLE
Add non-monolith standards and refactor tasks

### DIFF
--- a/.codex/tasks/44b19f87-split-style-module.md
+++ b/.codex/tasks/44b19f87-split-style-module.md
@@ -1,0 +1,21 @@
+# Split `codex_local_conatinerd/style.py` into palette + stylesheet builder
+
+## Context
+`codex_local_conatinerd/style.py` is above the soft limit and will likely grow as UI evolves.
+
+## Goal
+Separate style constants (palette/metrics) from stylesheet construction to keep modules small and reusable.
+
+## Proposed module layout
+- `codex_local_conatinerd/style.py`: compatibility shim exporting `app_stylesheet()`
+- `codex_local_conatinerd/style/` package:
+  - `palette.py`: colors and constants
+  - `metrics.py`: spacing/font sizes (if applicable)
+  - `sheet.py`: stylesheet builder functions
+  - `__init__.py`: exports `app_stylesheet`
+
+## Acceptance criteria
+- `app_stylesheet()` output remains byte-for-byte identical (or visually identical if ordering is not stable).
+- No file exceeds 600 lines; prefer ≤ 300.
+- Square-corner constraint remains enforced (no `border-radius`, no rounded painting).
+

--- a/.codex/tasks/6878ed34-split-github-management-module.md
+++ b/.codex/tasks/6878ed34-split-github-management-module.md
@@ -1,0 +1,22 @@
+# Split `codex_local_conatinerd/gh_management.py` into focused helpers
+
+## Context
+`codex_local_conatinerd/gh_management.py` is above the soft limit and contains mixed responsibilities: git operations, `gh` CLI interactions, planning, and error handling.
+
+## Goal
+Split GitHub/Git management into smaller modules with clear boundaries and stable public APIs.
+
+## Proposed module layout
+- `codex_local_conatinerd/gh_management.py`: compatibility shim for public API
+- `codex_local_conatinerd/gh/` package:
+  - `git_ops.py`: `is_git_repo`, `git_list_remote_heads`, small git helpers
+  - `gh_cli.py`: `is_gh_available`, `gh` invocation and parsing
+  - `repo_clone.py`: `ensure_github_clone` and checkout/update logic
+  - `task_plan.py`: `plan_repo_task`, `prepare_branch_for_task`, `commit_push_and_pr`
+  - `errors.py`: `GhManagementError` and related exceptions
+
+## Acceptance criteria
+- Existing call sites (especially `codex_local_conatinerd/app.py`) keep working without behavior changes.
+- No file exceeds 600 lines; prefer ≤ 300.
+- Errors remain user-friendly and actionable.
+

--- a/.codex/tasks/8709f5da-split-docker-runner-module.md
+++ b/.codex/tasks/8709f5da-split-docker-runner-module.md
@@ -1,0 +1,27 @@
+# Split `codex_local_conatinerd/docker_runner.py` into smaller modules
+
+## Context
+`codex_local_conatinerd/docker_runner.py` is over the hard limit (600+ lines) and mixes configuration, process execution, and Qt thread/worker logic.
+
+## Goal
+Break `docker_runner.py` into a small, testable set of modules without changing runtime behavior.
+
+## Proposed module layout
+- `codex_local_conatinerd/docker_runner.py`: compatibility shim that re-exports public API
+- `codex_local_conatinerd/docker/` package:
+  - `config.py`: `DockerRunnerConfig` and related normalization/validation
+  - `workers.py`: `DockerCodexWorker`, `DockerPreflightWorker` (Qt/QThread/QObject worker classes)
+  - `process.py`: subprocess invocation helpers, streaming log handling, time parsing
+  - `paths.py`: host/container path and mount helpers (if present today)
+
+## Acceptance criteria
+- Existing imports keep working:
+  - `from codex_local_conatinerd.docker_runner import DockerCodexWorker`
+  - `from codex_local_conatinerd.docker_runner import DockerPreflightWorker`
+  - `from codex_local_conatinerd.docker_runner import DockerRunnerConfig`
+- No file exceeds 600 lines; prefer ≤ 300.
+- `uv run main.py` still runs end-to-end docker flows that previously worked.
+
+## Notes
+- Keep process execution code free of Qt when possible; isolate Qt concerns in `workers.py`.
+

--- a/.codex/tasks/c5121604-split-qt-ui-out-of-app-py.md
+++ b/.codex/tasks/c5121604-split-qt-ui-out-of-app-py.md
@@ -1,0 +1,36 @@
+# Split Qt UI out of `codex_local_conatinerd/app.py`
+
+## Context
+`codex_local_conatinerd/app.py` is a multi-thousand-line module mixing:
+- Qt widgets/pages
+- animations/painting helpers
+- task state/model
+- thread/worker bridges
+- glue logic (docker, environments, GH management, persistence)
+
+This violates the project guideline to avoid monolith files (soft max 300 lines, hard max 600 lines).
+
+## Goal
+Refactor the UI code into a small set of cohesive modules so no single file exceeds the line limits, while keeping behavior and public entrypoints stable.
+
+## Proposed module layout
+- `codex_local_conatinerd/app.py`: thin shim that keeps `run_app(argv)` and imports the real implementation.
+- `codex_local_conatinerd/ui/main_window.py`: `MainWindow` + top-level wiring
+- `codex_local_conatinerd/ui/pages/`: `DashboardPage`, `TaskDetailsPage`, `NewTaskPage`, `EnvironmentsPage`, `SettingsPage`
+- `codex_local_conatinerd/ui/task_model.py`: `Task` dataclass + status helpers
+- `codex_local_conatinerd/ui/bridges.py`: `TaskRunnerBridge`, `DockerPruneBridge`, `HostCleanupBridge`
+- `codex_local_conatinerd/ui/graphics.py`: `_EnvironmentTintOverlay`, `_BackgroundOrb`, color/blend helpers
+- `codex_local_conatinerd/ui/icons.py`: `_app_icon()` and asset helpers (if needed)
+- `codex_local_conatinerd/ui/utils.py`: safe string/formatting/time parsing helpers used by UI
+
+## Acceptance criteria
+- `uv run main.py` still launches and all existing pages render and function.
+- `codex_local_conatinerd/app.py` stays ≤ 300 lines and is primarily re-exports/glue.
+- No single new module exceeds 600 lines; prefer ≤ 300.
+- Public imports used elsewhere remain valid (or are re-exported from the old locations).
+- Minimal diff behavior: no UX/style changes unless necessary for the refactor.
+
+## Notes
+- Avoid circular imports by keeping Qt-only helpers in `ui/*` and domain logic in existing modules (`docker_runner`, `environments`, `persistence`, `gh_management`).
+- Keep square-corner UI constraint (no rounded corners) unchanged during refactor.
+

--- a/.codex/tasks/cc5a24e0-split-environments-module.md
+++ b/.codex/tasks/cc5a24e0-split-environments-module.md
@@ -1,0 +1,26 @@
+# Split `codex_local_conatinerd/environments.py` into model + parsing + storage
+
+## Context
+`codex_local_conatinerd/environments.py` is at/above the soft limit and mixes:
+- the `Environment` model and constants
+- text parsing (mounts/env vars)
+- filesystem persistence (load/save/delete)
+- repo checkout path helpers
+
+## Goal
+Split environment management into clear layers while keeping the current behavior and serialized format.
+
+## Proposed module layout
+- `codex_local_conatinerd/environments.py`: compatibility shim for public API/constants
+- `codex_local_conatinerd/environments/` package:
+  - `model.py`: `Environment`, constants (including stain options), GH management mode constants
+  - `parse.py`: `parse_env_vars_text`, `parse_mounts_text`, normalization helpers
+  - `storage.py`: `load_environments`, `save_environment`, `delete_environment`
+  - `paths.py`: `managed_repos_dir`, `managed_repo_checkout_path`
+  - `serialize.py`: `serialize_environment` and versioning if needed
+
+## Acceptance criteria
+- Existing behavior and on-disk formats remain unchanged.
+- No file exceeds 600 lines; prefer ≤ 300.
+- Existing imports used by `codex_local_conatinerd/app.py` remain valid (via re-exports).
+

--- a/.codex/tasks/e1f3c894-split-widgets-module.md
+++ b/.codex/tasks/e1f3c894-split-widgets-module.md
@@ -1,0 +1,22 @@
+# Split `codex_local_conatinerd/widgets.py` into a widgets package
+
+## Context
+`codex_local_conatinerd/widgets.py` is above the soft limit and contains multiple independent widget classes.
+
+## Goal
+Move each widget (or small related groups) into dedicated modules for maintainability and faster iteration.
+
+## Proposed module layout
+- `codex_local_conatinerd/widgets.py`: compatibility shim that re-exports symbols
+- `codex_local_conatinerd/widgets/` package:
+  - `glass_card.py`: `GlassCard`
+  - `status_glyph.py`: `StatusGlyph`
+  - `loading_bar.py`: `BouncingLoadingBar`
+  - `log_highlighter.py`: `LogHighlighter`
+  - `__init__.py`: re-exports used by the rest of the app
+
+## Acceptance criteria
+- Existing imports keep working (via re-exports).
+- No widget module exceeds 600 lines; prefer ≤ 300.
+- No visual/style changes other than those required to preserve behavior.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ This project uses the Codex contributor coordination system. Follow these guidel
 
 - Run `uv run main.py` to test the GUI locally before committing changes.
 - Follow existing code style: Python 3.13+, type hints throughout, and minimal modifications.
+- Avoid monolith files: **soft max 300 lines per file**, **hard max 600 lines per file** (split modules/classes when approaching the soft limit).
 - Keep UI elements sharp—no rounded corners in stylesheets or custom painting code.
 - Run linters and tests before submitting PRs.
 - Use structured commit messages: `[TYPE] Concise summary`


### PR DESCRIPTION
## Summary
- Document non-monolith standard (soft max 300 LOC, hard max 600 LOC).
- Add Task Master tickets to split oversized modules.

## Tasks added
- `.codex/tasks/c5121604-split-qt-ui-out-of-app-py.md`
- `.codex/tasks/8709f5da-split-docker-runner-module.md`
- `.codex/tasks/6878ed34-split-github-management-module.md`
- `.codex/tasks/e1f3c894-split-widgets-module.md`
- `.codex/tasks/44b19f87-split-style-module.md`
- `.codex/tasks/cc5a24e0-split-environments-module.md`

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner).
Agent Used: codex
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI).
