### PR TITLE
[FIX] Preflight uses Environments env settings

### DIFF
--- a/agents_runner/ui/main_window_preflight.py
+++ b/agents_runner/ui/main_window_preflight.py
@@ -111,6 +111,7 @@ class _MainWindowPreflightMixin:
             host_codex_dir=host_codex,
             host_workdir=host_workdir,
             agent_cli=agent_cli,
+            environment_id=env.env_id if env else "",
             auto_remove=True,
             pull_before_run=True,
             settings_preflight_script=settings_preflight_script,


### PR DESCRIPTION
## Summary

Fixes #130: Preflight testing now correctly uses Environment env settings in the `unstable` environment.

## Problem

Preflight tests were not using environment variables configured in the Environment settings. While the code was passing `env_vars`, it was missing the `environment_id` parameter needed to properly associate the configuration with the environment.

## Solution

Added `environment_id` parameter to `DockerRunnerConfig` creation in `agents_runner/ui/main_window_preflight.py` (line 117), ensuring preflight tasks load the correct environment settings.

## Changes

- **File**: `agents_runner/ui/main_window_preflight.py`
- **Change**: Added `environment_id=env.env_id if env else ""` to DockerRunnerConfig
- **Impact**: Preflight tests now behave consistently with regular agent tasks

## Verification

- Aligns preflight task creation with agent task creation pattern
- Preflight worker uses `self._config.env_vars` which now gets properly populated
- Environment configuration correctly loaded and used

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [Github Copilot](https://github.com/github/copilot-cli)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
