### PR TITLE
Agent Runner: make it so that the `[host/finalize][INFO] finalization...

### DIFF
--- a/agents_runner/ui/main_window_task_recovery.py
+++ b/agents_runner/ui/main_window_task_recovery.py
@@ -23,7 +23,7 @@ class _MainWindowTaskRecoveryMixin:
             if task.is_active():
                 self._tick_recovery_task(task)
                 continue
-            if self._task_needs_finalization(task):
+            if self._task_needs_finalization(task) and not task.is_interactive_run():
                 self._queue_task_finalization(task.task_id, reason="startup_reconcile")
 
     def _tick_recovery(self) -> None:
@@ -40,7 +40,7 @@ class _MainWindowTaskRecoveryMixin:
                 self._ensure_recovery_log_tail(task)
                 return
 
-        if self._task_needs_finalization(task):
+        if self._task_needs_finalization(task) and not task.is_interactive_run():
             self._queue_task_finalization(task.task_id, reason="recovery_tick")
 
     def _task_needs_finalization(self, task: Task) -> bool:


### PR DESCRIPTION
Automated by [Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner).

Agent: [Github Copilot](https://github.com/github/copilot-cli)

Task: 2b8c0995df

Prompt:
make it so that the `[host/finalize][INFO] finalization running (reason=recovery_tick)` does not happen on `Run Interactive` tasks please...
Do not do other tasks, just fix this issue, it should be one or two lines of code to change...

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [Github Copilot](https://github.com/github/copilot-cli)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
