### PR TITLE
Replace agent dropdown with read-only label in environments table

### DIFF
--- a/agents_runner/ui/pages/environments_agents.py
+++ b/agents_runner/ui/pages/environments_agents.py
@@ -288,33 +288,10 @@ class AgentsTabWidget(QWidget):
         self.agents_changed.emit()
 
     def _agent_cli_widget(self, row_index: int, inst: AgentInstance) -> QWidget:
-        combo = QComboBox()
-        for agent in SUPPORTED_AGENTS:
-            combo.addItem(agent.title(), agent)
-        current = normalize_agent(inst.agent_cli)
-        idx = combo.findData(current)
-        if idx >= 0:
-            combo.setCurrentIndex(idx)
-        combo.currentIndexChanged.connect(
-            lambda _i: self._set_row_agent_cli(
-                row_index, str(combo.currentData() or "")
-            )
-        )
-        return combo
-
-    def _set_row_agent_cli(self, row_index: int, agent_cli: str) -> None:
-        if row_index < 0 or row_index >= len(self._rows):
-            return
-        agent_cli = normalize_agent(agent_cli)
-        inst = self._rows[row_index]
-        self._rows[row_index] = AgentInstance(
-            agent_id=inst.agent_id,
-            agent_cli=agent_cli,
-            config_dir=inst.config_dir,
-            cli_flags=inst.cli_flags,
-        )
-        self._update_fallback_options()
-        self.agents_changed.emit()
+        label = QLabel(normalize_agent(inst.agent_cli).title())
+        label.setAlignment(Qt.AlignCenter)
+        label.setStyleSheet("color: rgba(237, 239, 245, 200);")
+        return label
 
     def _agent_id_widget(self, row_index: int, inst: AgentInstance) -> QWidget:
         line = QLineEdit()


### PR DESCRIPTION
## Summary

This PR addresses two bug reports:

### Bug 1: Test Artifacts
- Created 20 test artifacts in `/tmp/agents-artifacts/` to verify the artifacts menu is working properly

### Bug 2: Agent Dropdown Removal
- Replaced the Agent dropdown (QComboBox) in the Environments agents table with a read-only label (QLabel)
- The user noted that the fallback system works well using the table order, so the dropdown for changing agent type per row is no longer needed
- Agent type is now set only when adding a new agent via the 'Add agent' dropdown
- Deleted the unused `_set_row_agent_cli` method

## Changes

- `agents_runner/ui/pages/environments_agents.py`:
  - `_agent_cli_widget()`: Changed from QComboBox to QLabel displaying agent type
  - Removed `_set_row_agent_cli()` method (no longer needed)
  - Fixed blank line spacing for PEP 8 compliance

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner).
Agent Used: [Github Copilot](https://github.com/github/copilot-cli)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI).
