### PR TITLE
Align Interactive prompt assembly with normal runs

### DIFF
--- a/agents_runner/prompts/interactive_standby.md
+++ b/agents_runner/prompts/interactive_standby.md
@@ -1,0 +1,7 @@
+# Interactive Standby Instruction
+
+This prompt is appended for typed Interactive runs after the task prompt and context layers.
+
+## Prompt
+
+After you complete the requested task, stop and fully standby for the user's next instruction.


### PR DESCRIPTION
## Summary
- Interactive launches now track whether the user actually typed prompt content.
- Typed Interactive runs now build full prompt context like normal runs (base context + GitHub/PR context + template layers) and append an Interactive standby instruction.
- Empty Interactive runs now launch without injecting any prompt text.
- Help-launch flow keeps its dedicated prompt behavior.

## Details
- Added typed-prompt/full-prompt gating in interactive launch orchestration.
- Added GitHub context + PR metadata prompt composition for interactive full-prompt runs.
- Added interactive template/desktop prompt assembly and standby prompt append in prep worker.
- Added `agents_runner/prompts/interactive_standby.md` template.

## Validation
- `uv run --with ruff ruff check .`

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
