### PR TITLE
[UI] Standardize settings and environments menu formatting

### DIFF
--- a/agents_runner/ui/constants.py
+++ b/agents_runner/ui/constants.py
@@ -10,3 +10,36 @@ PIXELARCH_AGENT_CONTEXT_SUFFIX = (
     "- If you need to install packages, use `yay -Syu`.\n"
     "- You have full control of the container you are running in.\n"
 )
+
+# UI Layout Constants (standardized across all pages)
+# Main layout constants
+MAIN_LAYOUT_MARGINS = (0, 0, 0, 0)
+MAIN_LAYOUT_SPACING = 14
+
+# Header constants (GlassCard with title/subtitle/back)
+HEADER_MARGINS = (18, 16, 18, 16)
+HEADER_SPACING = 10
+
+# Content card constants (GlassCard with form/content)
+CARD_MARGINS = (18, 16, 18, 16)
+CARD_SPACING = 12
+
+# Tab content constants (for widgets inside tab containers)
+TAB_CONTENT_MARGINS = (0, 16, 0, 12)
+TAB_CONTENT_SPACING = 10
+
+# Grid layout constants
+GRID_HORIZONTAL_SPACING = 10
+GRID_VERTICAL_SPACING = 10
+
+# Button row constants
+BUTTON_ROW_SPACING = 10
+
+# Standard button width for Browse/similar buttons
+STANDARD_BUTTON_WIDTH = 100
+
+# Table row height
+TABLE_ROW_HEIGHT = 56
+
+# Standard column widths
+AGENT_COMBO_WIDTH = 170

--- a/agents_runner/ui/pages/environments.py
+++ b/agents_runner/ui/pages/environments.py
@@ -28,6 +28,20 @@ from agents_runner.environments import GH_MANAGEMENT_NONE
 from agents_runner.environments import normalize_gh_management_mode
 from agents_runner.gh_management import is_gh_available
 from agents_runner.widgets import GlassCard
+from agents_runner.ui.constants import (
+    MAIN_LAYOUT_MARGINS,
+    MAIN_LAYOUT_SPACING,
+    HEADER_MARGINS,
+    HEADER_SPACING,
+    CARD_MARGINS,
+    CARD_SPACING,
+    GRID_HORIZONTAL_SPACING,
+    GRID_VERTICAL_SPACING,
+    BUTTON_ROW_SPACING,
+    STANDARD_BUTTON_WIDTH,
+    TAB_CONTENT_MARGINS,
+    TAB_CONTENT_SPACING,
+)
 
 from agents_runner.ui.pages.environments_actions import _EnvironmentsPageActionsMixin
 from agents_runner.ui.pages.environments_prompts import PromptsTabWidget
@@ -46,13 +60,13 @@ class EnvironmentsPage(QWidget, _EnvironmentsPageActionsMixin):
         self._current_env_id: str | None = None
 
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(14)
+        layout.setContentsMargins(*MAIN_LAYOUT_MARGINS)
+        layout.setSpacing(MAIN_LAYOUT_SPACING)
 
         header = GlassCard()
         header_layout = QHBoxLayout(header)
-        header_layout.setContentsMargins(18, 16, 18, 16)
-        header_layout.setSpacing(10)
+        header_layout.setContentsMargins(*HEADER_MARGINS)
+        header_layout.setSpacing(HEADER_SPACING)
 
         title = QLabel("Environments")
         title.setStyleSheet("font-size: 18px; font-weight: 750;")
@@ -71,11 +85,11 @@ class EnvironmentsPage(QWidget, _EnvironmentsPageActionsMixin):
 
         card = GlassCard()
         card_layout = QVBoxLayout(card)
-        card_layout.setContentsMargins(18, 16, 18, 16)
-        card_layout.setSpacing(12)
+        card_layout.setContentsMargins(*CARD_MARGINS)
+        card_layout.setSpacing(CARD_SPACING)
 
         top_row = QHBoxLayout()
-        top_row.setSpacing(10)
+        top_row.setSpacing(BUTTON_ROW_SPACING)
         self._env_select = QComboBox()
         self._env_select.currentIndexChanged.connect(self._on_env_selected)
 
@@ -112,12 +126,12 @@ class EnvironmentsPage(QWidget, _EnvironmentsPageActionsMixin):
 
         general_tab = QWidget()
         general_layout = QVBoxLayout(general_tab)
-        general_layout.setContentsMargins(0, 16, 0, 12)
-        general_layout.setSpacing(10)
+        general_layout.setContentsMargins(*TAB_CONTENT_MARGINS)
+        general_layout.setSpacing(TAB_CONTENT_SPACING)
 
         grid = QGridLayout()
