### PR TITLE
Copilot: add Local/Cloud Run Agent menu

### DIFF
--- a/agents_runner/ui/main_window.py
+++ b/agents_runner/ui/main_window.py
@@ -166,6 +166,15 @@ class MainWindow(
         self._dashboard.task_discard_requested.connect(self._discard_task_from_ui)
         self._new_task = NewTaskPage()
         self._new_task.requested_run.connect(self._start_task_from_ui)
+        self._new_task.requested_run_cloud.connect(
+            lambda prompt, host_codex, env_id, base_branch: self._start_task_from_ui(
+                prompt,
+                host_codex,
+                env_id,
+                base_branch,
+                True,
+            )
+        )
         self._new_task.requested_launch.connect(self._start_interactive_task_from_ui)
         self._new_task.environment_changed.connect(self._on_new_task_env_changed)
         self._new_task.back_requested.connect(self._show_dashboard)

--- a/agents_runner/ui/main_window_tasks_agent.py
+++ b/agents_runner/ui/main_window_tasks_agent.py
@@ -67,6 +67,7 @@ class _MainWindowTasksAgentMixin:
         host_codex: str,
         env_id: str,
         base_branch: str,
+        copilot_cloud: bool = False,
     ) -> None:
         if shutil.which("docker") is None:
             QMessageBox.critical(self, "Docker not found", "Could not find `docker` in PATH.")
@@ -219,6 +220,9 @@ class _MainWindowTasksAgentMixin:
             gh_recreate_if_needed=True,
             gh_base_branch=desired_base or None,
         )
+        if copilot_cloud and normalize_agent(agent_cli) == "copilot":
+            runner_prompt = f"/delegate {runner_prompt.strip()}"
+
         task._runner_config = config
         task._runner_prompt = runner_prompt
 


### PR DESCRIPTION
### What changed

- When the effective agent is **Copilot**, the **Run Agent** button now exposes a small dropdown with:
  - **Local Agent** (current behavior)
  - **Cloud Agent** (runs Copilot CLI with a `/delegate …` prompt to hand off to Copilot coding agent)
- For non-Copilot agents, the UI remains unchanged.

### Notes

- Cloud Agent is implemented by prefixing the runner prompt with `/delegate` (per Copilot CLI docs).

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner).
Agent Used: copilot
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI).
