### PR TITLE
Fix Qt timer warnings by canceling TaskRow animations

### DIFF
--- a/agents_runner/ui/pages/dashboard.py
+++ b/agents_runner/ui/pages/dashboard.py
@@ -421,6 +421,7 @@ class DashboardPage(QWidget):
             for task_id in task_ids:
                 row = rows.pop(task_id, None)
                 if row is not None:
+                    row.cancel_entrance()
                     row.setParent(None)
                     row.deleteLater()
                 if self._selected_task_id == task_id:


### PR DESCRIPTION
Fixes #141 by stopping TaskRow entrance animations before widget deletion.

### What changed
- In `Dashboard.remove_tasks()`, call `row.cancel_entrance()` immediately before `row.deleteLater()`

### Why
Qt logs `QObject::killTimer/startTimer` warnings when timers tied to animations are stopped/started from the wrong thread during teardown. Canceling the animation first prevents the timer cleanup path from running at an unsafe time.

### Verification
- `uv run ruff check`

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [Github Copilot](https://github.com/github/copilot-cli)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
