### PR TITLE
Add Diff tab to Task Viewer with side-by-side comparison

### DIFF
--- a/agents_runner/gh/git_diff.py
+++ b/agents_runner/gh/git_diff.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .process import _run, _expand_dir
+
+
+@dataclass
+class ChangedFile:
+    path: str
+    status: str  # A=Added, M=Modified, D=Deleted, R=Renamed, U=Untracked
+
+
+def git_merge_base(repo_root: str, base_ref: str) -> str | None:
+    """Get merge-base commit SHA between HEAD and base_ref."""
+    expanded = _expand_dir(repo_root)
+    proc = _run(["git", "merge-base", "HEAD", base_ref], cwd=expanded)
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip() or None
+
+
+def git_changed_files(repo_root: str, base_commit: str) -> list[ChangedFile]:
+    """Get list of changed files vs base_commit.
+
+    Combines:
+    - git diff --name-status <base_commit>...HEAD (committed changes)
+    - git diff --name-status <base_commit> (includes staged/unstaged)
+    - git ls-files --others --exclude-standard (untracked)
+
+    Returns unique list with stable order.
+    """
+    expanded = _expand_dir(repo_root)
+    files: dict[str, str] = {}
+
+    # Get committed changes (base_commit...HEAD)
+    proc = _run(
+        ["git", "diff", "--name-status", f"{base_commit}...HEAD"], cwd=expanded
+    )
+    if proc.returncode == 0:
+        for line in proc.stdout.strip().split("\n"):
+            if not line:
+                continue
+            parts = line.split("\t", 1)
+            if len(parts) == 2:
+                status, path = parts
+                files[path] = status[0]  # First char: A/M/D/R
+
+    # Get all changes including staged/unstaged (base_commit vs working tree)
+    proc = _run(["git", "diff", "--name-status", base_commit], cwd=expanded)
+    if proc.returncode == 0:
+        for line in proc.stdout.strip().split("\n"):
+            if not line:
+                continue
+            parts = line.split("\t", 1)
+            if len(parts) == 2:
+                status, path = parts
+                # Update status if file wasn't already tracked or is more specific
+                if path not in files:
+                    files[path] = status[0]
+
+    # Get untracked files
+    proc = _run(
+        ["git", "ls-files", "--others", "--exclude-standard"], cwd=expanded
+    )
+    if proc.returncode == 0:
+        for line in proc.stdout.strip().split("\n"):
+            if line and line not in files:
+                files[line] = "U"
+
+    # Convert to list with stable order (alphabetical)
+    return [
+        ChangedFile(path=path, status=status)
+        for path, status in sorted(files.items())
+    ]
+
+
+def git_file_at_commit(repo_root: str, commit: str, path: str) -> str | None:
+    """Get file content at specific commit.
+
+    Uses: git show <commit>:<path>
+    Returns file content or None if file doesn't exist at commit.
+    """
+    expanded = _expand_dir(repo_root)
+    proc = _run(["git", "show", f"{commit}:{path}"], cwd=expanded)
+    if proc.returncode != 0:
+        return None
+
+    # Check if binary
+    output_bytes = proc.stdout.encode("utf-8", errors="surrogateescape")
+    if is_binary_file(output_bytes[:8192]):
+        return None
+
+    return proc.stdout
+
+
+def read_workspace_file(repo_root: str, path: str) -> str | None:
+    """Read current file content from disk.
+
+    Returns file content or None if file doesn't exist.
+    Handles binary detection and size limits (max 1MB).
+    Returns None for binary files.
+    """
+    expanded = _expand_dir(repo_root)
+    full_path = Path(expanded) / path
+
+    try:
+        if not full_path.is_file():
+            return None
+
+        # Check file size (max 1MB)
+        size = full_path.stat().st_size
+        if size > 1024 * 1024:
+            return None
+
+        # Read first 8KB to check if binary
+        with full_path.open("rb") as f:
+            header = f.read(8192)
+            if is_binary_file(header):
+                return None
+
+        # Read full content as text
+        return full_path.read_text(encoding="utf-8", errors="replace")
+
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def is_binary_file(content: bytes) -> bool:
+    """Check if content appears to be binary (contains null bytes in first 8KB)."""
+    return b"\x00" in content