-        grid.setHorizontalSpacing(10)
-        grid.setVerticalSpacing(10)
+        grid.setHorizontalSpacing(GRID_HORIZONTAL_SPACING)
+        grid.setVerticalSpacing(GRID_VERTICAL_SPACING)
         grid.setContentsMargins(0, 0, 0, 0)
 
         self._name = QLineEdit()
@@ -142,7 +156,7 @@ class EnvironmentsPage(QWidget, _EnvironmentsPageActionsMixin):
         self._max_agents_running.setMaximumWidth(150)
 
         browse_codex = QPushButton("Browse…")
-        browse_codex.setFixedWidth(100)
+        browse_codex.setFixedWidth(STANDARD_BUTTON_WIDTH)
         browse_codex.clicked.connect(self._pick_codex_dir)
 
         grid.addWidget(QLabel("Name"), 0, 0)
@@ -172,7 +186,7 @@ class EnvironmentsPage(QWidget, _EnvironmentsPageActionsMixin):
         max_agents_row = QWidget(general_tab)
         max_agents_row_layout = QHBoxLayout(max_agents_row)
         max_agents_row_layout.setContentsMargins(0, 0, 0, 0)
-        max_agents_row_layout.setSpacing(10)
+        max_agents_row_layout.setSpacing(BUTTON_ROW_SPACING)
         max_agents_row_layout.addWidget(self._max_agents_running)
         max_agents_row_layout.addStretch(1)
 
@@ -184,7 +198,7 @@ class EnvironmentsPage(QWidget, _EnvironmentsPageActionsMixin):
         self._gh_pr_metadata_row = QWidget(general_tab)
         gh_pr_metadata_layout = QHBoxLayout(self._gh_pr_metadata_row)
         gh_pr_metadata_layout.setContentsMargins(0, 0, 0, 0)
-        gh_pr_metadata_layout.setSpacing(10)
+        gh_pr_metadata_layout.setSpacing(BUTTON_ROW_SPACING)
         gh_pr_metadata_layout.addWidget(self._gh_pr_metadata_enabled)
         gh_pr_metadata_layout.addStretch(1)
 
@@ -204,7 +218,7 @@ class EnvironmentsPage(QWidget, _EnvironmentsPageActionsMixin):
         self._gh_management_target.textChanged.connect(self._sync_gh_management_controls)
 
         self._gh_management_browse = QPushButton("Browse…", general_tab)
-        self._gh_management_browse.setFixedWidth(100)
+        self._gh_management_browse.setFixedWidth(STANDARD_BUTTON_WIDTH)
         self._gh_management_browse.clicked.connect(self._pick_gh_management_folder)
 
         self._gh_use_host_cli = QCheckBox("Use host `gh` for clone/PR (if installed)", general_tab)
@@ -240,8 +254,8 @@ class EnvironmentsPage(QWidget, _EnvironmentsPageActionsMixin):
 
         preflight_tab = QWidget()
         preflight_layout = QVBoxLayout(preflight_tab)
-        preflight_layout.setSpacing(10)
-        preflight_layout.setContentsMargins(0, 16, 0, 12)
+        preflight_layout.setSpacing(TAB_CONTENT_SPACING)
+        preflight_layout.setContentsMargins(*TAB_CONTENT_MARGINS)
         preflight_layout.addWidget(self._preflight_enabled)
         preflight_layout.addWidget(QLabel("Preflight script"))
         preflight_layout.addWidget(self._preflight_script, 1)
@@ -251,8 +265,8 @@ class EnvironmentsPage(QWidget, _EnvironmentsPageActionsMixin):
         self._env_vars.setTabChangesFocus(True)
         env_vars_tab = QWidget()
         env_vars_layout = QVBoxLayout(env_vars_tab)
-        env_vars_layout.setSpacing(10)
-        env_vars_layout.setContentsMargins(0, 16, 0, 12)
+        env_vars_layout.setSpacing(TAB_CONTENT_SPACING)
+        env_vars_layout.setContentsMargins(*TAB_CONTENT_MARGINS)
         env_vars_layout.addWidget(QLabel("Container env vars"))
         env_vars_layout.addWidget(self._env_vars, 1)
 
@@ -261,8 +275,8 @@ class EnvironmentsPage(QWidget, _EnvironmentsPageActionsMixin):
         self._mounts.setTabChangesFocus(True)
         mounts_tab = QWidget()
         mounts_layout = QVBoxLayout(mounts_tab)
