### PR TITLE
Reduce recovery tick log spam

### DIFF
--- a/.agents/tasks/done/02-reduce-log-verbosity-for-done-state.md
+++ b/.agents/tasks/done/02-reduce-log-verbosity-for-done-state.md
@@ -1,0 +1,36 @@
+# Task: Reduce log spam for already-finalized tasks
+
+## Problem
+Tasks with `finalization_state="done"` log a DEBUG message every 5 seconds during recovery_tick (lines 89-99). This creates unnecessary log noise. Note: Task 03 (stable task tracking) provides a comprehensive solution by preventing repeated checks entirely.
+
+## Location
+File: `agents_runner/ui/main_window_task_recovery.py`
+Function: `_tick_recovery_task` (lines 89-99)
+
+## Required Change
+Remove the DEBUG log for already-done tasks (strongly recommended):
+
+**Option 1 (Strongly Recommended):** Remove the log entirely
+```python
+if (task.finalization_state or "").lower() == "done":
+    return  # Silent return - Task 03 will provide proper deduplication
+```
+
+**Option 2 (Not recommended):** Add throttling (Task 03 makes this obsolete)
+```python
+if (task.finalization_state or "").lower() == "done":
+    # Only log once per task (but Task 03 is the proper solution)
+    return
+```
+
+**Note:** This task provides immediate symptom relief. Task 03 (stable task tracking) addresses the root cause by preventing repeated processing of completed tasks.
+
+## Acceptance Criteria
+- No repeated logs for tasks already in finalization_state="done"
+- Recovery_tick still processes active/pending tasks normally
+- Log file size significantly reduced for long-running applications
+
+## Testing
+1. Run several tasks to completion
+2. Let app run for 60+ seconds
+3. Check logs - should NOT see repeated "skipping finalization (reason=already done)" messages

--- a/.agents/tasks/wip/01-add-early-return-for-interactive-runs.md
+++ b/.agents/tasks/wip/01-add-early-return-for-interactive-runs.md
@@ -1,0 +1,32 @@
+# Task: Add early return for interactive runs in _tick_recovery_task
+
+## Problem
+Interactive runs trigger recovery_tick checks every 5 seconds and generate log spam even though they never need finalization. Note: `_reconcile_tasks_after_restart()` already filters interactive runs (line 58), but `_tick_recovery_task()` does not, creating inconsistent behavior.
+
+## Location
+File: `agents_runner/ui/main_window_task_recovery.py`
+Function: `_tick_recovery_task` (lines 80-156)
+
+## Required Change
+Add early return at start of `_tick_recovery_task` before finalization_state checks:
+
+```python
+def _tick_recovery_task(self, task: Task) -> None:
+    # Skip recovery for interactive runs - they don't need finalization
+    if task.is_interactive_run():
+        return
+    
+    # ... rest of existing logic
+```
+
+## Acceptance Criteria
+- Interactive runs immediately return from recovery_tick (consistent with startup reconciliation)
+- No log messages generated for interactive runs during recovery_tick
+- Non-interactive runs continue normal recovery behavior
+- Behavior matches `_reconcile_tasks_after_restart()` filtering (line 58)
+- Run `uv run main.py` and verify no spam for interactive tasks
+
+## Testing
+1. Start an interactive run (`agents-runner-tui-it-*` container)
+2. Check logs - should see NO recovery_tick messages for that task
+3. Verify normal tasks still get recovery_tick processing

--- a/.agents/tasks/wip/03-add-state-tracking-for-stable-tasks.md
+++ b/.agents/tasks/wip/03-add-state-tracking-for-stable-tasks.md
@@ -1,0 +1,52 @@
+# Task: Add state tracking to skip recovery checks for stable tasks
+
+## Problem
+Recovery_tick processes ALL tasks every 5 seconds, even tasks that are long-completed and stable. This wastes CPU and generates potential log spam. This is the root cause of the issues addressed in Tasks 01 and 02.
+
+## Location
+File: `agents_runner/ui/main_window_task_recovery.py`
+Function: `_tick_recovery` (line 71-78)
+
+## Required Change
+Add a set to track tasks that have reached stable terminal state:
+
+```python
+# In MainWindow.__init__ (near line 136-137, with other recovery structures):
+self._stable_tasks: set[str] = set()
+
+# In _tick_recovery_task after confirming finalization is done:
+def _tick_recovery_task(self, task: Task) -> None:
+    task_id = str(task.task_id or "")
+    
+    # Skip if already marked stable
+    if task_id in self._stable_tasks:
+        return
+    
+    if (task.finalization_state or "").lower() == "done":
+        self._stable_tasks.add(task_id)  # Mark as stable
+        return
+    
+    # ... rest of existing logic
+```
+
+**Thread Safety Note:** Consider synchronization if set operations can occur concurrently (recovery_tick runs on timer thread).
+
+**Cleanup Requirements:** Remove task from `_stable_tasks` when task is discarded/removed:
+```python
+# In task discard/removal function:
+self._stable_tasks.discard(task_id)
+```
+
+## Acceptance Criteria
+- Completed tasks are only checked once, then marked stable
+- Recovery_tick skips stable tasks entirely (no processing, no logs)
+- Stable task set is properly initialized in `MainWindow.__init__` (near line 136-137)
+- Task IDs are removed from stable set when tasks are discarded
+- Memory usage remains reasonable (set only stores task IDs as strings)
+- Thread safety considered for concurrent set access
+
+## Testing
+1. Complete several tasks
+2. Let app run for several minutes
+3. Verify CPU usage is minimal (not repeatedly processing completed tasks)
+4. Check that discarding a task removes it from stable set