--- a/agents_runner/ui/diff_utils.py
+++ b/agents_runner/ui/diff_utils.py
@@ -1,0 +1,70 @@
+"""Diff parsing and line alignment utilities for side-by-side display."""
+
+from __future__ import annotations
+from dataclasses import dataclass
+import difflib
+
+
+@dataclass
+class DiffLine:
+    """A single line in the side-by-side diff."""
+
+    before_line_no: int | None  # Line number in before file (None for additions)
+    before_text: str  # Text content (empty string for additions)
+    after_line_no: int | None  # Line number in after file (None for deletions)
+    after_text: str  # Text content (empty string for deletions)
+    change_type: str  # "unchanged", "added", "deleted", "modified"
+
+
+def compute_side_by_side_diff(before_text: str, after_text: str) -> list[DiffLine]:
+    """Compute side-by-side diff lines using difflib.SequenceMatcher.
+
+    Returns DiffLine objects where unchanged lines have both before/after content,
+    deleted lines have before content only, and added lines have after content only.
+    Lines are aligned for side-by-side scrolling.
+    """
+    before_lines = before_text.splitlines() if before_text else []
+    after_lines = after_text.splitlines() if after_text else []
+    matcher = difflib.SequenceMatcher(None, before_lines, after_lines)
+    diff_lines: list[DiffLine] = []
+    before_idx = after_idx = 0
+
+    for before_start, after_start, size in matcher.get_matching_blocks():
+        # Process gap (deletions and additions) before this matching block
+        if before_idx < before_start or after_idx < after_start:
+            deleted_lines = before_lines[before_idx:before_start]
+            added_lines = after_lines[after_idx:after_start]
+
+            # Add all deletions, then all additions
+            for i, line in enumerate(deleted_lines):
+                diff_lines.append(
+                    DiffLine(before_idx + i + 1, line, None, "", "deleted")
+                )
+            for i, line in enumerate(added_lines):
+                diff_lines.append(
+                    DiffLine(None, "", after_idx + i + 1, line, "added")
+                )
+
+        # Process matching block (unchanged lines)
+        for i in range(size):
+            diff_lines.append(
+                DiffLine(
+                    before_start + i + 1,
+                    before_lines[before_start + i],
+                    after_start + i + 1,
+                    after_lines[after_start + i],
+                    "unchanged",
+                )
+            )
+
+        before_idx = before_start + size
+        after_idx = after_start + size
+
+    return diff_lines
+
+
+def format_line_number(num: int | None, width: int = 4) -> str:
+    """Format line number for display, or spaces if None."""
+    if num is None:
+        return " " * width
+    return str(num).rjust(width)

