### PR TITLE
Agent Runner: Update agent display names and PR formatting

### DIFF
--- a/agents_runner/agent_display.py
+++ b/agents_runner/agent_display.py
@@ -1,0 +1,38 @@
+"""Agent display name and GitHub URL mappings."""
+
+from __future__ import annotations
+
+AGENT_DISPLAY_NAMES = {
+    "codex": "OpenAI Codex",
+    "claude": "Claude Code",
+    "copilot": "Github Copilot",
+    "gemini": "Google Gemini",
+}
+
+AGENT_GITHUB_URLS = {
+    "codex": "https://github.com/openai/codex",
+    "claude": "https://github.com/anthropics/claude-code",
+    "copilot": "https://github.com/github/copilot-cli",
+    "gemini": "https://github.com/google-gemini/gemini-cli",
+}
+
+
+def get_agent_display_name(agent_cli: str) -> str:
+    """Get the display name for an agent CLI."""
+    normalized = str(agent_cli or "").strip().lower()
+    return AGENT_DISPLAY_NAMES.get(normalized, agent_cli)
+
+
+def get_agent_github_url(agent_cli: str) -> str:
+    """Get the GitHub URL for an agent CLI."""
+    normalized = str(agent_cli or "").strip().lower()
+    return AGENT_GITHUB_URLS.get(normalized, "")
+
+
+def format_agent_markdown_link(agent_cli: str) -> str:
+    """Format agent as a markdown link."""
+    display_name = get_agent_display_name(agent_cli)
+    github_url = get_agent_github_url(agent_cli)
+    if github_url:
+        return f"[{display_name}]({github_url})"
+    return display_name

--- a/agents_runner/ui/main_window_tasks_interactive_finalize.py
+++ b/agents_runner/ui/main_window_tasks_interactive_finalize.py
@@ -8,6 +8,8 @@ from datetime import timezone
 from PySide6.QtWidgets import QApplication
 from PySide6.QtWidgets import QMessageBox
 
+from agents_runner.agent_display import format_agent_markdown_link
+from agents_runner.agent_display import get_agent_display_name
 from agents_runner.environments import GH_MANAGEMENT_GITHUB
 from agents_runner.environments import normalize_gh_management_mode
 from agents_runner.gh_management import commit_push_and_pr
@@ -90,10 +92,16 @@ class _MainWindowTasksInteractiveFinalizeMixin:
             return
 
         prompt_line = (prompt_text or "").strip().splitlines()[0] if prompt_text else ""
-        default_title = f"codex: {prompt_line or task_id}"
+        default_title = f"Agent Runner: {prompt_line or task_id}"
         default_title = normalize_pr_title(default_title, fallback=default_title)
+        
+        agent_display = get_agent_display_name(agent_cli) if agent_cli else "Agent"
+        agent_link = format_agent_markdown_link(agent_cli) if agent_cli else agent_display
+        runners_link = "[Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)"
+        
         default_body = (
-            f"Automated by {APP_TITLE}.\n\n"
+            f"Automated by {runners_link}.\n\n"
+            f"Agent: {agent_link}\n\n"
             f"Task: {task_token}\n\n"
             "Prompt:\n"
             f"{(prompt_text or '').strip()}\n"

--- a/agents_runner/ui/pages/settings.py
+++ b/agents_runner/ui/pages/settings.py
@@ -64,10 +64,10 @@ class SettingsPage(QWidget):
         grid.setColumnStretch(1, 1)
 
         self._use = QComboBox()
-        self._use.addItem("Codex", "codex")
-        self._use.addItem("Claude", "claude")
-        self._use.addItem("GitHub Copilot", "copilot")
-        self._use.addItem("Gemini", "gemini")
+        self._use.addItem("OpenAI Codex", "codex")
+        self._use.addItem("Claude Code", "claude")
+        self._use.addItem("Github Copilot", "copilot")
+        self._use.addItem("Google Gemini", "gemini")
 
         self._shell = QComboBox()
         for label, value in [


### PR DESCRIPTION
Updated agent display names in settings and environments menus to be more descriptive:

- **Codex** → **OpenAI Codex**
- **Claude** → **Claude Code**
- **GitHub Copilot** → **Github Copilot**
- **Gemini** → **Google Gemini**

Updated PR creation to use "Agent Runner:" prefix instead of "codex:" and added agent attribution with GitHub links in PR body.

**Changes:**
- Created `agents_runner/agent_display.py` with helper functions for agent display names and GitHub URLs
- Updated `settings.py` to use new display names in dropdown
- Updated `main_window_tasks_interactive_finalize.py` to:
  - Change PR title prefix from "codex:" to "Agent Runner:"
  - Add agent name with GitHub link in PR body
  - Link to Agents Runner GitHub repository

**GitHub URLs match those in Get Agent Help system:**
- OpenAI Codex: https://github.com/openai/codex
- Claude Code: https://github.com/anthropics/claude-code
- Github Copilot: https://github.com/github/copilot-cli
- Google Gemini: https://github.com/google-gemini/gemini-cli

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner).
Agent Used: copilot
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI).
