### PR TITLE
Remember last branch for git-locked environments

### DIFF
--- a/agents_runner/environments/model.py
+++ b/agents_runner/environments/model.py
@@ -80,6 +80,7 @@ class Environment:
     gh_management_mode: str = GH_MANAGEMENT_NONE
     gh_management_target: str = ""
     gh_management_locked: bool = False
+    gh_last_base_branch: str = ""
     gh_use_host_cli: bool = True
     gh_pr_metadata_enabled: bool = False
     prompts: list[PromptConfig] = field(default_factory=list)

--- a/agents_runner/environments/serialize.py
+++ b/agents_runner/environments/serialize.py
@@ -63,6 +63,7 @@ def _environment_from_payload(payload: dict[str, Any]) -> Environment | None:
     gh_management_mode = normalize_gh_management_mode(str(payload.get("gh_management_mode") or ""))
     gh_management_target = str(payload.get("gh_management_target") or "").strip()
     gh_management_locked = bool(payload.get("gh_management_locked", False))
+    gh_last_base_branch = str(payload.get("gh_last_base_branch") or "").strip()
     gh_use_host_cli = bool(payload.get("gh_use_host_cli", True))
     gh_pr_metadata_enabled = bool(payload.get("gh_pr_metadata_enabled", False))
 
@@ -172,6 +173,7 @@ def _environment_from_payload(payload: dict[str, Any]) -> Environment | None:
         gh_management_mode=gh_management_mode,
         gh_management_target=gh_management_target,
         gh_management_locked=gh_management_locked,
+        gh_last_base_branch=gh_last_base_branch,
         gh_use_host_cli=gh_use_host_cli,
         gh_pr_metadata_enabled=gh_pr_metadata_enabled,
         prompts=prompts,
@@ -229,6 +231,7 @@ def serialize_environment(env: Environment) -> dict[str, Any]:
         "gh_management_mode": normalize_gh_management_mode(env.gh_management_mode),
         "gh_management_target": str(env.gh_management_target or "").strip(),
         "gh_management_locked": bool(env.gh_management_locked),
+        "gh_last_base_branch": str(getattr(env, "gh_last_base_branch", "") or "").strip(),
         "gh_use_host_cli": bool(env.gh_use_host_cli),
         "gh_pr_metadata_enabled": bool(env.gh_pr_metadata_enabled),
         "prompts": [{"enabled": p.enabled, "text": p.text} for p in (env.prompts or [])],

--- a/agents_runner/ui/main_window_environment.py
+++ b/agents_runner/ui/main_window_environment.py
@@ -133,7 +133,15 @@ class _MainWindowEnvironmentMixin:
         cleaned = [str(b or "").strip() for b in branches]
         cleaned = [b for b in cleaned if b]
         self._new_task.set_repo_controls_visible(True)
-        self._new_task.set_repo_branches(cleaned)
+        
+        # Restore last selected branch for locked environments
+        selected_branch = None
+        if env and env.gh_management_locked:
+            last_branch = str(getattr(env, "gh_last_base_branch", "") or "").strip()
+            if last_branch and last_branch in cleaned:
+                selected_branch = last_branch
+        
+        self._new_task.set_repo_branches(cleaned, selected=selected_branch)
 
 
     def _populate_environment_pickers(self) -> None:

--- a/agents_runner/ui/main_window_tasks_agent.py
+++ b/agents_runner/ui/main_window_tasks_agent.py
@@ -21,6 +21,7 @@ from agents_runner.environments import GH_MANAGEMENT_GITHUB
 from agents_runner.environments import GH_MANAGEMENT_LOCAL
 from agents_runner.environments import GH_MANAGEMENT_NONE
 from agents_runner.environments import normalize_gh_management_mode
+from agents_runner.environments import save_environment
 from agents_runner.gh_management import is_gh_available
 from agents_runner.docker_runner import DockerRunnerConfig
 from agents_runner.pr_metadata import ensure_pr_metadata_file
@@ -162,6 +163,11 @@ class _MainWindowTasksAgentMixin:
         task.gh_use_host_cli = use_host_gh
 
         desired_base = str(base_branch or "").strip()
+        
+        # Save the selected branch for locked environments
+        if env and env.gh_management_locked and desired_base and gh_mode == GH_MANAGEMENT_GITHUB:
+            env.gh_last_base_branch = desired_base
+            save_environment(env)
 
         runner_prompt = prompt
         if bool(self._settings_data.get("append_pixelarch_context") or False):

--- a/agents_runner/ui/main_window_tasks_interactive.py
+++ b/agents_runner/ui/main_window_tasks_interactive.py
@@ -28,6 +28,7 @@ from agents_runner.environments import GH_MANAGEMENT_GITHUB
 from agents_runner.environments import GH_MANAGEMENT_LOCAL
 from agents_runner.environments import GH_MANAGEMENT_NONE
 from agents_runner.environments import normalize_gh_management_mode
+from agents_runner.environments import save_environment
 from agents_runner.gh_management import is_gh_available
 from agents_runner.prompt_sanitizer import sanitize_prompt
 from agents_runner.terminal_apps import detect_terminal_options
@@ -85,6 +86,11 @@ class _MainWindowTasksInteractiveMixin:
             return
 
         desired_base = str(base_branch or "").strip()
+        
+        # Save the selected branch for locked environments
+        if env and env.gh_management_locked and desired_base and gh_mode == GH_MANAGEMENT_GITHUB:
+            env.gh_last_base_branch = desired_base
+            save_environment(env)
 
         # Get effective agent and config dir (environment agent_selection overrides settings)
         agent_instance_id = ""


### PR DESCRIPTION
## Summary

Adds branch memory feature for git-locked Environments. When a user selects a branch for a locked environment, it will be remembered and automatically restored the next time they create a task in that environment.

## Changes

### Core Data Model
- Added `gh_last_base_branch` field to `Environment` model
- Updated serialization/deserialization to persist the branch selection
- Maintains backwards compatibility with existing environment files

### UI Integration
- Modified `_on_repo_branches_ready()` to restore saved branch for locked environments
- Updated `_start_task_from_ui()` to save branch selection when task starts
- Updated `_start_interactive_task_from_ui()` for interactive tasks

### Behavior
- Only remembers branch for environments with `gh_management_locked=True`
- Only saves when `gh_management_mode=github`
- Non-locked environments continue to default to "Auto (default)"
- Empty/invalid branches fall back to "Auto (default)"

## Testing

✅ Environment model includes new field
✅ Serialization/deserialization works correctly
✅ Backwards compatible with old environment files
✅ Branch memory logic tested for locked environments
✅ All Python files compile successfully

## Files Modified

- `agents_runner/environments/model.py`
- `agents_runner/environments/serialize.py`
- `agents_runner/ui/main_window_environment.py`
- `agents_runner/ui/main_window_tasks_agent.py`
- `agents_runner/ui/main_window_tasks_interactive.py`

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner).
Agent Used: copilot
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI).
