### PR TITLE
Fix desktop preflight error masking with explicit handling

### DIFF
--- a/agents_runner/preflights/headless_desktop_novnc.sh
+++ b/agents_runner/preflights/headless_desktop_novnc.sh
@@ -13,22 +13,30 @@ mkdir -p "${RUNTIME_BASE}"/{run,log,out,config}
 mkdir -p "/tmp/agents-artifacts"
 
 if command -v yay >/dev/null 2>&1; then
-  yay -S --noconfirm --needed \
+  echo "[desktop] Installing official repository packages..."
+  if ! yay -S --noconfirm --needed \
     tigervnc \
     fluxbox \
     xterm \
     imagemagick \
     xorg-xwininfo \
     xcb-util-cursor \
-    novnc \
     websockify \
     wmctrl \
     xdotool \
     xorg-xprop \
     xorg-xauth \
     ttf-dejavu \
-    xorg-fonts-misc \
-    || true
+    xorg-fonts-misc; then
+    echo "[desktop] WARNING: Some official packages failed to install"
+    echo "[desktop] Attempting to continue with available packages..."
+  fi
+  
+  echo "[desktop] Installing AUR packages..."
+  if ! yay -S --noconfirm --needed novnc; then
+    echo "[desktop] WARNING: novnc (AUR) failed to install"
+    echo "[desktop] Desktop web interface may not be available"
+  fi
 fi
 
 Xvnc "${DISPLAY}" \


### PR DESCRIPTION
## Problem

The desktop preflight script was using `|| true` to mask all package installation errors, making it impossible to debug when packages failed to install in production environments.

## Solution

- Replaced `|| true` with explicit `if !` error handling that logs failures clearly
- Separated `novnc` (AUR package) from official packages for better diagnostics
- Added informative warning messages when installations fail
- Maintained error-tolerant behavior (script continues on failures)

## Changes

- Modified `agents_runner/preflights/headless_desktop_novnc.sh`
- Added logging: `[desktop] Installing official repository packages...`
- Added logging: `[desktop] Installing AUR packages...`
- Added warnings for package failures with actionable messages

## Testing

✅ Syntax validation passed
✅ Script executes successfully
✅ Desktop services start correctly (Xvnc, fluxbox, xterm, websockify)
✅ Error messages are clear and helpful for debugging

## Impact

- Improves observability when package installations fail
- Makes debugging possible in production environments
- No breaking changes to existing functionality
- Minimal, surgical code changes (+12, -4 lines)

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner).
Agent Used: [Github Copilot](https://github.com/github/copilot-cli)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI).
