### PR TITLE
[FIX] Update helpme.sh path in new task menu

### DIFF
--- a/agents_runner/ui/pages/new_task.py
+++ b/agents_runner/ui/pages/new_task.py
@@ -245,7 +245,7 @@ class NewTaskPage(QWidget):
             )
             return
 
-        helpme_path = Path(__file__).resolve().parent / "preflights" / "helpme.sh"
+        helpme_path = Path(__file__).resolve().parent.parent.parent / "preflights" / "helpme.sh"
         try:
             helpme_script = helpme_path.read_text(encoding="utf-8")
         except Exception:


### PR DESCRIPTION
## Summary
Fixed the path reference to `helpme.sh` in the new task menu's "get agent help" button.

## Changes
- Updated path construction in `new_task.py` to correctly point to `agents_runner/preflights/helpme.sh`
- Changed from `parent / "preflights"` to `parent.parent.parent / "preflights"` to account for the file's actual location

## Context
The `helpme.sh` file was moved to `agents_runner/preflights/` but the reference in the UI was still looking in the old location relative to the pages directory.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner).
Agent Used: copilot
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI).
