### PR TITLE
Fix environment agent selection not being respected

### DIFF
--- a/agents_runner/ui/main_window_settings.py
+++ b/agents_runner/ui/main_window_settings.py
@@ -135,9 +135,27 @@ class _MainWindowSettingsMixin:
                 settings.get("host_codex_dir")
                 or os.environ.get("CODEX_HOST_CODEX_DIR", os.path.expanduser("~/.codex"))
             )
-        if env and env.host_codex_dir:
+        
+        if env and env.agent_selection and env.agent_selection.agent_config_dirs:
+            agent_config = env.agent_selection.agent_config_dirs.get(agent_cli, "")
+            if agent_config:
+                config_dir = agent_config
+        elif env and env.host_codex_dir:
             config_dir = env.host_codex_dir
+        
         return os.path.expanduser(str(config_dir or "").strip())
+
+
+    def _effective_agent_cli(
+        self,
+        *,
+        env: Environment | None,
+        settings: dict[str, object] | None = None,
+    ) -> str:
+        settings = settings or self._settings_data
+        if env and env.agent_selection and env.agent_selection.enabled_agents:
+            return normalize_agent(env.agent_selection.enabled_agents[0])
+        return normalize_agent(str(settings.get("use") or "codex"))
 
 
     def _ensure_agent_config_dir(self, agent_cli: str, host_config_dir: str) -> bool:

--- a/agents_runner/ui/main_window_tasks_agent.py
+++ b/agents_runner/ui/main_window_tasks_agent.py
@@ -73,8 +73,6 @@ class _MainWindowTasksAgentMixin:
             return
         prompt = sanitize_prompt((prompt or "").strip())
 
-        agent_cli = normalize_agent(str(self._settings_data.get("use") or "codex"))
-
         task_id = uuid4().hex[:10]
         env_id = str(env_id or "").strip() or self._active_environment_id()
         if env_id not in self._environments:
@@ -82,6 +80,8 @@ class _MainWindowTasksAgentMixin:
             return
         self._settings_data["active_environment_id"] = env_id
         env = self._environments.get(env_id)
+
+        agent_cli = self._effective_agent_cli(env=env)
 
         gh_mode = normalize_gh_management_mode(str(env.gh_management_mode or GH_MANAGEMENT_NONE)) if env else GH_MANAGEMENT_NONE
         effective_workdir, ready, message = self._new_task_workspace(env)

--- a/agents_runner/ui/main_window_tasks_interactive.py
+++ b/agents_runner/ui/main_window_tasks_interactive.py
@@ -85,7 +85,7 @@ class _MainWindowTasksInteractiveMixin:
 
         desired_base = str(base_branch or "").strip()
 
-        agent_cli = normalize_agent(str(self._settings_data.get("use") or "codex"))
+        agent_cli = self._effective_agent_cli(env=env)
         if not host_codex:
             host_codex = self._effective_host_config_dir(agent_cli=agent_cli, env=env)
         if not self._ensure_agent_config_dir(agent_cli, host_codex):


### PR DESCRIPTION
## Problem

There was a bug where the environment's agent selection was being ignored when launching interactive or agent tasks. The system was always using the agent specified in Settings, regardless of what was configured in the environment's Agents tab.

## Root Cause

Both `main_window_tasks_interactive.py` and `main_window_tasks_agent.py` were hardcoded to use `self._settings_data.get("use")` to determine which agent to run, completely bypassing the environment's `agent_selection` configuration.

## Solution

Added a new helper method `_effective_agent_cli()` that:
1. Checks if the environment has an `agent_selection` with `enabled_agents`
2. If yes, returns the first enabled agent from the environment
3. Otherwise, falls back to the settings agent

Also updated `_effective_host_config_dir()` to check for agent-specific config directories in `agent_selection.agent_config_dirs`.

## Changes

- Added `_effective_agent_cli()` helper method in `main_window_settings.py`
- Updated `_effective_host_config_dir()` to use environment agent config directories
- Updated interactive task launcher to use `_effective_agent_cli(env=env)`
- Updated agent task launcher to use `_effective_agent_cli(env=env)`

## Testing

- Code compiles and imports successfully
- Logic verified through code review

Now when an environment has an agent selected in the Agents tab, that agent will be used for tasks instead of the global Settings agent.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner).
Agent Used: copilot
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI).
