### PR TITLE
[REFINE] Highlight additional log tags

### DIFF
--- a/agents_runner/widgets/log_highlighter.py
+++ b/agents_runner/widgets/log_highlighter.py
@@ -39,10 +39,19 @@ class LogHighlighter(QSyntaxHighlighter):
         amber = QColor(245, 158, 11, 235)
         violet = QColor(168, 85, 247, 235)
         zinc = QColor(226, 232, 240, 235)
+        blue = QColor(59, 130, 246, 235)
+        fuchsia = QColor(217, 70, 239, 235)
 
         self._rules: list[tuple[object, QTextCharFormat]] = [
             (r"\[host\]", fmt(cyan, True)),
             (r"\[preflight\]", fmt(emerald, True)),
+            (r"\[gh\]", fmt(violet, True)),
+            (r"\[git\]", fmt(violet, True)),
+            (r"\[docker\]", fmt(blue, True)),
+            (r"\[desktop\]", fmt(fuchsia, True)),
+            (r"\[cleanup\]", fmt(amber, True)),
+            (r"\[queue\]", fmt(slate, True)),
+            (r"\[interactive\]", fmt(cyan, True)),
             (r"\bpull complete\b", fmt(emerald, True)),
             (r"\bdocker pull\b", fmt(cyan, True)),
             (r"\b(exit|exited)\b", fmt(amber, True)),


### PR DESCRIPTION
Adds syntax highlighting rules for additional log prefixes: [gh], [git], [docker], [desktop], [cleanup], [queue], [interactive].