### PR TITLE
[FEAT] Add CLEANER.md support to Midori AI template detection

### DIFF
--- a/agents_runner/midoriai_template.py
+++ b/agents_runner/midoriai_template.py
@@ -20,6 +20,7 @@ _CANDIDATE_DIRS: tuple[str, ...] = (
 _KNOWN_NAMES_BY_DIR: dict[str, tuple[str, ...]] = {
     ".agents/modes": (
         "AUDITOR.md",
+        "CLEANER.md",
         "CODER.md",
         "MANAGER.md",
         "QA.md",
@@ -29,6 +30,7 @@ _KNOWN_NAMES_BY_DIR: dict[str, tuple[str, ...]] = {
     ),
     ".codex/modes": (
         "AUDITOR.md",
+        "CLEANER.md",
         "CODER.md",
         "MANAGER.md",
         "QA.md",
@@ -38,6 +40,7 @@ _KNOWN_NAMES_BY_DIR: dict[str, tuple[str, ...]] = {
     ),
     ".github/agents": (
         "auditor.md",
+        "cleaner.md",
         "coder.md",
         "mode-picker.md",
         "qa.md",


### PR DESCRIPTION
## Summary
- Add `CLEANER.md` as a supported Midori AI template marker.

## Testing
- Not run (not requested).

## Compliance
- Preflight: non-container CachyOS detected (high risk); proceeded with git/gh operations per explicit request.
- Rules discovery: reviewed repo `AGENTS.md` + `.github/copilot-instructions.md`; checked `.agents/tasks/` + `.agents/implementation/` (no updates needed).
- Tooling/network: used `git` + `gh`; no installs.
- Temp artifacts/docs: none created; README untouched.