### PR TITLE
Agent Runner: There is a small type oh in the auto pr system, there i...

### DIFF
--- a/agents_runner/prompts/pr_attribution_footer.md
+++ b/agents_runner/prompts/pr_attribution_footer.md
@@ -12,8 +12,8 @@ This footer is appended to PR descriptions to attribute work to Midori AI Agents
 ## Prompt
 ---
 {marker}
-Created by [Midori AI Agents Runner]({agents_runner_url}).
+Created by [Midori AI Agents Runner]({agents_runner_url})
 Agent Used: {agent_used}
-Related: [Midori AI Monorepo]({midori_ai_url}).
+Related: [Midori AI Monorepo]({midori_ai_url})
 
 


### PR DESCRIPTION
Automated by [Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner).

Agent: [Github Copilot](https://github.com/github/copilot-cli)

Task: 2f897aa299

Prompt:
There is a small type oh in the auto pr system, there is a `.` after the midori ai agents runner line and the mono repo, can you fix that?

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner).
Agent Used: [Github Copilot](https://github.com/github/copilot-cli)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI).