-        mounts_layout.setSpacing(10)
-        mounts_layout.setContentsMargins(0, 16, 0, 12)
+        mounts_layout.setSpacing(TAB_CONTENT_SPACING)
+        mounts_layout.setContentsMargins(*TAB_CONTENT_MARGINS)
         mounts_layout.addWidget(QLabel("Extra bind mounts"))
         mounts_layout.addWidget(self._mounts, 1)
 

--- a/agents_runner/ui/pages/environments_agents.py
+++ b/agents_runner/ui/pages/environments_agents.py
@@ -21,6 +21,14 @@ from agents_runner.agent_cli import normalize_agent
 from agents_runner.agent_cli import SUPPORTED_AGENTS
 from agents_runner.environments.model import AgentInstance
 from agents_runner.environments.model import AgentSelection
+from agents_runner.ui.constants import (
+    TAB_CONTENT_MARGINS,
+    TAB_CONTENT_SPACING,
+    BUTTON_ROW_SPACING,
+    TABLE_ROW_HEIGHT,
+    AGENT_COMBO_WIDTH,
+    STANDARD_BUTTON_WIDTH,
+)
 
 
 _ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
@@ -35,8 +43,6 @@ class AgentsTabWidget(QWidget):
     _COL_CONFIG = 3
     _COL_FALLBACK = 4
     _COL_REMOVE = 5
-    _ROW_HEIGHT_PX = 56
-    _AGENT_COL_WIDTH_PX = 170
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -45,8 +51,8 @@ class AgentsTabWidget(QWidget):
         self._fallbacks: dict[str, str] = {}
 
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 16, 0, 12)
-        layout.setSpacing(10)
+        layout.setContentsMargins(*TAB_CONTENT_MARGINS)
+        layout.setSpacing(TAB_CONTENT_SPACING)
 
         header_label = QLabel(
             "Override the Settings agent configuration for this environment.\n"
@@ -56,7 +62,7 @@ class AgentsTabWidget(QWidget):
         layout.addWidget(header_label)
 
         add_row = QHBoxLayout()
-        add_row.setSpacing(10)
+        add_row.setSpacing(BUTTON_ROW_SPACING)
         add_row.addWidget(QLabel("Add agent"))
         self._add_agent_cli = QComboBox()
         for agent in SUPPORTED_AGENTS:
@@ -76,14 +82,14 @@ class AgentsTabWidget(QWidget):
         self._agent_table.setHorizontalHeaderLabels(["Priority", "Agent", "ID", "Config folder", "Fallback", ""])
         self._agent_table.horizontalHeader().setSectionResizeMode(self._COL_PRIORITY, QHeaderView.ResizeToContents)
         self._agent_table.horizontalHeader().setSectionResizeMode(self._COL_AGENT, QHeaderView.Interactive)
-        self._agent_table.setColumnWidth(self._COL_AGENT, self._AGENT_COL_WIDTH_PX)
+        self._agent_table.setColumnWidth(self._COL_AGENT, AGENT_COMBO_WIDTH)
         self._agent_table.horizontalHeader().setSectionResizeMode(self._COL_ID, QHeaderView.ResizeToContents)
         self._agent_table.horizontalHeader().setSectionResizeMode(self._COL_CONFIG, QHeaderView.Stretch)
         self._agent_table.horizontalHeader().setSectionResizeMode(self._COL_FALLBACK, QHeaderView.ResizeToContents)
         self._agent_table.horizontalHeader().setSectionResizeMode(self._COL_REMOVE, QHeaderView.ResizeToContents)
         self._agent_table.verticalHeader().setVisible(False)
-        self._agent_table.verticalHeader().setMinimumSectionSize(self._ROW_HEIGHT_PX)
-        self._agent_table.verticalHeader().setDefaultSectionSize(self._ROW_HEIGHT_PX)
+        self._agent_table.verticalHeader().setMinimumSectionSize(TABLE_ROW_HEIGHT)
+        self._agent_table.verticalHeader().setDefaultSectionSize(TABLE_ROW_HEIGHT)
         self._agent_table.setSelectionMode(QTableWidget.NoSelection)
         self._agent_table.setFocusPolicy(Qt.NoFocus)
         layout.addWidget(self._agent_table)
@@ -92,7 +98,7 @@ class AgentsTabWidget(QWidget):
         layout.addWidget(self._selection_mode_label)
 
         mode_row = QHBoxLayout()
-        mode_row.setSpacing(10)
+        mode_row.setSpacing(BUTTON_ROW_SPACING)
         self._selection_mode = QComboBox()
         self._selection_mode.addItem("Round-robin", "round-robin")
         self._selection_mode.addItem("Least used (active tasks)", "least-used")
@@ -148,7 +154,7 @@ class AgentsTabWidget(QWidget):
         self._agent_table.setMinimumHeight(1)
 
         for row_index, inst in enumerate(self._rows):
-            self._agent_table.setRowHeight(row_index, self._ROW_HEIGHT_PX)
+            self._agent_table.setRowHeight(row_index, TABLE_ROW_HEIGHT)
             self._agent_table.setCellWidget(row_index, self._COL_PRIORITY, self._priority_widget(row_index))
             self._agent_table.setCellWidget(row_index, self._COL_AGENT, self._agent_cli_widget(row_index, inst))
             self._agent_table.setCellWidget(row_index, self._COL_ID, self._agent_id_widget(row_index, inst))

--- a/agents_runner/ui/pages/environments_prompts.py
+++ b/agents_runner/ui/pages/environments_prompts.py
@@ -15,6 +15,11 @@ from PySide6.QtWidgets import QWidget
 
 from agents_runner.environments import Environment
 from agents_runner.environments.model import PromptConfig
+from agents_runner.ui.constants import (
+    TAB_CONTENT_MARGINS,
+    TAB_CONTENT_SPACING,
+    BUTTON_ROW_SPACING,
+)
 
 
 class FocusOutPlainTextEdit(QPlainTextEdit):
@@ -43,11 +48,11 @@ class PromptsTabWidget(QWidget):
         self._current_visible_count = 0
 
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 16, 0, 12)
-        layout.setSpacing(10)
+        layout.setContentsMargins(*TAB_CONTENT_MARGINS)
+        layout.setSpacing(TAB_CONTENT_SPACING)
 
         unlock_row = QHBoxLayout()