--- a/agents_runner/ui/pages/diff_tab.py
+++ b/agents_runner/ui/pages/diff_tab.py
@@ -1,0 +1,418 @@
+from __future__ import annotations
+
+import logging
+from PySide6.QtCore import Qt, QTimer
+from PySide6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QListWidget,
+    QListWidgetItem, QPlainTextEdit, QSplitter,
+)
+from PySide6.QtGui import QFont, QTextCharFormat, QColor, QTextCursor
+
+from agents_runner.gh.git_diff import (
+    git_merge_base, git_changed_files, git_file_at_commit,
+    read_workspace_file, ChangedFile
+)
+from agents_runner.ui.diff_utils import compute_side_by_side_diff, DiffLine, format_line_number
+from agents_runner.ui.task_model import Task
+from agents_runner.widgets.glass_card import GlassCard
+
+logger = logging.getLogger(__name__)
+
+
+# Status colors
+STATUS_COLORS = {
+    "A": "rgba(100, 255, 100, 200)",  # Added - green
+    "M": "rgba(255, 200, 100, 200)",  # Modified - orange
+    "D": "rgba(255, 100, 100, 200)",  # Deleted - red
+    "R": "rgba(100, 200, 255, 200)",  # Renamed - cyan
+    "U": "rgba(180, 180, 180, 200)",  # Untracked - gray
+}
+
+STATUS_LABELS = {
+    "A": "A",
+    "M": "M",
+    "D": "D",
+    "R": "R",
+    "U": "U",
+}
+
+
+class DiffTab(QWidget):
+    """Side-by-side diff viewer tab."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._current_task: Task | None = None
+        self._changed_files: list[ChangedFile] = []
+        self._base_commit: str | None = None
+        self._syncing_scroll = False
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(14)
+
+        # Main splitter: file list (left) and diff view (right)
+        main_splitter = QSplitter(Qt.Horizontal)
+        main_splitter.setChildrenCollapsible(False)
+
+        # Left panel: File list
+        left_panel = GlassCard()
+        left_layout = QVBoxLayout(left_panel)
+        left_layout.setContentsMargins(18, 16, 18, 16)
+        left_layout.setSpacing(10)
+
+        list_header = QHBoxLayout()
+        list_header.setSpacing(8)
+        list_title = QLabel("Changed Files")
+        list_title.setStyleSheet("font-size: 14px; font-weight: 650;")
+        self._file_count = QLabel("(0)")
+        self._file_count.setStyleSheet("color: rgba(237, 239, 245, 160);")
+        list_header.addWidget(list_title)
+        list_header.addWidget(self._file_count)
+        list_header.addStretch(1)
+
+        self._file_list = QListWidget()
+        self._file_list.setSpacing(2)
+        self._file_list.currentRowChanged.connect(self._on_file_selected)
+
+        left_layout.addLayout(list_header)
+        left_layout.addWidget(self._file_list, 1)
+
+        # Right panel: Diff view
+        right_panel = GlassCard()
+        right_layout = QVBoxLayout(right_panel)
+        right_layout.setContentsMargins(18, 16, 18, 16)
+        right_layout.setSpacing(10)
+
+        # Headers for diff panes
+        headers = QHBoxLayout()
+        headers.setSpacing(0)
+
+        before_header = QLabel("Before")
+        before_header.setStyleSheet("font-size: 14px; font-weight: 650;")
+        after_header = QLabel("After")
+        after_header.setStyleSheet("font-size: 14px; font-weight: 650;")
+
+        headers.addWidget(before_header, 1)
+        headers.addWidget(after_header, 1)
+
+        # Diff splitter: before (left) and after (right)
+        diff_splitter = QSplitter(Qt.Horizontal)
+        diff_splitter.setChildrenCollapsible(False)
+
+        # Before pane
+        self._before_view = QPlainTextEdit()
+        self._before_view.setReadOnly(True)
+        self._before_view.setLineWrapMode(QPlainTextEdit.NoWrap)
+        font = QFont("Monospace", 9)
+        font.setStyleHint(QFont.TypeWriter)
+        self._before_view.setFont(font)
+        self._before_view.setStyleSheet("""
+            QPlainTextEdit {
+                background-color: rgba(18, 20, 28, 200);
+                color: rgba(237, 239, 245, 230);
+                border: 1px solid rgba(255, 255, 255, 25);
+                border-radius: 0px;
+            }
+        """)
+
+        # After pane
+        self._after_view = QPlainTextEdit()
+        self._after_view.setReadOnly(True)
+        self._after_view.setLineWrapMode(QPlainTextEdit.NoWrap)
+        self._after_view.setFont(font)
+        self._after_view.setStyleSheet("""
+            QPlainTextEdit {
+                background-color: rgba(18, 20, 28, 200);
+                color: rgba(237, 239, 245, 230);
+                border: 1px solid rgba(255, 255, 255, 25);
+                border-radius: 0px;
+            }
+        """)
+
+        # Connect scroll bars for sync
+        self._before_view.verticalScrollBar().valueChanged.connect(
+            self._on_before_scroll_vertical
+        )
+        self._before_view.horizontalScrollBar().valueChanged.connect(
+            self._on_before_scroll_horizontal
+        )
+        self._after_view.verticalScrollBar().valueChanged.connect(
+            self._on_after_scroll_vertical
+        )
+        self._after_view.horizontalScrollBar().valueChanged.connect(
+            self._on_after_scroll_horizontal
+        )
+
+        diff_splitter.addWidget(self._before_view)
+        diff_splitter.addWidget(self._after_view)
+        diff_splitter.setStretchFactor(0, 1)
+        diff_splitter.setStretchFactor(1, 1)
+
+        # Empty state
+        self._empty_state = QLabel("No changes to display")
+        self._empty_state.setAlignment(Qt.AlignCenter)
+        self._empty_state.setStyleSheet(
+            "color: rgba(237, 239, 245, 120); font-size: 13px;"
+        )
+
+        right_layout.addLayout(headers)
+        right_layout.addWidget(diff_splitter, 1)
+        right_layout.addWidget(self._empty_state, 1)
+
+        main_splitter.addWidget(left_panel)
+        main_splitter.addWidget(right_panel)
+        main_splitter.setStretchFactor(0, 1)  # 1/4 width for file list
+        main_splitter.setStretchFactor(1, 3)  # 3/4 width for diff view
+
+        layout.addWidget(main_splitter, 1)
+
+        # Initially hide diff view, show empty state
+        diff_splitter.hide()
+        self._empty_state.show()
+        self._diff_splitter = diff_splitter
+
+    def set_task(self, task: Task) -> None:
+        """Load diff data for the given task."""
+        self._current_task = task
+        self._changed_files = []
+        self._base_commit = None
+
+        if not task.gh_repo_root or not task.gh_base_branch:
+            logger.debug("Task has no git repo or base branch configured")
+            self._update_file_list()
+            return
+
+        # Get base commit
+        try:
+            base_commit = git_merge_base(task.gh_repo_root, task.gh_base_branch)
+            if not base_commit:
+                logger.warning(
+                    f"Could not find merge-base for {task.gh_base_branch}"
+                )
+                self._update_file_list()
+                return
+
+            self._base_commit = base_commit
+            logger.debug(f"Base commit: {base_commit[:8]}")
+
+            # Get changed files
+            self._changed_files = git_changed_files(task.gh_repo_root, base_commit)
+            logger.debug(f"Found {len(self._changed_files)} changed files")
+
+        except Exception as e:
+            logger.error(f"Failed to load git diff: {e}")
+
+        self._update_file_list()
+
+    def refresh(self) -> None:
+        """Refresh the changed file list and current diff."""
+        if self._current_task:
+            selected_row = self._file_list.currentRow()
+            self.set_task(self._current_task)
+            # Restore selection if possible
+            if 0 <= selected_row < len(self._changed_files):
+                self._file_list.setCurrentRow(selected_row)
+
+    def has_changes(self) -> bool:
+        """Return True if there are any changes to display."""
+        return len(self._changed_files) > 0
+
+    def _update_file_list(self) -> None:
+        """Update the file list widget."""
+        self._file_list.clear()
+        self._file_count.setText(f"({len(self._changed_files)})")
+
+        if not self._changed_files:
+            self._empty_state.setText("No changes to display")
+            self._empty_state.show()
+            self._diff_splitter.hide()
+            return
+
+        for changed_file in self._changed_files:
+            item = QListWidgetItem()
+            item.setData(Qt.UserRole, changed_file)
+
+            widget = QWidget()
+            layout = QHBoxLayout(widget)
+            layout.setContentsMargins(8, 4, 8, 4)
+            layout.setSpacing(8)
+
+            # Status marker
+            status_label = QLabel(STATUS_LABELS.get(changed_file.status, "?"))
+            status_label.setFixedWidth(20)
+            status_label.setStyleSheet(
+                f"font-weight: 700; color: {STATUS_COLORS.get(changed_file.status, 'white')};"
+            )
+
+            # Filename
+            filename = QLabel(changed_file.path)
+            filename.setStyleSheet("color: rgba(237, 239, 245, 230);")
+
+            layout.addWidget(status_label)
+            layout.addWidget(filename, 1)
+
+            item.setSizeHint(widget.sizeHint())
+            self._file_list.addItem(item)
+            self._file_list.setItemWidget(item, widget)
+
+        # Select first file
+        if self._changed_files:
+            self._file_list.setCurrentRow(0)
+
+    def _on_file_selected(self, current_row: int) -> None:
+        """Handle file selection change."""
+        if current_row < 0 or current_row >= len(self._changed_files):
+            self._empty_state.show()
+            self._diff_splitter.hide()
+            return
+
+        changed_file = self._changed_files[current_row]
+        self._load_diff(changed_file)
+
+    def _load_diff(self, changed_file: ChangedFile) -> None:
+        """Load and display diff for a file."""
+        if not self._current_task or not self._base_commit:
+            self._show_error("No git information available")
+            return
+
+        try:
+            repo_root = self._current_task.gh_repo_root
+
+            # Get before content
+            if changed_file.status == "A":
+                # Added file - no before content
+                before_text = ""
+            else:
+                before_text = git_file_at_commit(
+                    repo_root, self._base_commit, changed_file.path
+                )
+                if before_text is None:
+                    self._show_error(
+                        "Binary file or too large to display\n\n"
+                        "(Files over 1MB or binary files are not shown)"
+                    )
+                    return
+
+            # Get after content
+            if changed_file.status == "D":
+                # Deleted file - no after content
+                after_text = ""
+            else:
+                after_text = read_workspace_file(repo_root, changed_file.path)
+                if after_text is None:
+                    self._show_error(
+                        "Binary file or too large to display\n\n"
+                        "(Files over 1MB or binary files are not shown)"
+                    )
+                    return
+
+            # Compute diff
+            diff_lines = compute_side_by_side_diff(before_text, after_text)
+
+            # Render diff
+            self._render_diff(diff_lines)
+
+        except Exception as e:
+            logger.error(f"Failed to load diff for {changed_file.path}: {e}")
+            self._show_error(f"Error loading diff:\n{str(e)}")
+
+    def _render_diff(self, diff_lines: list[DiffLine]) -> None:
+        """Render diff lines in both panes."""
+        self._empty_state.hide()
+        self._diff_splitter.show()
+
+        # Clear both views
+        self._before_view.clear()
+        self._after_view.clear()
+
+        # Build formatted text for both sides
+        before_parts: list[str] = []
+        after_parts: list[str] = []
+
+        for line in diff_lines:
+            # Format before side
+            if line.before_line_no is not None:
+                before_num = format_line_number(line.before_line_no)
+                before_parts.append(f"{before_num} {line.before_text}")
+            else:
+                # Empty line for additions
+                before_parts.append("")
+
+            # Format after side
+            if line.after_line_no is not None:
+                after_num = format_line_number(line.after_line_no)
+                after_parts.append(f"{after_num} {line.after_text}")
+            else:
+                # Empty line for deletions
+                after_parts.append("")
+
+        # Set text
+        self._before_view.setPlainText("\n".join(before_parts))
+        self._after_view.setPlainText("\n".join(after_parts))
+
+        # Apply highlighting
+        self._apply_highlighting(diff_lines)
+
+    def _apply_highlighting(self, diff_lines: list[DiffLine]) -> None:
+        """Apply background colors to changed lines."""
+        # Create formats
+        deleted_format = QTextCharFormat()
+        deleted_format.setBackground(QColor(80, 30, 30, 120))
+
+        added_format = QTextCharFormat()
+        added_format.setBackground(QColor(30, 80, 30, 120))
+
+        # Apply to before pane (deletions)
+        before_cursor = QTextCursor(self._before_view.document())
+        for i, line in enumerate(diff_lines):
+            if line.change_type == "deleted":
+                before_cursor.movePosition(QTextCursor.Start)
+                before_cursor.movePosition(QTextCursor.Down, QTextCursor.MoveAnchor, i)
+                before_cursor.select(QTextCursor.LineUnderCursor)
+                before_cursor.setCharFormat(deleted_format)
+
+        # Apply to after pane (additions)
+        after_cursor = QTextCursor(self._after_view.document())
+        for i, line in enumerate(diff_lines):
+            if line.change_type == "added":
+                after_cursor.movePosition(QTextCursor.Start)
+                after_cursor.movePosition(QTextCursor.Down, QTextCursor.MoveAnchor, i)
+                after_cursor.select(QTextCursor.LineUnderCursor)
+                after_cursor.setCharFormat(added_format)
+
+    def _show_error(self, message: str) -> None:
+        """Show error message in both panes."""
+        self._empty_state.hide()
+        self._diff_splitter.show()
+        self._before_view.setPlainText(message)
+        self._after_view.setPlainText(message)
+
+    # Scroll sync methods
+    def _on_before_scroll_vertical(self, value: int) -> None:
+        if self._syncing_scroll:
+            return
+        self._syncing_scroll = True
+        self._after_view.verticalScrollBar().setValue(value)
+        self._syncing_scroll = False
+
+    def _on_before_scroll_horizontal(self, value: int) -> None:
+        if self._syncing_scroll:
+            return
+        self._syncing_scroll = True
+        self._after_view.horizontalScrollBar().setValue(value)
+        self._syncing_scroll = False
+
+    def _on_after_scroll_vertical(self, value: int) -> None:
+        if self._syncing_scroll:
+            return
+        self._syncing_scroll = True
+        self._before_view.verticalScrollBar().setValue(value)
+        self._syncing_scroll = False
+
+    def _on_after_scroll_horizontal(self, value: int) -> None:
+        if self._syncing_scroll:
+            return
+        self._syncing_scroll = True
+        self._before_view.horizontalScrollBar().setValue(value)
+        self._syncing_scroll = False

--- a/agents_runner/ui/pages/task_details.py
+++ b/agents_runner/ui/pages/task_details.py
@@ -29,6 +29,7 @@ except Exception:  # pragma: no cover
     QWebEngineView = None
 
 from agents_runner.ui.pages.artifacts_tab import ArtifactsTab
+from agents_runner.ui.pages.diff_tab import DiffTab
 
 from agents_runner.artifacts import get_artifact_info
 from agents_runner.environments import GH_MANAGEMENT_GITHUB
@@ -83,6 +84,7 @@ class TaskDetailsPage(QWidget):
         self._current_task_id: str | None = None
         self._desktop_tab_visible: bool = False
         self._artifacts_tab_visible: bool = False
+        self._diff_tab_visible: bool = False
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
@@ -306,16 +308,22 @@ class TaskDetailsPage(QWidget):
         artifacts_tab = ArtifactsTab()
         self._artifacts_tab = artifacts_tab
 
+        # Diff tab
+        diff_tab = DiffTab()
+        self._diff_tab = diff_tab
+
         # Store tab widgets for dynamic show/hide
         self._task_tab_widget = task_tab
         self._desktop_tab_widget = desktop_tab
         self._artifacts_tab_widget = artifacts_tab
+        self._diff_tab_widget = diff_tab
 
         # Add only the Task tab initially (always visible)
         self._task_tab_index = self._tabs.addTab(task_tab, "Task")
         # Desktop and Artifacts tabs will be added dynamically when needed
         self._desktop_tab_index = -1
         self._artifacts_tab_index = -1
+        self._diff_tab_index = -1
         layout.addWidget(self._tabs, 1)
 
         self._ticker = QTimer(self)
@@ -341,6 +349,9 @@ class TaskDetailsPage(QWidget):
 
         if index == getattr(self, "_artifacts_tab_index", -1) and index >= 0:
             QTimer.singleShot(0, self._load_artifacts)
+
+        if index == getattr(self, "_diff_tab_index", -1) and index >= 0:
+            QTimer.singleShot(0, self._load_diff)
 
     def _show_desktop_tab(self) -> None:
         """Show the Desktop tab if not already visible."""
@@ -377,6 +388,23 @@ class TaskDetailsPage(QWidget):
         self._tabs.removeTab(self._artifacts_tab_index)
         self._artifacts_tab_index = -1
         self._artifacts_tab_visible = False
+
+    def _show_diff_tab(self) -> None:
+        """Show the Diff tab if not already visible."""
+        if self._diff_tab_visible:
+            return
+        self._diff_tab_index = self._tabs.addTab(self._diff_tab_widget, "Diff")
+        self._diff_tab_visible = True
+
+    def _hide_diff_tab(self) -> None:
+        """Hide the Diff tab if currently visible."""
+        if not self._diff_tab_visible:
+            return
+        if self._tabs.currentIndex() == self._diff_tab_index:
+            self._tabs.setCurrentIndex(self._task_tab_index)
+        self._tabs.removeTab(self._diff_tab_index)
+        self._diff_tab_index = -1
+        self._diff_tab_visible = False
 
     def _on_pr_triggered(self) -> None:
         task_id = str(self._current_task_id or "").strip()
@@ -435,6 +463,7 @@ class TaskDetailsPage(QWidget):
         self._tabs.setCurrentIndex(self._task_tab_index)
         self._sync_desktop(task)
         self._sync_artifacts(task)
+        self._sync_diff(task)
         self._sync_container_actions(task)
         self._logs.setPlainText("\n".join(task.logs[-5000:]))
         QTimer.singleShot(0, self._scroll_logs_to_bottom)
@@ -457,6 +486,7 @@ class TaskDetailsPage(QWidget):
         self._container.setText(task.container_id or "—")
         self._sync_desktop(task)
         self._sync_artifacts(task)
+        self._sync_diff(task)
         self._sync_container_actions(task)
         self._exit.setText("—" if task.exit_code is None else str(task.exit_code))
         self._apply_status(task)
@@ -567,6 +597,33 @@ class TaskDetailsPage(QWidget):
     def _load_artifacts(self) -> None:
         if self._last_task:
             self._artifacts_tab.set_task(self._last_task)
+
+    def _sync_diff(self, task: Task) -> None:
+        """Update Diff tab visibility based on git status."""
+        from agents_runner.environments import GH_MANAGEMENT_GITHUB
+        from agents_runner.environments import normalize_gh_management_mode
+        
+        gh_mode = normalize_gh_management_mode(str(task.gh_management_mode or ""))
+        
+        # Show diff tab only for GitHub-managed tasks with repo info
+        should_show = bool(
+            gh_mode == GH_MANAGEMENT_GITHUB and
+            task.gh_repo_root and
+            task.gh_base_branch
+        )
+        
+        if should_show:
+            was_visible = self._diff_tab_visible
+            self._show_diff_tab()
+            if not was_visible:
+                QTimer.singleShot(0, self._load_diff)
+        else:
+            self._hide_diff_tab()
+
+    def _load_diff(self) -> None:
+        """Load diff for current task."""
+        if self._last_task:
+            self._diff_tab.set_task(self._last_task)
 
     def _apply_status(self, task: Task) -> None:
         status = _task_display_status(task)


### PR DESCRIPTION
## Summary

Add a **Diff** tab to the Task Viewer that shows a GitHub-style side-by-side diff (Before | After) with scroll-locked panes.

## Changes

### New Files
- `agents_runner/gh/git_diff.py` - Git utilities for merge-base, changed files, and file content retrieval
- `agents_runner/ui/diff_utils.py` - Line-based diff computation with side-by-side alignment using difflib
- `agents_runner/ui/pages/diff_tab.py` - Side-by-side diff viewer widget

### Modified Files
- `agents_runner/ui/pages/task_details.py` - Integrate DiffTab with dynamic visibility

## Features

- **Diff tab visibility**: Only shown when task has GitHub-managed repo with base branch configured
- **Changed file list**: Left panel shows files with colorized status markers (A=Added/green, M=Modified/orange, D=Deleted/red, R=Renamed/cyan, U=Untracked/gray)
- **Side-by-side diff**: Before/After panes with synchronized horizontal and vertical scroll
- **Syntax highlighting**: Deletions highlighted in red background, additions in green
- **Binary/large file handling**: Shows error message for files >1MB or binary files
- **Lazy loading**: Diff computed only when tab is selected

## Technical Details

- Uses `git merge-base HEAD <base_ref>` to find comparison point
- Combines `git diff --name-status` and `git ls-files --others` for complete file list
- Uses Python's `difflib.SequenceMatcher` for line alignment
- Guard flags prevent scroll sync recursion/jitter

## Testing

- Syntax validation passed for all files
- Core diff algorithm tested and verified
- Follows existing tab pattern from ArtifactsTab

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner).
Agent Used: [Github Copilot](https://github.com/github/copilot-cli)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI).
