### PR TITLE
Fix Stop/Kill buttons to actually terminate running tasks

### DIFF
--- a/agents_runner/ui/main_window_task_events.py
+++ b/agents_runner/ui/main_window_task_events.py
@@ -95,7 +95,7 @@ class _MainWindowTaskEventsMixin:
                     QMetaObject.invokeMethod(
                         bridge,
                         "request_user_kill" if is_kill else "request_user_cancel",
-                        Qt.QueuedConnection,
+                        Qt.DirectConnection,
                     )
                 except Exception:
                     bridge = None
@@ -215,7 +215,7 @@ class _MainWindowTaskEventsMixin:
         if bridge is not None:
             try:
                 QMetaObject.invokeMethod(
-                    bridge, "request_user_cancel", Qt.QueuedConnection
+                    bridge, "request_user_cancel", Qt.DirectConnection
                 )
             except Exception:
                 pass


### PR DESCRIPTION
## Summary
Fixes Stop/Kill buttons not actually stopping running tasks in the Task Viewer.

## Root Cause
The Stop/Kill buttons used `Qt.QueuedConnection` to invoke stop methods on worker threads. However, worker threads were blocked in synchronous Python code (`worker.run()`) and not processing Qt's event queue. Stop/kill requests sat in the queue unexecuted until after the task completed naturally.

## Solution
Changed `Qt.QueuedConnection` to `Qt.DirectConnection` in two locations in `agents_runner/ui/main_window_task_events.py`:
1. Line 98 - Stop/Kill button handler
2. Line 218 - Discard task handler

With `DirectConnection`, the stop methods execute immediately from the UI thread, calling thread-safe `Event.set()` operations. The worker thread checks this flag in its main loop, providing instant response.

## Thread Safety
This is safe because the invoked methods (`request_user_cancel`, `request_user_kill`) only:
- Set `threading.Event` flags (inherently thread-safe)
- Call docker subprocess commands
- Do not manipulate UI state

## Testing
- Start a task, press Stop: task stops within a short time
- Start a task, press Kill: task terminates quickly
- No retry/fallback occurs after user-initiated stop
- Status correctly reflects user termination

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner).
Agent Used: [Github Copilot](https://github.com/github/copilot-cli)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI).