-        unlock_row.setSpacing(10)
+        unlock_row.setSpacing(BUTTON_ROW_SPACING)
         self._unlock_btn = QPushButton("Unlock Prompts")
         self._unlock_btn.setToolTip("Enable custom prompt injection for this environment")
         self._unlock_btn.clicked.connect(self._on_unlock_clicked)
@@ -72,8 +77,8 @@ class PromptsTabWidget(QWidget):
         for i in range(self.MAX_PROMPTS):
             tab = QWidget()
             tab_layout = QVBoxLayout(tab)
-            tab_layout.setContentsMargins(0, 10, 0, 0)
-            tab_layout.setSpacing(10)
+            tab_layout.setContentsMargins(0, TAB_CONTENT_SPACING, 0, 0)
+            tab_layout.setSpacing(TAB_CONTENT_SPACING)
 
             enabled_cb = QCheckBox(f"Enable Prompt {i + 1}")
             enabled_cb.toggled.connect(self._on_prompt_changed)

--- a/agents_runner/ui/pages/settings.py
+++ b/agents_runner/ui/pages/settings.py
@@ -19,6 +19,18 @@ from PySide6.QtWidgets import QWidget
 
 from agents_runner.agent_cli import normalize_agent
 from agents_runner.widgets import GlassCard
+from agents_runner.ui.constants import (
+    MAIN_LAYOUT_MARGINS,
+    MAIN_LAYOUT_SPACING,
+    HEADER_MARGINS,
+    HEADER_SPACING,
+    CARD_MARGINS,
+    CARD_SPACING,
+    GRID_HORIZONTAL_SPACING,
+    GRID_VERTICAL_SPACING,
+    BUTTON_ROW_SPACING,
+    STANDARD_BUTTON_WIDTH,
+)
 
 
 class SettingsPage(QWidget):
@@ -30,13 +42,13 @@ class SettingsPage(QWidget):
         super().__init__(parent)
 
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(14)
+        layout.setContentsMargins(*MAIN_LAYOUT_MARGINS)
+        layout.setSpacing(MAIN_LAYOUT_SPACING)
 
         header = GlassCard()
         header_layout = QHBoxLayout(header)
-        header_layout.setContentsMargins(18, 16, 18, 16)
-        header_layout.setSpacing(10)
+        header_layout.setContentsMargins(*HEADER_MARGINS)
+        header_layout.setSpacing(HEADER_SPACING)
 
         title = QLabel("Settings")
         title.setStyleSheet("font-size: 18px; font-weight: 750;")
@@ -55,12 +67,12 @@ class SettingsPage(QWidget):
 
         card = GlassCard()
         card_layout = QVBoxLayout(card)
