### PR TITLE
[FIX] Show correct agent labels in new task view based on selection mode

### DIFF
--- a/agents_runner/ui/main_window_environment.py
+++ b/agents_runner/ui/main_window_environment.py
@@ -249,10 +249,12 @@ class _MainWindowEnvironmentMixin:
         from agents_runner.agent_cli import normalize_agent
 
         # Get agent chain from environment or settings
+        selection_mode = ""
         if env and env.agent_selection and env.agent_selection.agents:
             # Environment has custom agent configuration
             selection = env.agent_selection
             mode = str(selection.selection_mode or "round-robin")
+            selection_mode = mode
 
             if mode == "fallback":
                 # Build fallback chain
@@ -296,6 +298,7 @@ class _MainWindowEnvironmentMixin:
                     str(self._settings_data.get("agent_cli") or "codex")
                 )
                 agent_names = [default_agent]
+                selection_mode = ""  # Reset mode for default agent
         else:
             # No environment or no agents configured: use global default
             default_agent = normalize_agent(
@@ -303,7 +306,7 @@ class _MainWindowEnvironmentMixin:
             )
             agent_names = [default_agent]
 
-        self._new_task.set_agent_chain(agent_names)
+        self._new_task.set_agent_chain(agent_names, selection_mode)
 
     def _on_new_task_env_changed(self, env_id: str) -> None:
         if self._syncing_environment:

--- a/agents_runner/ui/pages/new_task.py
+++ b/agents_runner/ui/pages/new_task.py
@@ -858,11 +858,12 @@ class NewTaskPage(QWidget):
         self._run_interactive.setToolTip(tooltip)
         self._run_agent.setToolTip(tooltip)
 
-    def set_agent_chain(self, agents: list[str]) -> None:
+    def set_agent_chain(self, agents: list[str], selection_mode: str = "") -> None:
         """Set the agent chain display for the selected environment.
 
         Args:
             agents: List of agent names in priority order
+            selection_mode: Agent selection mode ("fallback", "round-robin", "least-used", or empty)
         """
         # Hide chain display when empty or single agent
         if not agents or len(agents) <= 1:
@@ -883,13 +884,17 @@ class NewTaskPage(QWidget):
         
         self._agent_chain.setText(chain_text)
 
-        # Full tooltip always shows all agents
+        # Build tooltip based on selection mode
+        is_fallback_mode = str(selection_mode or "").strip() == "fallback"
         tooltip = "Agents will be used in this order:\n"
         for i, agent in enumerate(agents, 1):
             if i == 1:
                 tooltip += f"{i}. {agent.title()} (Primary)\n"
             else:
-                tooltip += f"{i}. {agent.title()} (Fallback {i-1})\n"
+                if is_fallback_mode:
+                    tooltip += f"{i}. {agent.title()} (Fallback {i-1})\n"
+                else:
+                    tooltip += f"{i}. {agent.title()} (Priority {i})\n"
         self._agent_chain.setToolTip(tooltip.strip())
 
     def reset_for_new_run(self) -> None:


### PR DESCRIPTION
## Summary

Fixed the UI label text next to Prompt in the new task view to accurately reflect the agent setup based on the environment's selection mode. The tooltip now only shows "Fallback N" labels when the environment is configured to use fallback mode, and shows "Priority N" labels for round-robin and least-used modes.

## Changes

- Modified `set_agent_chain()` in `new_task.py` to accept a `selection_mode` parameter
- Updated tooltip generation logic to check selection mode and apply appropriate labels:
  - Fallback mode: "Primary" → "Fallback 1" → "Fallback 2" → ...
  - Round-robin/Least-used: "Primary" → "Priority 2" → "Priority 3" → ...
- Updated `_update_new_task_agent_chain()` in `main_window_environment.py` to pass the selection mode
- Reset selection mode to empty string when falling back to default agent

## Testing

- Syntax check: Passed
- Linter (ruff): All checks passed
- Code is backward compatible (optional parameter with default value)

## Files Modified

- `agents_runner/ui/pages/new_task.py`
- `agents_runner/ui/main_window_environment.py`

## Commit

- 95e4ac8: [FIX] Show correct agent labels in new task view based on selection mode

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [Github Copilot](https://github.com/github/copilot-cli)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
