### PR TITLE
Fix tab switching crashes in task viewer

### DIFF
--- a/agents_runner/ui/pages/artifacts_tab.py
+++ b/agents_runner/ui/pages/artifacts_tab.py
@@ -196,7 +196,7 @@ class ArtifactsTab(QWidget):
         self._preview_label.setText(f"{artifact.original_filename}\n{artifact.mime_type}")
 
         if artifact.mime_type.startswith("image/"):
-            QTimer.singleShot(0, lambda: self._load_thumbnail(artifact))
+            QTimer.singleShot(0, lambda a=artifact: self._load_thumbnail(a))
 
     def _load_thumbnail(self, artifact: ArtifactMeta) -> None:
         if not self._current_task:
@@ -230,7 +230,7 @@ class ArtifactsTab(QWidget):
 
     def _on_open_clicked(self) -> None:
         current_row = self._artifact_list.currentRow()
-        if current_row < 0 or not self._current_task:
+        if current_row < 0 or current_row >= len(self._artifacts) or not self._current_task:
             return
 
         artifact = self._artifacts[current_row]
@@ -264,7 +264,7 @@ class ArtifactsTab(QWidget):
 
     def _on_download_clicked(self) -> None:
         current_row = self._artifact_list.currentRow()
-        if current_row < 0 or not self._current_task:
+        if current_row < 0 or current_row >= len(self._artifacts) or not self._current_task:
             return
 
         artifact = self._artifacts[current_row]


### PR DESCRIPTION
## Summary
Fix crashes that can occur when switching tabs in the task viewer, particularly when switching to/from the Desktop and Artifacts tabs.

## Changes

### task_details.py
- Added null check for `_last_task` in `_maybe_load_desktop()` to prevent AttributeError when deferred callback executes after task changes
- Added null check in `_load_artifacts()` before calling `set_task()` on artifacts tab
- Added reentrancy guard (`_syncing_desktop` flag) in `_sync_desktop()` to prevent recursive tab switching and state corruption

### artifacts_tab.py
- Fixed lambda closure in `set_task()` to capture artifact by value (`lambda a=artifact: ...`) instead of reference, preventing stale artifact reference when timer fires
- Added bounds checks in `_on_open_clicked()` and `_on_download_clicked()` before accessing the artifacts list

## Root Cause
The crashes occurred due to race conditions in Qt's event-driven model:
1. `QTimer.singleShot()` deferred operations that accessed shared state that could change between scheduling and execution
2. Lambda closures captured loop variables by reference instead of value
3. No guards against reentrancy when forced tab switches occurred during sync operations

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner).
Agent Used: [Github Copilot](https://github.com/github/copilot-cli)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI).