-        card_layout.setContentsMargins(18, 16, 18, 16)
-        card_layout.setSpacing(12)
+        card_layout.setContentsMargins(*CARD_MARGINS)
+        card_layout.setSpacing(CARD_SPACING)
 
         grid = QGridLayout()
-        grid.setHorizontalSpacing(10)
-        grid.setVerticalSpacing(10)
+        grid.setHorizontalSpacing(GRID_HORIZONTAL_SPACING)
+        grid.setVerticalSpacing(GRID_VERTICAL_SPACING)
         grid.setColumnStretch(1, 1)
 
         self._use = QComboBox()
@@ -82,25 +94,25 @@ class SettingsPage(QWidget):
         self._host_codex_dir = QLineEdit()
         self._host_codex_dir.setPlaceholderText(os.path.expanduser("~/.codex"))
         browse_codex = QPushButton("Browse…")
-        browse_codex.setFixedWidth(100)
+        browse_codex.setFixedWidth(STANDARD_BUTTON_WIDTH)
         browse_codex.clicked.connect(self._pick_codex_dir)
 
         self._host_claude_dir = QLineEdit()
         self._host_claude_dir.setPlaceholderText(os.path.expanduser("~/.claude"))
         browse_claude = QPushButton("Browse…")
-        browse_claude.setFixedWidth(100)
+        browse_claude.setFixedWidth(STANDARD_BUTTON_WIDTH)
         browse_claude.clicked.connect(self._pick_claude_dir)
 
         self._host_copilot_dir = QLineEdit()
         self._host_copilot_dir.setPlaceholderText(os.path.expanduser("~/.copilot"))
         browse_copilot = QPushButton("Browse…")
-        browse_copilot.setFixedWidth(100)
+        browse_copilot.setFixedWidth(STANDARD_BUTTON_WIDTH)
         browse_copilot.clicked.connect(self._pick_copilot_dir)
 
         self._host_gemini_dir = QLineEdit()
         self._host_gemini_dir.setPlaceholderText(os.path.expanduser("~/.gemini"))
         browse_gemini = QPushButton("Browse…")
-        browse_gemini.setFixedWidth(100)
+        browse_gemini.setFixedWidth(STANDARD_BUTTON_WIDTH)
         browse_gemini.clicked.connect(self._pick_gemini_dir)
 
         self._preflight_enabled = QCheckBox("Enable settings preflight bash (runs on all envs, before env preflight)")
@@ -161,7 +173,7 @@ class SettingsPage(QWidget):
         self._sync_agent_config_widgets()
 
         buttons = QHBoxLayout()
-        buttons.setSpacing(10)
+        buttons.setSpacing(BUTTON_ROW_SPACING)
         save = QToolButton()
         save.setText("Save")
         save.setToolButtonStyle(Qt.ToolButtonTextOnly)


### PR DESCRIPTION
## Summary

Standardized the UI formatting across all settings and environments menu components to ensure consistency throughout the application.

## Changes Made

### New Constants Module
- Added UI layout constants to `agents_runner/ui/constants.py`:
  - `MAIN_LAYOUT_MARGINS` and `MAIN_LAYOUT_SPACING` for page containers
  - `HEADER_MARGINS` and `HEADER_SPACING` for page headers
  - `CARD_MARGINS` and `CARD_SPACING` for content cards
  - `TAB_CONTENT_MARGINS` and `TAB_CONTENT_SPACING` for tab widgets
  - `GRID_HORIZONTAL_SPACING` and `GRID_VERTICAL_SPACING` for grid layouts
  - `BUTTON_ROW_SPACING` for button containers
  - `STANDARD_BUTTON_WIDTH` for Browse buttons
  - `TABLE_ROW_HEIGHT` for table widgets
  - `AGENT_COMBO_WIDTH` for agent combo boxes

### Refactored Files
- **`agents_runner/ui/pages/settings.py`**: Updated to use standardized constants
- **`agents_runner/ui/pages/environments.py`**: Updated to use standardized constants
- **`agents_runner/ui/pages/environments_agents.py`**: Updated to use standardized constants
- **`agents_runner/ui/pages/environments_prompts.py`**: Updated to use standardized constants

## Benefits

1. **Consistency**: All UI components now use the same spacing, margins, and layout values
2. **Maintainability**: Single source of truth for all UI metrics
3. **Cleaner Code**: No more magic numbers scattered throughout the codebase
4. **Easier Updates**: Change spacing/margins in one place to update the entire UI

## Testing

- ✅ All files compile successfully
- ✅ Module imports work correctly
- ✅ No functional changes to UI behavior

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner).
Agent Used: [Github Copilot](https://github.com/github/copilot-cli)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI).
