### PR TITLE
Fix folder path in Environments and Settings menu subtitles

### DIFF
--- a/agents_runner/ui/pages/environments.py
+++ b/agents_runner/ui/pages/environments.py
@@ -54,7 +54,7 @@ class EnvironmentsPage(QWidget, _EnvironmentsPageActionsMixin):
 
         title = QLabel("Environments")
         title.setStyleSheet("font-size: 18px; font-weight: 750;")
-        subtitle = QLabel("Saved locally in ~/.midoriai/codex-container-gui/state.json")
+        subtitle = QLabel("Saved locally in ~/.midoriai/agents-runner/state.json")
         subtitle.setStyleSheet("color: rgba(237, 239, 245, 160);")
 
         back = QToolButton()

--- a/agents_runner/ui/pages/settings.py
+++ b/agents_runner/ui/pages/settings.py
@@ -40,7 +40,7 @@ class SettingsPage(QWidget):
 
         title = QLabel("Settings")
         title.setStyleSheet("font-size: 18px; font-weight: 750;")
-        subtitle = QLabel("Saved locally in ~/.midoriai/codex-container-gui/state.json")
+        subtitle = QLabel("Saved locally in ~/.midoriai/agents-runner/state.json")
         subtitle.setStyleSheet("color: rgba(237, 239, 245, 160);")
 
         back = QToolButton()


### PR DESCRIPTION
Updated the subtitle text in both Environments and Settings pages to reflect the correct folder structure.

**Changes:**
- Changed `~/.midoriai/codex-container-gui/state.json` to `~/.midoriai/agents-runner/state.json` in both pages
- This matches the actual path used in `persistence.py` and documented in README.md

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner).
Agent Used: copilot
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI).
