### PR TITLE
Clarify fallback wording and fix legacy config override

### DIFF
--- a/agents_runner/ui/main_window_settings.py
+++ b/agents_runner/ui/main_window_settings.py
@@ -154,8 +154,8 @@ class _MainWindowSettingsMixin:
                 or os.environ.get("CODEX_HOST_CODEX_DIR", os.path.expanduser("~/.codex"))
             )
 
-        # Legacy: check env.host_codex_dir override (deprecated)
-        if env and env.host_codex_dir:
+        # Legacy: check env.host_codex_dir override (deprecated) — only apply for codex
+        if agent_cli == "codex" and env and env.host_codex_dir:
             config_dir = env.host_codex_dir
 
         return os.path.expanduser(str(config_dir or "").strip())
@@ -372,7 +372,10 @@ class _MainWindowSettingsMixin:
             fallbacks = dict(getattr(env.agent_selection, "agent_fallbacks", {}) or {})
             wanted_id = str(fallbacks.get(str(getattr(current, "agent_id", "") or "").strip(), "") or "").strip()
             next_inst = next((a for a in agents if str(getattr(a, "agent_id", "") or "").strip() == wanted_id), None)
-            return self._format_agent_label(current), (self._format_agent_label(next_inst) if next_inst else "")
+            next_label = (self._format_agent_label(next_inst) if next_inst else "")
+            if next_label:
+                next_label = f"Fallback: {next_label}"
+            return self._format_agent_label(current), next_label
 
         if mode == "least-used":
             tasks = getattr(self, "_tasks", {}) or {}

--- a/agents_runner/ui/pages/new_task.py
+++ b/agents_runner/ui/pages/new_task.py
@@ -424,7 +424,10 @@ class NewTaskPage(QWidget):
         next_agent = str(next_agent or "").strip()
         
         if next_agent and next_agent != agent:
-            tooltip = f"Using: {agent} | Next: {next_agent}"
+            if str(next_agent).startswith("Fallback:"):
+                tooltip = f"Using: {agent} | {next_agent}"
+            else:
+                tooltip = f"Using: {agent} | Next: {next_agent}"
         elif agent:
             tooltip = f"Using: {agent}"
         else:


### PR DESCRIPTION
- Show fallback mapping as 'Fallback: <agent>' in New Task tooltips when environment selection mode is fallback.
- Only apply legacy env.host_codex_dir override for the 'codex' agent so per-agent config dirs (e.g. Copilot) are resolved correctly.

This makes the UI clearer (doesn't imply a fallback is the next round-robin choice) and fixes config mounting using the intended per-agent directory.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner).
Agent Used: copilot
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI).
