### PR TITLE
Use diamond icon for Kill action

### DIFF
--- a/agents_runner/ui/pages/task_details.py
+++ b/agents_runner/ui/pages/task_details.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
 from PySide6.QtCore import Qt
+from PySide6.QtCore import QPoint
 from PySide6.QtCore import QSize
 from PySide6.QtCore import QTimer
 from PySide6.QtCore import Signal
+from PySide6.QtGui import QColor
+from PySide6.QtGui import QIcon
+from PySide6.QtGui import QPainter
+from PySide6.QtGui import QPixmap
+from PySide6.QtGui import QPolygon
 from PySide6.QtWidgets import QMenu
 from PySide6.QtWidgets import QGridLayout
 from PySide6.QtWidgets import QHBoxLayout
@@ -24,6 +30,32 @@ from agents_runner.ui.utils import _status_color
 from agents_runner.widgets import GlassCard
 from agents_runner.widgets import LogHighlighter
 from agents_runner.widgets import StatusGlyph
+
+
+def _diamond_icon(size: int = 16, color: QColor | None = None) -> QIcon:
+    color = color or QColor(237, 239, 245)
+    pm = QPixmap(size, size)
+    pm.fill(Qt.transparent)
+
+    half = (size - 1) / 2.0
+    inset = max(2, int(size * 0.22))
+    pts = QPolygon(
+        [
+            QPoint(int(half), inset),
+            QPoint(size - inset - 1, int(half)),
+            QPoint(int(half), size - inset - 1),
+            QPoint(inset, int(half)),
+        ]
+    )
+
+    p = QPainter(pm)
+    p.setRenderHint(QPainter.Antialiasing, True)
+    p.setPen(Qt.NoPen)
+    p.setBrush(color)
+    p.drawPolygon(pts)
+    p.end()
+
+    return QIcon(pm)
 
 
 class TaskDetailsPage(QWidget):
@@ -143,7 +175,7 @@ class TaskDetailsPage(QWidget):
         self._btn_kill = QToolButton()
         self._btn_kill.setToolButtonStyle(Qt.ToolButtonIconOnly)
         self._btn_kill.setAutoRaise(True)
-        self._btn_kill.setIcon(self.style().standardIcon(QStyle.SP_TitleBarCloseButton))
+        self._btn_kill.setIcon(_diamond_icon(16))
         self._btn_kill.setIconSize(QSize(16, 16))
         self._btn_kill.setToolTip("Kill container (force stop)")
         self._btn_kill.clicked.connect(lambda: self._emit_container_action("kill"))


### PR DESCRIPTION
Replaced the Kill container button icon in Task Details from the titlebar close (X) glyph to a custom diamond glyph so it matches the media-control style better.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner).
Agent Used: copilot
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI).
