### PR TITLE
Animate background by agent theme

### DIFF
--- a/agents_runner/ui/main_window.py
+++ b/agents_runner/ui/main_window.py
@@ -115,10 +115,10 @@ class MainWindow(
         self._dashboard_ticker.timeout.connect(self._tick_dashboard_elapsed)
         self._dashboard_ticker.start()
 
-        root = GlassRoot()
-        self.setCentralWidget(root)
+        self._root = GlassRoot()
+        self.setCentralWidget(self._root)
 
-        outer = QVBoxLayout(root)
+        outer = QVBoxLayout(self._root)
         outer.setContentsMargins(18, 18, 18, 18)
         outer.setSpacing(14)
 

--- a/agents_runner/ui/main_window_environment.py
+++ b/agents_runner/ui/main_window_environment.py
@@ -156,6 +156,11 @@ class _MainWindowEnvironmentMixin:
         env = self._environments.get(self._active_environment_id())
         # Get effective agent and config dir (environment agent_selection overrides settings)
         agent_cli, host_codex = self._effective_agent_and_config(env=env)
+        if hasattr(self, "_root"):
+            try:
+                self._root.set_agent_theme(agent_cli)
+            except Exception:
+                pass
         current_agent, next_agent = self._get_next_agent_info(env=env)
         workdir, ready, message = self._new_task_workspace(env)
         self._new_task.set_defaults(host_codex=host_codex)


### PR DESCRIPTION
### What changed
- Added agent-specific background themes (Codex, Copilot, Claude, Gemini) to the `GlassRoot` renderer.
- Implemented a 7s cross-fade when switching themes.
- Wired the background theme to the *effective* agent selection (global Settings + per-environment overrides).

### UX notes
- The fade is overlapping (new theme fades in while the previous remains visible beneath it) and lasts 7000ms.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner).
Agent Used: copilot
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI).