--- a/.agents/tasks/wip/04-review-recovery-tick-interval.md
+++ b/.agents/tasks/wip/04-review-recovery-tick-interval.md
@@ -1,0 +1,50 @@
+# Task: Review and optimize recovery_tick interval
+
+## Problem
+Recovery_tick runs every 5 seconds unconditionally. For applications with many completed tasks or mostly stable state, this may be too frequent. Note: Implementing Task 03 (stable task tracking) significantly reduces work per tick and may make interval changes unnecessary.
+
+## Context
+Code comments (lines 139-143) contain rationale for 5-second interval and reference missing implementation document `.agents/implementation/recovery-tick-timing-analysis.md` (file does not exist).
+
+## Location
+File: `agents_runner/ui/main_window.py`
+Lines: 138-146 (QTimer setup)
+
+## Required Analysis
+Review whether 5-second interval is optimal:
+
+**Current setup:**
+```python
+self._recovery_ticker = QTimer(self)
+self._recovery_ticker.setInterval(5000)  # 5 seconds
+self._recovery_ticker.timeout.connect(self._tick_recovery)
+self._recovery_ticker.start()
+```
+
+## Considerations
+1. **Safety vs Performance:** Balance between catching missed events quickly vs CPU/log overhead
+2. **Task patterns:** Most tasks complete cleanly via event-driven finalization
+3. **Recovery is safety net:** Only needed when events are missed
+4. **Dynamic interval:** Consider adaptive interval (5s when active tasks, 30s when all stable)
+
+## Recommended Options
+- **Option A (Preferred):** Keep 5s but implement Task 03 (stable task tracking) to reduce work per tick, then re-evaluate
+- **Option B:** Increase to 10-15s (recovery is edge case, not primary path)
+- **Option C:** Adaptive interval based on active task count
+- **Option D:** Only run recovery when tasks exist that need checking
+- **Option E:** Create or remove reference to `.agents/implementation/recovery-tick-timing-analysis.md`
+
+## Implementation Priority
+**Recommendation:** Implement Task 03 first, then re-evaluate if interval adjustment is still needed. Task 03 addresses the root cause (repeated processing) while keeping the safety net responsive.
+
+## Acceptance Criteria
+- Decision documented on chosen approach
+- If interval changed, verify edge cases still caught (container state changes, missed events)
+- Performance improved without sacrificing reliability
+- Referenced implementation document either created or reference removed from code
+- Evaluation done AFTER Task 03 implementation for accurate impact assessment
+
+## Testing
+1. Simulate missed events (kill container externally, force restart)
+2. Verify recovery still catches and finalizes tasks
+3. Measure CPU/log impact before and after change

--- a/agents_runner/ui/main_window_task_recovery.py
+++ b/agents_runner/ui/main_window_task_recovery.py
@@ -88,16 +88,7 @@ class _MainWindowTaskRecoveryMixin:
         """
         # If finalization already completed, no work is needed.
         if (task.finalization_state or "").lower() == "done":
-            self.host_log.emit(
-                str(task.task_id or ""),
-                format_log(
-                    "host",
-                    "recovery_tick",
-                    "DEBUG",
-                    f"Task {task.task_id}: skipping finalization (reason=already done, state=done)",
-                ),
-            )
-            return
+            return  # Silent return - Task 03 will provide proper deduplication
 
         status_lower = (task.status or "").lower()
         if task.is_active() or status_lower == "unknown":


### PR DESCRIPTION
## Summary
- remove repeated DEBUG log spam for already-finalized tasks
- add task tracking files for remaining recovery tick follow-ups

## Testing
- uv run ruff check .
- uv run pytest -v

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [Github Copilot](https://github.com/github/copilot-cli)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
