### PR TITLE
Fix Copilot CLI sandboxing bypass flags

### DIFF
--- a/agents_runner/agent_cli.py
+++ b/agents_runner/agent_cli.py
@@ -84,6 +84,7 @@ def build_noninteractive_cmd(
         args = [
             "copilot",
             "--allow-all-tools",
+            "--allow-all-paths",
             "--add-dir",
             container_workdir,
             *extra_args,

--- a/agents_runner/ui/main_window.py
+++ b/agents_runner/ui/main_window.py
@@ -82,7 +82,7 @@ class MainWindow(
             "interactive_terminal_id": "",
             "interactive_command": "--sandbox danger-full-access",
             "interactive_command_claude": "--add-dir /home/midori-ai/workspace",
-            "interactive_command_copilot": "--add-dir /home/midori-ai/workspace",
+            "interactive_command_copilot": "--allow-all-tools --allow-all-paths --add-dir /home/midori-ai/workspace",
             "window_w": 1280,
             "window_h": 720,
             "max_agents_running": -1,

--- a/agents_runner/ui/main_window_persistence.py
+++ b/agents_runner/ui/main_window_persistence.py
@@ -91,7 +91,7 @@ class _MainWindowPersistenceMixin:
         self._settings_data.setdefault("host_claude_dir", "")
         self._settings_data.setdefault("host_copilot_dir", "")
         self._settings_data.setdefault("interactive_command_claude", "--add-dir /home/midori-ai/workspace")
-        self._settings_data.setdefault("interactive_command_copilot", "--add-dir /home/midori-ai/workspace")
+        self._settings_data.setdefault("interactive_command_copilot", "--allow-all-tools --allow-all-paths --add-dir /home/midori-ai/workspace")
         host_codex_dir = os.path.normpath(os.path.expanduser(str(self._settings_data.get("host_codex_dir") or "").strip()))
         if host_codex_dir == os.path.expanduser("~/.midoriai"):
             self._settings_data["host_codex_dir"] = os.path.expanduser("~/.codex")


### PR DESCRIPTION
## Problem

The Copilot CLI was being invoked with incomplete sandbox bypass flags, causing it to fail when trying to access system files like `/etc/os-release` in containers. The agent would show "Permission denied and could not request permission from user" errors.

## Root Cause

Copilot was configured with `--allow-all-tools` and `--add-dir` but was missing the critical `--allow-all-paths` flag that disables file path verification completely (equivalent to Codex's `--sandbox danger-full-access`).

## Changes

### Non-interactive mode (`agent_cli.py`)
- Added `--allow-all-paths` flag to the Copilot command builder

### Interactive mode defaults
- Updated default `interactive_command_copilot` in `main_window.py` and `main_window_persistence.py`
- Changed from: `--add-dir /home/midori-ai/workspace`
- Changed to: `--allow-all-tools --allow-all-paths --add-dir /home/midori-ai/workspace`

## Testing

Copilot agents should now be able to:
- Access system files (`/etc/os-release`, `/usr/lib/os-release`)
- Run preflight environment checks without permission errors
- Operate with the same unrestricted access as Codex agents in containerized environments

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner).
Agent Used: copilot
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI).
