### PR TITLE
Fallback to browser when desktop viewer crashes

### DIFF
--- a/agents_runner/ui/pages/task_details.py
+++ b/agents_runner/ui/pages/task_details.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from PySide6.QtCore import Qt
 from PySide6.QtCore import QProcess
+from PySide6.QtCore import QUrl
 from PySide6.QtCore import QSize
 from PySide6.QtCore import QTimer
 from PySide6.QtCore import Signal
+from PySide6.QtGui import QDesktopServices
 from PySide6.QtGui import QShowEvent
 from PySide6.QtWidgets import QApplication
 from PySide6.QtWidgets import QMenu
@@ -414,6 +416,8 @@ class TaskDetailsPage(QWidget):
         """Handle desktop viewer process exit."""
         if exit_status == QProcess.ExitStatus.CrashExit:
             logger.warning(f"Desktop viewer crashed (exit code {exit_code})")
+            if self._desktop_viewer_url.startswith("http") and exit_code != 9:
+                QDesktopServices.openUrl(QUrl(self._desktop_viewer_url))
         else:
             logger.info(f"Desktop viewer exited (exit code {exit_code})")
         


### PR DESCRIPTION
Fixes #140.

- When the external noVNC desktop viewer process exits via CrashExit, automatically opens the noVNC URL in the user's default browser.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
