### PR TITLE
Refactor Environments UI and bump project version to 0.1.0.50

### DIFF
--- a/agents_runner/ui/pages/environments.py
+++ b/agents_runner/ui/pages/environments.py
@@ -3,67 +3,72 @@ from __future__ import annotations
 import os
 
 from PySide6.QtCore import Qt
+from PySide6.QtCore import QTimer
 from PySide6.QtCore import Signal
-from PySide6.QtGui import QIntValidator
-from PySide6.QtWidgets import QCheckBox
 from PySide6.QtWidgets import QComboBox
-from PySide6.QtWidgets import QFileDialog
-from PySide6.QtWidgets import QGridLayout
 from PySide6.QtWidgets import QHBoxLayout
 from PySide6.QtWidgets import QLabel
-from PySide6.QtWidgets import QLineEdit
-from PySide6.QtWidgets import QPlainTextEdit
-from PySide6.QtWidgets import QPushButton
-from PySide6.QtWidgets import QSplitter
 from PySide6.QtWidgets import QStackedWidget
-from PySide6.QtWidgets import QTabWidget
 from PySide6.QtWidgets import QToolButton
 from PySide6.QtWidgets import QVBoxLayout
 from PySide6.QtWidgets import QWidget
 
-from agents_runner.environments import ALLOWED_STAINS
 from agents_runner.environments import Environment
 from agents_runner.environments import WORKSPACE_CLONED
 from agents_runner.environments import WORKSPACE_MOUNTED
 from agents_runner.environments import WORKSPACE_NONE
 from agents_runner.gh_management import is_gh_available
 from agents_runner.persistence import default_state_path
-from agents_runner.ui.widgets import GlassCard
 from agents_runner.ui.constants import (
-    MAIN_LAYOUT_MARGINS,
-    MAIN_LAYOUT_SPACING,
-    HEADER_MARGINS,
-    HEADER_SPACING,
+    BUTTON_ROW_SPACING,
     CARD_MARGINS,
     CARD_SPACING,
-    GRID_HORIZONTAL_SPACING,
-    GRID_VERTICAL_SPACING,
-    BUTTON_ROW_SPACING,
-    STANDARD_BUTTON_WIDTH,
-    TAB_CONTENT_MARGINS,
-    TAB_CONTENT_SPACING,
+    HEADER_MARGINS,
+    HEADER_SPACING,
+    MAIN_LAYOUT_MARGINS,
+    MAIN_LAYOUT_SPACING,
 )
-
-from agents_runner.ui.pages.environments_actions import _EnvironmentsPageActionsMixin
-from agents_runner.ui.pages.environments_prompts import PromptsTabWidget
-from agents_runner.ui.pages.environments_agents import AgentsTabWidget
-from agents_runner.ui.pages.environments_ports import PortsTabWidget
 from agents_runner.ui.graphics import _EnvironmentTintOverlay
+from agents_runner.ui.pages.environments_actions import _EnvironmentsPageActionsMixin
+from agents_runner.ui.pages.environments_form import _EnvironmentsFormMixin
+from agents_runner.ui.pages.environments_navigation import _EnvironmentsNavigationMixin
 from agents_runner.ui.utils import _apply_environment_combo_tint
 from agents_runner.ui.utils import _stain_color
+from agents_runner.ui.widgets import GlassCard
 
 
-class EnvironmentsPage(QWidget, _EnvironmentsPageActionsMixin):
+class EnvironmentsPage(
+    QWidget,
+    _EnvironmentsNavigationMixin,
+    _EnvironmentsFormMixin,
+    _EnvironmentsPageActionsMixin,
+):
     back_requested = Signal()
     updated = Signal(str)
     test_preflight_requested = Signal(object)
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
+        self.setObjectName("EnvironmentsPageRoot")
 
         self._environments: dict[str, Environment] = {}
         self._current_env_id: str | None = None
-        self._settings_data: dict[str, object] = {}  # Reference to main window settings
+        self._settings_data: dict[str, object] = {}
+
+        self._suppress_autosave = False
+        self._autosave_timer = QTimer(self)
+        self._autosave_timer.setSingleShot(True)
+        self._autosave_timer.setInterval(450)
+        self._autosave_timer.timeout.connect(self._emit_autosave)
+
+        self._pane_animation = None
+        self._pane_rest_pos = None
+        self._compact_mode = False
+        self._active_pane_key = ""
+
+        self._pane_specs = self._default_pane_specs()
+        self._pane_index_by_key: dict[str, int] = {}
+        self._nav_buttons: dict[str, QToolButton] = {}
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(*MAIN_LAYOUT_MARGINS)
@@ -85,7 +90,7 @@ class EnvironmentsPage(QWidget, _EnvironmentsPageActionsMixin):
         back = QToolButton()
         back.setText("Back")
         back.setToolButtonStyle(Qt.ToolButtonTextOnly)
-        back.clicked.connect(self.back_requested.emit)
+        back.clicked.connect(self._on_back)
 
         header_layout.addWidget(title)
         header_layout.addStretch(1)
@@ -99,6 +104,7 @@ class EnvironmentsPage(QWidget, _EnvironmentsPageActionsMixin):
 
         top_row = QHBoxLayout()
         top_row.setSpacing(BUTTON_ROW_SPACING)
+
         self._env_select = QComboBox()
         self._env_select.currentIndexChanged.connect(self._on_env_selected)
 
@@ -112,11 +118,6 @@ class EnvironmentsPage(QWidget, _EnvironmentsPageActionsMixin):
         delete_btn.setToolButtonStyle(Qt.ToolButtonTextOnly)
         delete_btn.clicked.connect(self._on_delete)
 
-        save_btn = QToolButton()
-        save_btn.setText("Save")
-        save_btn.setToolButtonStyle(Qt.ToolButtonTextOnly)
-        save_btn.clicked.connect(self._on_save)
-
         test_btn = QToolButton()
         test_btn.setText("Test preflight")
         test_btn.setToolButtonStyle(Qt.ToolButtonTextOnly)
@@ -127,343 +128,63 @@ class EnvironmentsPage(QWidget, _EnvironmentsPageActionsMixin):
         top_row.addWidget(new_btn)
         top_row.addWidget(delete_btn)
         top_row.addWidget(test_btn)
-        top_row.addWidget(save_btn)
         card_layout.addLayout(top_row)
 
-        tabs = QTabWidget()
-        tabs.setDocumentMode(True)
-        tabs.tabBar().setDrawBase(False)
+        self._compact_nav = QComboBox()
+        self._compact_nav.setObjectName("SettingsCompactNav")
+        self._compact_nav.setVisible(False)
+        self._compact_nav.currentIndexChanged.connect(self._on_compact_nav_changed)
+        card_layout.addWidget(self._compact_nav)
 
-        general_tab = QWidget()
-        general_layout = QVBoxLayout(general_tab)
-        general_layout.setContentsMargins(*TAB_CONTENT_MARGINS)
-        general_layout.setSpacing(TAB_CONTENT_SPACING)
+        panes_layout = QHBoxLayout()
+        panes_layout.setContentsMargins(0, 0, 0, 0)
+        panes_layout.setSpacing(14)
 
-        grid = QGridLayout()
-        grid.setHorizontalSpacing(GRID_HORIZONTAL_SPACING)
-        grid.setVerticalSpacing(GRID_VERTICAL_SPACING)
-        grid.setContentsMargins(0, 0, 0, 0)
+        self._nav_panel = QWidget()
+        self._nav_panel.setObjectName("SettingsNavPanel")
+        self._nav_panel.setMinimumWidth(250)
+        self._nav_panel.setMaximumWidth(320)
+        nav_layout = QVBoxLayout(self._nav_panel)
+        nav_layout.setContentsMargins(10, 10, 10, 10)
+        nav_layout.setSpacing(6)
 
-        self._name = QLineEdit()
-        self._color = QComboBox()
-        for stain in ALLOWED_STAINS:
-            self._color.addItem(stain.title(), stain)
-        self._color.currentIndexChanged.connect(self._apply_environment_tints)
+        self._right_panel = QWidget()
+        self._right_panel.setObjectName("SettingsPaneHost")
+        right_layout = QVBoxLayout(self._right_panel)
+        right_layout.setContentsMargins(0, 0, 0, 0)
+        right_layout.setSpacing(0)
 
-        self._max_agents_running = QLineEdit()
-        self._max_agents_running.setPlaceholderText("-1")
-        self._max_agents_running.setToolTip(
-            "Maximum agents running at the same time for this environment. Set to -1 for no limit.\n"
-            "Tip: For local-folder workspaces, set this to 1 to avoid agents fighting over setup/files."
-        )
-        self._max_agents_running.setValidator(QIntValidator(-1, 10_000_000, self))
-        self._max_agents_running.setMaximumWidth(150)
+        self._page_stack = QStackedWidget()
+        self._page_stack.setObjectName("SettingsPageStack")
+        right_layout.addWidget(self._page_stack, 1)
 
-        grid.addWidget(QLabel("Name"), 0, 0)
-        grid.addWidget(self._name, 0, 1, 1, 2)
-        grid.addWidget(QLabel("Color"), 1, 0)
-        grid.addWidget(self._color, 1, 1, 1, 2)
-
-        self._headless_desktop_enabled = QCheckBox("Enable headless desktop")
-        self._headless_desktop_enabled.setToolTip(
-            "When enabled, agent runs for this environment will start a noVNC desktop.\n"
-            "Settings → Force headless desktop overrides this setting."
-        )
-
-        self._cache_desktop_build = QCheckBox("Cache desktop build")
-        self._cache_desktop_build.setToolTip(
-            "When enabled, desktop components are pre-installed in a cached Docker image.\n"
-            "This reduces task startup time from 45-90s to 2-5s.\n"
-            "Requires 'Enable headless desktop' to be enabled.\n\n"
-            "Image is automatically rebuilt when scripts change."
-        )
-        self._cache_desktop_build.setEnabled(False)  # Disabled until desktop is enabled
-
-        # Connect desktop enabled checkbox to cache checkbox state
-        self._headless_desktop_enabled.stateChanged.connect(
-            self._on_headless_desktop_toggled
-        )
-
-        self._container_caching_enabled = QCheckBox("Enable container caching")
-        self._container_caching_enabled.setToolTip(
-            "When enabled, environment preflight scripts are executed at Docker build time.\n"
-            "This creates a cached image with pre-installed dependencies, speeding up task startup.\n\n"
-            "The cached preflight script is configured in the Preflight tab.\n"
-            "Image is automatically rebuilt when the cached preflight script changes."
-        )
-        self._container_caching_enabled.stateChanged.connect(
-            self._on_container_caching_toggled
-        )
-
-        self._use_cross_agents = QCheckBox("Use cross agents")
-        self._use_cross_agents.setToolTip(
-            "When enabled, allows agent instances from the Agents tab to be mounted\n"
-            "as cross-agents in task containers. Configure the allowlist in the Agents tab."
-        )
-        self._use_cross_agents.stateChanged.connect(self._on_use_cross_agents_toggled)
-
-        self._gh_context_enabled = QCheckBox("Provide GitHub context to agent")
-        self._gh_context_enabled.setToolTip(
-            "When enabled, repository context (URL, branch, commit) is provided to the agent.\n"
-            "For GitHub-managed environments: Always available.\n"
-            "For folder-managed environments: Only if folder is a git repository.\n\n"
-            "Note: This does NOT provide GitHub authentication - that is separate."
-        )
-        self._gh_context_enabled.setEnabled(False)
-        self._gh_context_enabled.setVisible(True)
-
-        max_agents_row = QWidget(general_tab)
-        max_agents_row_layout = QHBoxLayout(max_agents_row)
-        max_agents_row_layout.setContentsMargins(0, 0, 0, 0)
-        max_agents_row_layout.setSpacing(BUTTON_ROW_SPACING)
-        max_agents_row_layout.addWidget(self._max_agents_running)
-        max_agents_row_layout.addStretch(1)
-
-        headless_desktop_row = QWidget(general_tab)
-        headless_desktop_layout = QHBoxLayout(headless_desktop_row)
-        headless_desktop_layout.setContentsMargins(0, 0, 0, 0)
-        headless_desktop_layout.setSpacing(BUTTON_ROW_SPACING)
-        headless_desktop_layout.addWidget(self._headless_desktop_enabled)
-        headless_desktop_layout.addWidget(self._cache_desktop_build)
-        headless_desktop_layout.addStretch(1)
-
-        container_caching_row = QWidget(general_tab)
-        container_caching_layout = QHBoxLayout(container_caching_row)
-        container_caching_layout.setContentsMargins(0, 0, 0, 0)
-        container_caching_layout.setSpacing(BUTTON_ROW_SPACING)
-        container_caching_layout.addWidget(self._container_caching_enabled)
-        container_caching_layout.addStretch(1)
-
-        cross_agents_row = QWidget(general_tab)
-        cross_agents_layout = QHBoxLayout(cross_agents_row)
-        cross_agents_layout.setContentsMargins(0, 0, 0, 0)
-        cross_agents_layout.setSpacing(BUTTON_ROW_SPACING)
-        cross_agents_layout.addWidget(self._use_cross_agents)
-        cross_agents_layout.addStretch(1)
-
-        grid.addWidget(QLabel("Max agents running"), 3, 0)
-        grid.addWidget(max_agents_row, 3, 1, 1, 2)
-        grid.addWidget(QLabel("Headless desktop"), 5, 0)
-        grid.addWidget(headless_desktop_row, 5, 1, 1, 2)
-        grid.addWidget(QLabel("Container caching"), 6, 0)
-        grid.addWidget(container_caching_row, 6, 1, 1, 2)
-        grid.addWidget(QLabel("Cross agents"), 7, 0)
-        grid.addWidget(cross_agents_row, 7, 1, 1, 2)
-
-        self._gh_context_label = QLabel("GitHub context")
-        self._gh_context_row = QWidget(general_tab)
-        gh_context_layout = QHBoxLayout(self._gh_context_row)
-        gh_context_layout.setContentsMargins(0, 0, 0, 0)
-        gh_context_layout.setSpacing(BUTTON_ROW_SPACING)
-        gh_context_layout.addWidget(self._gh_context_enabled)
-        gh_context_layout.addStretch(1)
-
-        self._gh_context_label.setVisible(False)
-        self._gh_context_row.setVisible(False)
-        grid.addWidget(self._gh_context_label, 4, 0)
-        grid.addWidget(self._gh_context_row, 4, 1, 1, 2)
-
-        self._workspace_type_combo = QComboBox(general_tab)
-        self._workspace_type_combo.addItem("Use Settings workdir", WORKSPACE_NONE)
-        self._workspace_type_combo.addItem("Mount local folder", WORKSPACE_MOUNTED)
-        self._workspace_type_combo.addItem("Clone GitHub repo", WORKSPACE_CLONED)
-        self._workspace_type_combo.currentIndexChanged.connect(
-            self._sync_workspace_controls
-        )
-
-        self._workspace_target = QLineEdit(general_tab)
-        self._workspace_target.setPlaceholderText(
-            "owner/repo, https://github.com/owner/repo, or /path/to/folder"
-        )
-        self._workspace_target.textChanged.connect(self._sync_workspace_controls)
-
-        self._gh_management_browse = QPushButton("Browse…", general_tab)
-        self._gh_management_browse.setFixedWidth(STANDARD_BUTTON_WIDTH)
-        self._gh_management_browse.clicked.connect(self._pick_gh_management_folder)
-
-        self._gh_use_host_cli = QCheckBox("Use host `gh` CLI", general_tab)
-        self._gh_use_host_cli.setToolTip(
-            "Use the host system's `gh` CLI for cloning and PR creation (if installed).\n"
-            "When disabled or unavailable, cloning uses `git` and PR creation is skipped."
-        )
-        self._gh_use_host_cli.setVisible(False)
-
-        self._workspace_type_combo.setVisible(False)
-        self._workspace_target.setVisible(False)
-        self._gh_management_browse.setVisible(False)
-
-        general_layout.addLayout(grid)
-        general_layout.addStretch(1)
-
-        # Single-editor mode widgets (caching OFF)
-        self._preflight_enabled = QCheckBox("Enable environment preflight")
-        self._preflight_enabled.setToolTip(
-            "Runs after Settings preflight script.\n"
-            "Use for environment-specific setup tasks."
-        )
-        self._preflight_script = QPlainTextEdit()
-        self._preflight_script.setPlaceholderText(
-            "#!/usr/bin/env bash\n"
-            "set -euo pipefail\n"
-            "\n"
-            "# Runs inside the container before the agent command.\n"
-            "# Runs after Settings preflight (if enabled).\n"
-        )
-        self._preflight_script.setTabChangesFocus(True)
-        self._preflight_enabled.toggled.connect(self._preflight_script.setEnabled)
-        self._preflight_script.setEnabled(False)
-
-        # Dual-editor mode widgets (caching ON)
-        self._cached_preflight_enabled = QCheckBox("Enable cached preflight")
-        self._cached_preflight_enabled.setToolTip(
-            "Runs at Docker build time to pre-install dependencies.\n"
-            "Creates a cached image for faster task startup."
-        )
-        self._cached_preflight_script = QPlainTextEdit()
-        self._cached_preflight_script.setPlaceholderText(
-            "#!/usr/bin/env bash\n"
-            "set -euo pipefail\n"
-            "\n"
-            "# Runs at Docker build time.\n"
-            "# Use for installing packages and dependencies.\n"
-        )
-        self._cached_preflight_script.setTabChangesFocus(True)
-        self._cached_preflight_enabled.toggled.connect(
-            self._cached_preflight_script.setEnabled
-        )
-        self._cached_preflight_script.setEnabled(False)
-
-        self._run_preflight_enabled = QCheckBox("Enable run preflight")
-        self._run_preflight_enabled.setToolTip(
-            "Runs at task startup after cached preflight.\n"
-            "Use for runtime setup and validation."
-        )
-        self._run_preflight_script = QPlainTextEdit()
-        self._run_preflight_script.setPlaceholderText(
-            "#!/usr/bin/env bash\n"
-            "set -euo pipefail\n"
-            "\n"
-            "# Runs at task startup (after cached layer).\n"
-            "# Use for runtime-specific setup.\n"
-        )
-        self._run_preflight_script.setTabChangesFocus(True)
-        self._run_preflight_enabled.toggled.connect(
-            self._run_preflight_script.setEnabled
-        )
-        self._run_preflight_script.setEnabled(False)
-
-        # Build single-editor container (caching OFF)
-        self._preflight_single_container = QWidget()
-        single_layout = QVBoxLayout(self._preflight_single_container)
-        single_layout.setSpacing(TAB_CONTENT_SPACING)
-        single_layout.setContentsMargins(0, 0, 0, 0)
-        single_layout.addWidget(self._preflight_enabled)
-        single_layout.addWidget(QLabel("Preflight script"))
-        single_layout.addWidget(self._preflight_script, 1)
-
-        # Build dual-editor container (caching ON)
-        self._preflight_dual_container = QWidget()
-        dual_layout = QVBoxLayout(self._preflight_dual_container)
-        dual_layout.setSpacing(TAB_CONTENT_SPACING)
-        dual_layout.setContentsMargins(0, 0, 0, 0)
-
-        splitter = QSplitter(Qt.Horizontal)
-        splitter.setChildrenCollapsible(False)
-
-        # Left panel: Cached preflight
-        left_panel = GlassCard()
-        left_layout = QVBoxLayout(left_panel)
-        left_layout.setContentsMargins(18, 16, 18, 16)
-        left_layout.setSpacing(10)
-
-        cached_label = QLabel("Cached preflight")
-        cached_label.setStyleSheet("font-size: 14px; font-weight: 650;")
-
-        left_layout.addWidget(self._cached_preflight_enabled)
-        left_layout.addWidget(cached_label)
-        left_layout.addWidget(self._cached_preflight_script, 1)
-
-        # Right panel: Run preflight
-        right_panel = GlassCard()
-        right_layout = QVBoxLayout(right_panel)
-        right_layout.setContentsMargins(18, 16, 18, 16)
-        right_layout.setSpacing(10)
-
-        run_label = QLabel("Run preflight")
-        run_label.setStyleSheet("font-size: 14px; font-weight: 650;")
-
-        right_layout.addWidget(self._run_preflight_enabled)
-        right_layout.addWidget(run_label)
-        right_layout.addWidget(self._run_preflight_script, 1)
-
-        splitter.addWidget(left_panel)
-        splitter.addWidget(right_panel)
-        splitter.setStretchFactor(0, 1)
-        splitter.setStretchFactor(1, 1)
-
-        dual_layout.addWidget(splitter, 1)
-
-        # Create stacked widget for layout switching
-        self._preflight_stack = QStackedWidget()
-        self._preflight_stack.addWidget(
-            self._preflight_single_container
-        )  # Index 0: caching OFF
-        self._preflight_stack.addWidget(
-            self._preflight_dual_container
-        )  # Index 1: caching ON
-
-        preflight_tab = QWidget()
-        preflight_layout = QVBoxLayout(preflight_tab)
-        preflight_layout.setSpacing(TAB_CONTENT_SPACING)
-        preflight_layout.setContentsMargins(*TAB_CONTENT_MARGINS)
-        preflight_layout.addWidget(self._preflight_stack, 1)
-
-        self._env_vars = QPlainTextEdit()
-        self._env_vars.setPlaceholderText("# KEY=VALUE (one per line)\n")
-        self._env_vars.setTabChangesFocus(True)
-        env_vars_tab = QWidget()
-        env_vars_layout = QVBoxLayout(env_vars_tab)
-        env_vars_layout.setSpacing(TAB_CONTENT_SPACING)
-        env_vars_layout.setContentsMargins(*TAB_CONTENT_MARGINS)
-        env_vars_layout.addWidget(QLabel("Container env vars"))
-        env_vars_layout.addWidget(self._env_vars, 1)
-
-        self._mounts = QPlainTextEdit()
-        self._mounts.setPlaceholderText("# host_path:container_path[:ro]\n")
-        self._mounts.setTabChangesFocus(True)
-        mounts_tab = QWidget()
-        mounts_layout = QVBoxLayout(mounts_tab)
-        mounts_layout.setSpacing(TAB_CONTENT_SPACING)
-        mounts_layout.setContentsMargins(*TAB_CONTENT_MARGINS)
-        mounts_layout.addWidget(QLabel("Extra bind mounts"))
-        mounts_layout.addWidget(self._mounts, 1)
-
-        self._ports_tab = PortsTabWidget()
-        self._ports_tab.ports_changed.connect(self._on_ports_changed)
-
-        self._prompts_tab = PromptsTabWidget()
-        self._prompts_tab.prompts_changed.connect(self._on_prompts_changed)
-
-        self._agents_tab = AgentsTabWidget()
-        self._agents_tab.agents_changed.connect(self._on_agents_changed)
-
-        tabs.addTab(general_tab, "General")
-        tabs.addTab(self._agents_tab, "Agents")
-        tabs.addTab(self._prompts_tab, "Prompts")
-        tabs.addTab(env_vars_tab, "Env Vars")
-        tabs.addTab(mounts_tab, "Mounts")
-        tabs.addTab(self._ports_tab, "Ports")
-        tabs.addTab(preflight_tab, "Preflight")
-
-        card_layout.addWidget(tabs, 1)
+        panes_layout.addWidget(self._nav_panel)
+        panes_layout.addWidget(self._right_panel, 1)
+        card_layout.addLayout(panes_layout, 1)
 
         layout.addWidget(card, 1)
+
+        self._build_controls()
+        self._build_pages()
+        self._build_navigation(nav_layout)
+        self._sync_nav_button_sizes()
+        self._connect_autosave_signals()
+
+        if self._pane_specs:
+            first_key = self._pane_specs[0].key
+            self._set_active_navigation(first_key)
+            self._set_current_pane(first_key, animate=False)
+
+        self._update_navigation_mode()
+        QTimer.singleShot(0, self._sync_nav_button_sizes)
 
         self._tint_overlay = _EnvironmentTintOverlay(self, alpha=13)
         self._tint_overlay.raise_()
 
     def resizeEvent(self, event) -> None:
         super().resizeEvent(event)
+        self._update_navigation_mode()
+        self._sync_nav_button_sizes()
         self._tint_overlay.setGeometry(self.rect())
         self._tint_overlay.raise_()
 
@@ -510,7 +231,6 @@ class EnvironmentsPage(QWidget, _EnvironmentsPageActionsMixin):
         self._apply_environment_tints()
 
     def set_settings_data(self, settings_data: dict[str, object]) -> None:
-        """Set reference to main window settings data."""
         self._settings_data = settings_data
         self._ports_tab.set_desktop_effective_enabled(self._effective_desktop_enabled())
 
@@ -520,159 +240,158 @@ class EnvironmentsPage(QWidget, _EnvironmentsPageActionsMixin):
         return bool(force or env_enabled)
 
     def _load_selected(self) -> None:
+        if self._autosave_timer.isActive():
+            self._autosave_timer.stop()
+
         env_id = str(self._env_select.currentData() or "")
         env = self._environments.get(env_id)
         self._current_env_id = env_id if env else None
-        if not env:
-            self._name.setText("")
-            self._max_agents_running.setText("-1")
-            self._headless_desktop_enabled.setChecked(False)
-            self._cache_desktop_build.setChecked(False)
-            self._cache_desktop_build.setEnabled(False)
-            self._container_caching_enabled.setChecked(False)
-            self._use_cross_agents.setChecked(False)
-            self._gh_context_enabled.setChecked(False)
-            self._gh_context_enabled.setEnabled(False)
-            self._gh_context_label.setVisible(False)
-            self._gh_context_row.setVisible(False)
-            self._workspace_type_combo.setCurrentIndex(0)
-            self._workspace_target.setText("")
-            self._gh_use_host_cli.setChecked(bool(is_gh_available()))
-            self._preflight_enabled.setChecked(False)
-            self._preflight_script.setPlainText("")
-            self._cached_preflight_enabled.setChecked(False)
-            self._cached_preflight_script.setPlainText("")
-            self._run_preflight_enabled.setChecked(False)
-            self._run_preflight_script.setPlainText("")
-            self._preflight_stack.setCurrentIndex(0)
-            self._env_vars.setPlainText("")
-            self._mounts.setPlainText("")
+
+        self._suppress_autosave = True
+        try:
+            if not env:
+                self._name.setText("")
+                self._max_agents_running.setText("-1")
+                self._headless_desktop_enabled.setChecked(False)
+                self._cache_desktop_build.setChecked(False)
+                self._cache_desktop_build.setEnabled(False)
+                self._container_caching_enabled.setChecked(False)
+                self._use_cross_agents.setChecked(False)
+                self._gh_context_enabled.setChecked(False)
+                self._gh_context_enabled.setEnabled(False)
+                self._gh_context_label.setVisible(False)
+                self._gh_context_row.setVisible(False)
+                self._workspace_type_combo.setCurrentIndex(0)
+                self._workspace_target.setText("")
+                self._gh_use_host_cli.setChecked(bool(is_gh_available()))
+                self._preflight_enabled.setChecked(False)
+                self._preflight_script.setPlainText("")
+                self._cached_preflight_enabled.setChecked(False)
+                self._cached_preflight_script.setPlainText("")
+                self._run_preflight_enabled.setChecked(False)
+                self._run_preflight_script.setPlainText("")
+                self._preflight_stack.setCurrentIndex(0)
+                self._env_vars.setPlainText("")
+                self._mounts.setPlainText("")
+                self._ports_tab.set_desktop_effective_enabled(
+                    self._effective_desktop_enabled()
+                )
+                self._ports_tab.set_ports([], False, False)
+                self._prompts_tab.set_prompts([], False)
+                self._agents_tab.set_agent_selection(None)
+                self._sync_workspace_controls()
+                return
+
+            self._name.setText(env.name)
+            idx = self._color.findData(env.color)
+            if idx >= 0:
+                self._color.setCurrentIndex(idx)
+            self._max_agents_running.setText(
+                str(int(getattr(env, "max_agents_running", -1)))
+            )
+            self._headless_desktop_enabled.setChecked(
+                bool(getattr(env, "headless_desktop_enabled", False))
+            )
             self._ports_tab.set_desktop_effective_enabled(
                 self._effective_desktop_enabled()
             )
-            self._ports_tab.set_ports([], False, False)
-            self._prompts_tab.set_prompts([], False)
-            self._agents_tab.set_agent_selection(None)
-            self._sync_workspace_controls()
-            return
+            self._cache_desktop_build.setChecked(
+                bool(getattr(env, "cache_desktop_build", False))
+            )
+            self._cache_desktop_build.setEnabled(
+                bool(getattr(env, "headless_desktop_enabled", False))
+            )
+            self._container_caching_enabled.setChecked(
+                bool(getattr(env, "container_caching_enabled", False))
+            )
+            self._use_cross_agents.setChecked(
+                bool(getattr(env, "use_cross_agents", False))
+            )
+            workspace_type = env.workspace_type or WORKSPACE_NONE
+            is_github_env = workspace_type == WORKSPACE_CLONED
+            is_local_env = workspace_type == WORKSPACE_MOUNTED
 
-        self._name.setText(env.name)
-        idx = self._color.findData(env.color)
-        if idx >= 0:
-            self._color.setCurrentIndex(idx)
-        self._max_agents_running.setText(
-            str(int(getattr(env, "max_agents_running", -1)))
-        )
-        self._headless_desktop_enabled.setChecked(
-            bool(getattr(env, "headless_desktop_enabled", False))
-        )
-        self._ports_tab.set_desktop_effective_enabled(self._effective_desktop_enabled())
-        self._cache_desktop_build.setChecked(
-            bool(getattr(env, "cache_desktop_build", False))
-        )
-        # Update cache checkbox enabled state based on desktop enabled state
-        self._cache_desktop_build.setEnabled(
-            bool(getattr(env, "headless_desktop_enabled", False))
-        )
-        self._container_caching_enabled.setChecked(
-            bool(getattr(env, "container_caching_enabled", False))
-        )
-        self._use_cross_agents.setChecked(bool(getattr(env, "use_cross_agents", False)))
-        workspace_type = env.workspace_type or WORKSPACE_NONE
-        is_github_env = workspace_type == WORKSPACE_CLONED
-        is_local_env = workspace_type == WORKSPACE_MOUNTED
+            is_git_repo = False
+            if is_local_env:
+                is_git_repo = env.detect_git_if_mounted_folder()
 
-        # Check if mounted folder environment is a git repo
-        is_git_repo = False
-        if is_local_env:
-            is_git_repo = env.detect_git_if_mounted_folder()
+            context_available = is_github_env or (is_local_env and is_git_repo)
 
-        # Enable GitHub context for cloned repos or mounted folder git repos
-        context_available = is_github_env or (is_local_env and is_git_repo)
+            self._gh_context_enabled.setChecked(
+                bool(getattr(env, "gh_context_enabled", False))
+            )
+            self._gh_context_enabled.setEnabled(context_available)
+            self._gh_context_label.setVisible(context_available)
+            self._gh_context_row.setVisible(context_available)
 
-        self._gh_context_enabled.setChecked(
-            bool(getattr(env, "gh_context_enabled", False))
-        )
-        self._gh_context_enabled.setEnabled(context_available)
-        self._gh_context_label.setVisible(context_available)
-        self._gh_context_row.setVisible(context_available)
+            idx = self._workspace_type_combo.findData(workspace_type)
+            if idx >= 0:
+                self._workspace_type_combo.setCurrentIndex(idx)
+            self._workspace_target.setText(str(env.workspace_target or ""))
+            self._gh_use_host_cli.setChecked(
+                bool(getattr(env, "gh_use_host_cli", True))
+            )
+            self._sync_workspace_controls(env=env)
 
-        # Set workspace type dropdown
-        idx = self._workspace_type_combo.findData(workspace_type)
-        if idx >= 0:
-            self._workspace_type_combo.setCurrentIndex(idx)
-        self._workspace_target.setText(str(env.workspace_target or ""))
-        self._gh_use_host_cli.setChecked(bool(getattr(env, "gh_use_host_cli", True)))
-        self._sync_workspace_controls(env=env)
+            container_caching = bool(getattr(env, "container_caching_enabled", False))
 
-        # Load preflight scripts based on container caching state
-        container_caching = bool(getattr(env, "container_caching_enabled", False))
+            self._preflight_enabled.setChecked(bool(env.preflight_enabled))
+            self._preflight_script.setEnabled(bool(env.preflight_enabled))
+            self._preflight_script.setPlainText(env.preflight_script or "")
 
-        # Single-editor mode (caching OFF)
-        self._preflight_enabled.setChecked(bool(env.preflight_enabled))
-        self._preflight_script.setEnabled(bool(env.preflight_enabled))
-        self._preflight_script.setPlainText(env.preflight_script or "")
+            cached_script = str(getattr(env, "cached_preflight_script", "") or "")
+            has_cached = bool(cached_script.strip())
+            self._cached_preflight_enabled.setChecked(has_cached)
+            self._cached_preflight_script.setEnabled(has_cached)
+            self._cached_preflight_script.setPlainText(cached_script)
 
-        # Dual-editor mode (caching ON)
-        cached_script = str(getattr(env, "cached_preflight_script", "") or "")
-        has_cached = bool(cached_script.strip())
-        self._cached_preflight_enabled.setChecked(has_cached)
-        self._cached_preflight_script.setEnabled(has_cached)
-        self._cached_preflight_script.setPlainText(cached_script)
+            self._run_preflight_enabled.setChecked(bool(env.preflight_enabled))
+            self._run_preflight_script.setEnabled(bool(env.preflight_enabled))
+            self._run_preflight_script.setPlainText(env.preflight_script or "")
 
-        self._run_preflight_enabled.setChecked(bool(env.preflight_enabled))
-        self._run_preflight_script.setEnabled(bool(env.preflight_enabled))
-        self._run_preflight_script.setPlainText(env.preflight_script or "")
+            self._preflight_stack.setCurrentIndex(1 if container_caching else 0)
 
-        # Set layout state
-        self._preflight_stack.setCurrentIndex(1 if container_caching else 0)
+            env_lines = "\n".join(f"{k}={v}" for k, v in sorted(env.env_vars.items()))
+            self._env_vars.setPlainText(env_lines)
+            self._mounts.setPlainText("\n".join(env.extra_mounts))
+            self._ports_tab.set_ports(
+                getattr(env, "ports", []) or [],
+                bool(getattr(env, "ports_unlocked", False)),
+                bool(getattr(env, "ports_advanced_acknowledged", False)),
+            )
+            self._prompts_tab.set_prompts(
+                env.prompts or [], env.prompts_unlocked or False
+            )
 
-        env_lines = "\n".join(f"{k}={v}" for k, v in sorted(env.env_vars.items()))
-        self._env_vars.setPlainText(env_lines)
-        self._mounts.setPlainText("\n".join(env.extra_mounts))
-        self._ports_tab.set_ports(
-            getattr(env, "ports", []) or [],
-            bool(getattr(env, "ports_unlocked", False)),
-            bool(getattr(env, "ports_advanced_acknowledged", False)),
-        )
-        self._prompts_tab.set_prompts(env.prompts or [], env.prompts_unlocked or False)
-
-        # Load agent selection and cross-agent allowlist
-        use_cross_agents = bool(getattr(env, "use_cross_agents", False))
-        cross_agent_allowlist = list(getattr(env, "cross_agent_allowlist", []))
-        self._agents_tab.set_cross_agent_allowlist(cross_agent_allowlist)
-        self._agents_tab.set_agent_selection(env.agent_selection)
-        self._agents_tab.set_cross_agents_enabled(use_cross_agents)
+            use_cross_agents = bool(getattr(env, "use_cross_agents", False))
+            cross_agent_allowlist = list(getattr(env, "cross_agent_allowlist", []))
+            self._agents_tab.set_cross_agent_allowlist(cross_agent_allowlist)
+            self._agents_tab.set_agent_selection(env.agent_selection)
+            self._agents_tab.set_cross_agents_enabled(use_cross_agents)
+        finally:
+            self._suppress_autosave = False
 
     def _on_prompts_changed(self) -> None:
-        pass
+        self._queue_debounced_autosave()
 
     def _on_agents_changed(self) -> None:
-        pass
+        self._queue_debounced_autosave()
 
     def _on_ports_changed(self) -> None:
-        pass
+        self._queue_debounced_autosave()
 
     def _on_headless_desktop_toggled(self, state: int) -> None:
-        """Handle headless desktop checkbox state change.
-
-        When desktop is disabled, also disable and uncheck cache checkbox.
-        When desktop is enabled, enable cache checkbox (but leave unchecked by default).
-        """
         is_enabled = state == Qt.CheckState.Checked.value
         self._ports_tab.set_desktop_effective_enabled(self._effective_desktop_enabled())
         self._cache_desktop_build.setEnabled(is_enabled)
         if not is_enabled:
-            # Desktop disabled, also disable cache
             self._cache_desktop_build.setChecked(False)
 
     def _on_container_caching_toggled(self, state: int) -> None:
-        """Switch preflight tab layout based on container caching state."""
         is_enabled = state == Qt.CheckState.Checked.value
         self._preflight_stack.setCurrentIndex(1 if is_enabled else 0)
 
     def _on_use_cross_agents_toggled(self, state: int) -> None:
-        """Handle use cross agents checkbox state change."""
         is_enabled = state == Qt.CheckState.Checked.value
         self._agents_tab.set_cross_agents_enabled(is_enabled)
 
@@ -680,7 +399,6 @@ class EnvironmentsPage(QWidget, _EnvironmentsPageActionsMixin):
         old_env_id = self._current_env_id
         new_env_id = str(self._env_select.currentData() or "")
         if not self.try_autosave(preferred_env_id=new_env_id):
-            # Autosave failed, revert dropdown selection
             if old_env_id:
                 self._env_select.blockSignals(True)
                 try:
@@ -692,12 +410,3 @@ class EnvironmentsPage(QWidget, _EnvironmentsPageActionsMixin):
             return
         self._load_selected()
         self._apply_environment_tints()
-
-    def _pick_gh_management_folder(self) -> None:
-        path = QFileDialog.getExistingDirectory(
-            self,
-            "Select locked Workdir folder",
-            self._workspace_target.text() or os.getcwd(),
-        )
-        if path:
-            self._workspace_target.setText(path)

--- a/agents_runner/ui/pages/environments_form.py
+++ b/agents_runner/ui/pages/environments_form.py
@@ -1,0 +1,471 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QIntValidator
+from PySide6.QtWidgets import QCheckBox
+from PySide6.QtWidgets import QComboBox
+from PySide6.QtWidgets import QFileDialog
+from PySide6.QtWidgets import QGridLayout
+from PySide6.QtWidgets import QHBoxLayout
+from PySide6.QtWidgets import QLabel
+from PySide6.QtWidgets import QLineEdit
+from PySide6.QtWidgets import QPlainTextEdit
+from PySide6.QtWidgets import QPushButton
+from PySide6.QtWidgets import QSizePolicy
+from PySide6.QtWidgets import QSplitter
+from PySide6.QtWidgets import QStackedWidget
+from PySide6.QtWidgets import QToolButton
+from PySide6.QtWidgets import QVBoxLayout
+from PySide6.QtWidgets import QWidget
+
+from agents_runner.environments import ALLOWED_STAINS
+from agents_runner.environments import WORKSPACE_CLONED
+from agents_runner.environments import WORKSPACE_MOUNTED
+from agents_runner.environments import WORKSPACE_NONE
+from agents_runner.ui.constants import (
+    BUTTON_ROW_SPACING,
+    GRID_HORIZONTAL_SPACING,
+    GRID_VERTICAL_SPACING,
+    STANDARD_BUTTON_WIDTH,
+    TAB_CONTENT_SPACING,
+)
+from agents_runner.ui.pages.environments_agents import AgentsTabWidget
+from agents_runner.ui.pages.environments_ports import PortsTabWidget
+from agents_runner.ui.pages.environments_prompts import PromptsTabWidget
+from agents_runner.ui.widgets import GlassCard
+
+
+@dataclass(frozen=True)
+class _EnvironmentPaneSpec:
+    key: str
+    title: str
+    subtitle: str
+    section: str
+
+
+class _EnvironmentsFormMixin:
+    def _default_pane_specs(self) -> list[_EnvironmentPaneSpec]:
+        return [
+            _EnvironmentPaneSpec(
+                key="general",
+                title="General",
+                subtitle="Core environment identity, limits, and runtime toggles.",
+                section="General",
+            ),
+            _EnvironmentPaneSpec(
+                key="agents",
+                title="Agents",
+                subtitle="Agent selection, chain behavior, and cross-agent controls.",
+                section="Collaboration",
+            ),
+            _EnvironmentPaneSpec(
+                key="prompts",
+                title="Prompts",
+                subtitle="Prompt snippets and unlock behavior for this environment.",
+                section="Collaboration",
+            ),
+            _EnvironmentPaneSpec(
+                key="env_vars",
+                title="Environment Variables",
+                subtitle="Container environment variables injected at runtime.",
+                section="Container",
+            ),
+            _EnvironmentPaneSpec(
+                key="mounts",
+                title="Mounts",
+                subtitle="Additional bind mounts exposed to task containers.",
+                section="Container",
+            ),
+            _EnvironmentPaneSpec(
+                key="ports",
+                title="Ports",
+                subtitle="Port mapping policy for task containers.",
+                section="Container",
+            ),
+            _EnvironmentPaneSpec(
+                key="preflight",
+                title="Preflight",
+                subtitle="Container setup scripts for cached and runtime execution.",
+                section="Automation",
+            ),
+        ]
+
+    def _build_controls(self) -> None:
+        self._name = QLineEdit()
+        self._color = QComboBox()
+        for stain in ALLOWED_STAINS:
+            self._color.addItem(stain.title(), stain)
+        self._color.currentIndexChanged.connect(self._apply_environment_tints)
+
+        self._max_agents_running = QLineEdit()
+        self._max_agents_running.setPlaceholderText("-1")
+        self._max_agents_running.setToolTip(
+            "Maximum agents running at the same time for this environment. Set to -1 for no limit.\n"
+            "Tip: For local-folder workspaces, set this to 1 to avoid agents fighting over setup/files."
+        )
+        self._max_agents_running.setValidator(QIntValidator(-1, 10_000_000, self))
+        self._max_agents_running.setMaximumWidth(150)
+
+        self._headless_desktop_enabled = QCheckBox("Enable headless desktop")
+        self._headless_desktop_enabled.setToolTip(
+            "When enabled, agent runs for this environment will start a noVNC desktop.\n"
+            "Settings → Force headless desktop overrides this setting."
+        )
+        self._headless_desktop_enabled.stateChanged.connect(
+            self._on_headless_desktop_toggled
+        )
+
+        self._cache_desktop_build = QCheckBox("Cache desktop build")
+        self._cache_desktop_build.setToolTip(
+            "When enabled, desktop components are pre-installed in a cached Docker image.\n"
+            "This reduces task startup time from 45-90s to 2-5s.\n"
+            "Requires 'Enable headless desktop' to be enabled.\n\n"
+            "Image is automatically rebuilt when scripts change."
+        )
+        self._cache_desktop_build.setEnabled(False)
+
+        self._container_caching_enabled = QCheckBox("Enable container caching")
+        self._container_caching_enabled.setToolTip(
+            "When enabled, environment preflight scripts are executed at Docker build time.\n"
+            "This creates a cached image with pre-installed dependencies, speeding up task startup.\n\n"
+            "The cached preflight script is configured in the Preflight pane.\n"
+            "Image is automatically rebuilt when the cached preflight script changes."
+        )
+        self._container_caching_enabled.stateChanged.connect(
+            self._on_container_caching_toggled
+        )
+
+        self._use_cross_agents = QCheckBox("Use cross agents")
+        self._use_cross_agents.setToolTip(
+            "When enabled, allows agent instances from the Agents pane to be mounted\n"
+            "as cross-agents in task containers. Configure the allowlist in the Agents pane."
+        )
+        self._use_cross_agents.stateChanged.connect(self._on_use_cross_agents_toggled)
+
+        self._gh_context_enabled = QCheckBox("Provide GitHub context to agent")
+        self._gh_context_enabled.setToolTip(
+            "When enabled, repository context (URL, branch, commit) is provided to the agent.\n"
+            "For GitHub-managed environments: Always available.\n"
+            "For folder-managed environments: Only if folder is a git repository.\n\n"
+            "Note: This does NOT provide GitHub authentication - that is separate."
+        )
+        self._gh_context_enabled.setEnabled(False)
+        self._gh_context_enabled.setVisible(True)
+
+        # Workspace controls are retained for compatibility with existing logic but remain hidden.
+        self._workspace_type_combo = QComboBox()
+        self._workspace_type_combo.addItem("Use Settings workdir", WORKSPACE_NONE)
+        self._workspace_type_combo.addItem("Mount local folder", WORKSPACE_MOUNTED)
+        self._workspace_type_combo.addItem("Clone GitHub repo", WORKSPACE_CLONED)
+        self._workspace_type_combo.currentIndexChanged.connect(
+            self._sync_workspace_controls
+        )
+
+        self._workspace_target = QLineEdit()
+        self._workspace_target.setPlaceholderText(
+            "owner/repo, https://github.com/owner/repo, or /path/to/folder"
+        )
+        self._workspace_target.textChanged.connect(self._sync_workspace_controls)
+
+        self._gh_management_browse = QPushButton("Browse…")
+        self._gh_management_browse.setFixedWidth(STANDARD_BUTTON_WIDTH)
+        self._gh_management_browse.clicked.connect(self._pick_gh_management_folder)
+
+        self._gh_use_host_cli = QCheckBox("Use host `gh` CLI")
+        self._gh_use_host_cli.setToolTip(
+            "Use the host system's `gh` CLI for cloning and PR creation (if installed).\n"
+            "When disabled or unavailable, cloning uses `git` and PR creation is skipped."
+        )
+
+        self._workspace_type_combo.setVisible(False)
+        self._workspace_target.setVisible(False)
+        self._gh_management_browse.setVisible(False)
+
+        self._preflight_enabled = QCheckBox("Enable environment preflight")
+        self._preflight_enabled.setToolTip(
+            "Runs after Settings preflight script.\n"
+            "Use for environment-specific setup tasks."
+        )
+
+        self._preflight_script = QPlainTextEdit()
+        self._preflight_script.setPlaceholderText(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "\n"
+            "# Runs inside the container before the agent command.\n"
+            "# Runs after Settings preflight (if enabled).\n"
+        )
+        self._preflight_script.setTabChangesFocus(True)
+        self._preflight_enabled.toggled.connect(self._preflight_script.setEnabled)
+        self._preflight_script.setEnabled(False)
+
+        self._cached_preflight_enabled = QCheckBox("Enable cached preflight")
+        self._cached_preflight_enabled.setToolTip(
+            "Runs at Docker build time to pre-install dependencies.\n"
+            "Creates a cached image for faster task startup."
+        )
+
+        self._cached_preflight_script = QPlainTextEdit()
+        self._cached_preflight_script.setPlaceholderText(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "\n"
+            "# Runs at Docker build time.\n"
+            "# Use for installing packages and dependencies.\n"
+        )
+        self._cached_preflight_script.setTabChangesFocus(True)
+        self._cached_preflight_enabled.toggled.connect(
+            self._cached_preflight_script.setEnabled
+        )
+        self._cached_preflight_script.setEnabled(False)
+
+        self._run_preflight_enabled = QCheckBox("Enable run preflight")
+        self._run_preflight_enabled.setToolTip(
+            "Runs at task startup after cached preflight.\n"
+            "Use for runtime setup and validation."
+        )
+
+        self._run_preflight_script = QPlainTextEdit()
+        self._run_preflight_script.setPlaceholderText(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "\n"
+            "# Runs at task startup (after cached layer).\n"
+            "# Use for runtime-specific setup.\n"
+        )
+        self._run_preflight_script.setTabChangesFocus(True)
+        self._run_preflight_enabled.toggled.connect(
+            self._run_preflight_script.setEnabled
+        )
+        self._run_preflight_script.setEnabled(False)
+
+        self._preflight_single_container = QWidget()
+        single_layout = QVBoxLayout(self._preflight_single_container)
+        single_layout.setSpacing(TAB_CONTENT_SPACING)
+        single_layout.setContentsMargins(0, 0, 0, 0)
+        single_layout.addWidget(self._preflight_enabled)
+        single_layout.addWidget(QLabel("Preflight script"))
+        single_layout.addWidget(self._preflight_script, 1)
+
+        self._preflight_dual_container = QWidget()
+        dual_layout = QVBoxLayout(self._preflight_dual_container)
+        dual_layout.setSpacing(TAB_CONTENT_SPACING)
+        dual_layout.setContentsMargins(0, 0, 0, 0)
+
+        splitter = QSplitter(Qt.Horizontal)
+        splitter.setChildrenCollapsible(False)
+
+        left_panel = GlassCard()
+        left_layout = QVBoxLayout(left_panel)
+        left_layout.setContentsMargins(18, 16, 18, 16)
+        left_layout.setSpacing(10)
+        left_layout.addWidget(self._cached_preflight_enabled)
+        left_layout.addWidget(QLabel("Cached preflight"))
+        left_layout.addWidget(self._cached_preflight_script, 1)
+
+        right_panel = GlassCard()
+        right_layout = QVBoxLayout(right_panel)
+        right_layout.setContentsMargins(18, 16, 18, 16)
+        right_layout.setSpacing(10)
+        right_layout.addWidget(self._run_preflight_enabled)
+        right_layout.addWidget(QLabel("Run preflight"))
+        right_layout.addWidget(self._run_preflight_script, 1)
+
+        splitter.addWidget(left_panel)
+        splitter.addWidget(right_panel)
+        splitter.setStretchFactor(0, 1)
+        splitter.setStretchFactor(1, 1)
+
+        dual_layout.addWidget(splitter, 1)
+
+        self._preflight_stack = QStackedWidget()
+        self._preflight_stack.addWidget(self._preflight_single_container)
+        self._preflight_stack.addWidget(self._preflight_dual_container)
+
+        self._env_vars = QPlainTextEdit()
+        self._env_vars.setPlaceholderText("# KEY=VALUE (one per line)\n")
+        self._env_vars.setTabChangesFocus(True)
+
+        self._mounts = QPlainTextEdit()
+        self._mounts.setPlaceholderText("# host_path:container_path[:ro]\n")
+        self._mounts.setTabChangesFocus(True)
+
+        self._ports_tab = PortsTabWidget()
+        self._ports_tab.ports_changed.connect(self._on_ports_changed)
+
+        self._prompts_tab = PromptsTabWidget()
+        self._prompts_tab.prompts_changed.connect(self._on_prompts_changed)
+
+        self._agents_tab = AgentsTabWidget()
+        self._agents_tab.agents_changed.connect(self._on_agents_changed)
+
+    def _build_pages(self) -> None:
+        specs_by_key = {spec.key: spec for spec in self._pane_specs}
+
+        general_page, general_body = self._create_page(specs_by_key["general"])
+        grid = QGridLayout()
+        grid.setHorizontalSpacing(GRID_HORIZONTAL_SPACING)
+        grid.setVerticalSpacing(GRID_VERTICAL_SPACING)
+        grid.setContentsMargins(0, 0, 0, 0)
+
+        max_agents_row = QWidget(general_page)
+        max_agents_row_layout = QHBoxLayout(max_agents_row)
+        max_agents_row_layout.setContentsMargins(0, 0, 0, 0)
+        max_agents_row_layout.setSpacing(BUTTON_ROW_SPACING)
+        max_agents_row_layout.addWidget(self._max_agents_running)
+        max_agents_row_layout.addStretch(1)
+
+        headless_desktop_row = QWidget(general_page)
+        headless_desktop_layout = QHBoxLayout(headless_desktop_row)
+        headless_desktop_layout.setContentsMargins(0, 0, 0, 0)
+        headless_desktop_layout.setSpacing(BUTTON_ROW_SPACING)
+        headless_desktop_layout.addWidget(self._headless_desktop_enabled)
+        headless_desktop_layout.addWidget(self._cache_desktop_build)
+        headless_desktop_layout.addStretch(1)
+
+        container_caching_row = QWidget(general_page)
+        container_caching_layout = QHBoxLayout(container_caching_row)
+        container_caching_layout.setContentsMargins(0, 0, 0, 0)
+        container_caching_layout.setSpacing(BUTTON_ROW_SPACING)
+        container_caching_layout.addWidget(self._container_caching_enabled)
+        container_caching_layout.addStretch(1)
+
+        cross_agents_row = QWidget(general_page)
+        cross_agents_layout = QHBoxLayout(cross_agents_row)
+        cross_agents_layout.setContentsMargins(0, 0, 0, 0)
+        cross_agents_layout.setSpacing(BUTTON_ROW_SPACING)
+        cross_agents_layout.addWidget(self._use_cross_agents)
+        cross_agents_layout.addStretch(1)
+
+        self._gh_context_label = QLabel("GitHub context")
+        self._gh_context_row = QWidget(general_page)
+        gh_context_layout = QHBoxLayout(self._gh_context_row)
+        gh_context_layout.setContentsMargins(0, 0, 0, 0)
+        gh_context_layout.setSpacing(BUTTON_ROW_SPACING)
+        gh_context_layout.addWidget(self._gh_context_enabled)
+        gh_context_layout.addStretch(1)
+
+        self._gh_context_label.setVisible(False)
+        self._gh_context_row.setVisible(False)
+
+        grid.addWidget(QLabel("Name"), 0, 0)
+        grid.addWidget(self._name, 0, 1, 1, 2)
+        grid.addWidget(QLabel("Color"), 1, 0)
+        grid.addWidget(self._color, 1, 1, 1, 2)
+        grid.addWidget(QLabel("Max agents running"), 3, 0)
+        grid.addWidget(max_agents_row, 3, 1, 1, 2)
+        grid.addWidget(self._gh_context_label, 4, 0)
+        grid.addWidget(self._gh_context_row, 4, 1, 1, 2)
+        grid.addWidget(QLabel("Headless desktop"), 5, 0)
+        grid.addWidget(headless_desktop_row, 5, 1, 1, 2)
+        grid.addWidget(QLabel("Container caching"), 6, 0)
+        grid.addWidget(container_caching_row, 6, 1, 1, 2)
+        grid.addWidget(QLabel("Cross agents"), 7, 0)
+        grid.addWidget(cross_agents_row, 7, 1, 1, 2)
+
+        general_body.addLayout(grid)
+        general_body.addStretch(1)
+        self._register_page("general", general_page)
+
+        agents_page, agents_body = self._create_page(specs_by_key["agents"])
+        agents_body.addWidget(self._agents_tab, 1)
+        self._register_page("agents", agents_page)
+
+        prompts_page, prompts_body = self._create_page(specs_by_key["prompts"])
+        prompts_body.addWidget(self._prompts_tab, 1)
+        self._register_page("prompts", prompts_page)
+
+        env_vars_page, env_vars_body = self._create_page(specs_by_key["env_vars"])
+        env_vars_body.addWidget(QLabel("Container env vars"))
+        env_vars_body.addWidget(self._env_vars, 1)
+        self._register_page("env_vars", env_vars_page)
+
+        mounts_page, mounts_body = self._create_page(specs_by_key["mounts"])
+        mounts_body.addWidget(QLabel("Extra bind mounts"))
+        mounts_body.addWidget(self._mounts, 1)
+        self._register_page("mounts", mounts_page)
+
+        ports_page, ports_body = self._create_page(specs_by_key["ports"])
+        ports_body.addWidget(self._ports_tab, 1)
+        self._register_page("ports", ports_page)
+
+        preflight_page, preflight_body = self._create_page(specs_by_key["preflight"])
+        preflight_body.addWidget(self._preflight_stack, 1)
+        self._register_page("preflight", preflight_page)
+
+    def _build_navigation(self, nav_layout: QVBoxLayout) -> None:
+        sections: dict[str, list[_EnvironmentPaneSpec]] = {}
+        for spec in self._pane_specs:
+            sections.setdefault(spec.section, []).append(spec)
+
+        for section_title, specs in sections.items():
+            section_label = QLabel(section_title)
+            section_label.setObjectName("SettingsNavSection")
+            nav_layout.addWidget(section_label)
+
+            for spec in specs:
+                button = QToolButton()
+                button.setObjectName("SettingsNavButton")
+                button.setText(self._pane_button_label(spec.key, spec.title))
+                button.setToolTip(spec.subtitle)
+                button.setCheckable(True)
+                button.setAutoExclusive(True)
+                button.setToolButtonStyle(Qt.ToolButtonTextOnly)
+                button.setFixedHeight(40)
+                button.setSizePolicy(
+                    QSizePolicy.Policy.Fixed,
+                    QSizePolicy.Policy.Fixed,
+                )
+                button.clicked.connect(
+                    lambda checked=False, key=spec.key: self._on_nav_button_clicked(key)
+                )
+                nav_layout.addWidget(button)
+                self._nav_buttons[spec.key] = button
+                self._compact_nav.addItem(spec.title, spec.key)
+
+        nav_layout.addStretch(1)
+
+    def _create_page(self, spec: _EnvironmentPaneSpec) -> tuple[QWidget, QVBoxLayout]:
+        page = QWidget()
+        page_layout = QVBoxLayout(page)
+        page_layout.setContentsMargins(0, 0, 0, 0)
+        page_layout.setSpacing(10)
+
+        title = QLabel(spec.title)
+        title.setObjectName("SettingsPaneTitle")
+
+        subtitle = QLabel(spec.subtitle)
+        subtitle.setObjectName("SettingsPaneSubtitle")
+        subtitle.setWordWrap(True)
+
+        body = QWidget(page)
+        body_layout = QVBoxLayout(body)
+        body_layout.setContentsMargins(0, 0, 0, 0)
+        body_layout.setSpacing(GRID_VERTICAL_SPACING)
+
+        page_layout.addWidget(title)
+        page_layout.addWidget(subtitle)
+        page_layout.addWidget(body, 1)
+        return page, body_layout
+
+    def _register_page(self, key: str, widget: QWidget) -> None:
+        index = self._page_stack.addWidget(widget)
+        self._pane_index_by_key[key] = index
+
+    @staticmethod
+    def _pane_button_label(key: str, title: str) -> str:
+        if key == "env_vars":
+            return "Env Vars"
+        return title
+
+    def _pick_gh_management_folder(self) -> None:
+        path = QFileDialog.getExistingDirectory(
+            self,
+            "Select locked Workdir folder",
+            self._workspace_target.text() or os.getcwd(),
+        )
+        if path:
+            self._workspace_target.setText(path)

--- a/agents_runner/ui/pages/environments_navigation.py
+++ b/agents_runner/ui/pages/environments_navigation.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from PySide6.QtCore import (
+    QEasingCurve,
+    QParallelAnimationGroup,
+    QPoint,
+    QPropertyAnimation,
+    QSignalBlocker,
+    QTimer,
+)
+from PySide6.QtWidgets import QGraphicsOpacityEffect
+
+
+class _EnvironmentsNavigationMixin:
+    def _on_back(self) -> None:
+        if not self.try_autosave():
+            return
+        self.back_requested.emit()
+
+    def _connect_autosave_signals(self) -> None:
+        for combo in (
+            self._color,
+            self._workspace_type_combo,
+        ):
+            combo.currentIndexChanged.connect(self._trigger_immediate_autosave)
+
+        for checkbox in (
+            self._headless_desktop_enabled,
+            self._cache_desktop_build,
+            self._container_caching_enabled,
+            self._use_cross_agents,
+            self._gh_context_enabled,
+            self._gh_use_host_cli,
+            self._preflight_enabled,
+            self._cached_preflight_enabled,
+            self._run_preflight_enabled,
+        ):
+            checkbox.toggled.connect(self._trigger_immediate_autosave)
+
+        for line_edit in (
+            self._name,
+            self._max_agents_running,
+            self._workspace_target,
+        ):
+            line_edit.textChanged.connect(self._queue_debounced_autosave)
+
+        for editor in (
+            self._preflight_script,
+            self._cached_preflight_script,
+            self._run_preflight_script,
+            self._env_vars,
+            self._mounts,
+        ):
+            editor.textChanged.connect(self._queue_debounced_autosave)
+
+    def _on_nav_button_clicked(self, key: str) -> None:
+        self._navigate_to_pane(key, user_initiated=True)
+
+    def _on_compact_nav_changed(self, _index: int) -> None:
+        key = str(self._compact_nav.currentData() or "").strip()
+        if not key:
+            return
+        self._navigate_to_pane(key, user_initiated=True)
+
+    def _navigate_to_pane(self, key: str, *, user_initiated: bool) -> None:
+        key = str(key or "").strip()
+        if not key or key not in self._pane_index_by_key:
+            return
+        if key == self._active_pane_key:
+            self._set_active_navigation(key)
+            return
+
+        if user_initiated and not self.try_autosave():
+            self._set_active_navigation(self._active_pane_key)
+            return
+
+        self._set_current_pane(key, animate=True)
+        self._set_active_navigation(key)
+
+    def _set_active_navigation(self, key: str) -> None:
+        self._active_pane_key = key
+        for pane_key, button in self._nav_buttons.items():
+            button.setChecked(pane_key == key)
+
+        idx = self._compact_nav.findData(key)
+        if idx >= 0:
+            with QSignalBlocker(self._compact_nav):
+                self._compact_nav.setCurrentIndex(idx)
+
+    def _set_current_pane(self, key: str, *, animate: bool) -> None:
+        target_index = self._pane_index_by_key.get(key)
+        if target_index is None:
+            return
+
+        current_index = self._page_stack.currentIndex()
+        if current_index == target_index:
+            self._active_pane_key = key
+            return
+
+        if current_index < 0 or not animate:
+            self._page_stack.setCurrentIndex(target_index)
+            self._active_pane_key = key
+            return
+
+        forward = target_index > current_index
+        self._page_stack.setCurrentIndex(target_index)
+        self._animate_stack(forward=forward)
+        self._active_pane_key = key
+
+    def _animate_stack(self, *, forward: bool) -> None:
+        if self._pane_animation is not None:
+            self._pane_animation.stop()
+            self._pane_animation = None
+
+        if self._pane_rest_pos is not None:
+            self._page_stack.move(self._pane_rest_pos)
+        self._page_stack.setGraphicsEffect(None)
+
+        base_pos = self._page_stack.pos()
+        self._pane_rest_pos = QPoint(base_pos)
+
+        offset = 16 if forward else -16
+        start_pos = QPoint(base_pos.x() + offset, base_pos.y())
+
+        effect = QGraphicsOpacityEffect(self._page_stack)
+        effect.setOpacity(0.0)
+        self._page_stack.setGraphicsEffect(effect)
+        self._page_stack.move(start_pos)
+
+        pos_anim = QPropertyAnimation(self._page_stack, b"pos", self)
+        pos_anim.setDuration(210)
+        pos_anim.setStartValue(start_pos)
+        pos_anim.setEndValue(base_pos)
+        pos_anim.setEasingCurve(QEasingCurve.Type.OutCubic)
+
+        opacity_anim = QPropertyAnimation(effect, b"opacity", self)
+        opacity_anim.setDuration(210)
+        opacity_anim.setStartValue(0.0)
+        opacity_anim.setEndValue(1.0)
+        opacity_anim.setEasingCurve(QEasingCurve.Type.OutCubic)
+
+        group = QParallelAnimationGroup(self)
+        group.addAnimation(pos_anim)
+        group.addAnimation(opacity_anim)
+
+        def _cleanup() -> None:
+            if self._pane_rest_pos is not None:
+                self._page_stack.move(self._pane_rest_pos)
+            self._page_stack.setGraphicsEffect(None)
+            self._pane_animation = None
+
+        group.finished.connect(_cleanup)
+        group.start()
+        self._pane_animation = group
+
+    def _queue_debounced_autosave(self, *_args: object) -> None:
+        if self._suppress_autosave:
+            return
+        self._autosave_timer.start()
+
+    def _trigger_immediate_autosave(self, *_args: object) -> None:
+        if self._suppress_autosave:
+            return
+        if self._autosave_timer.isActive():
+            self._autosave_timer.stop()
+        self._emit_autosave()
+
+    def _emit_autosave(self) -> None:
+        if self._suppress_autosave:
+            return
+        self.try_autosave(show_validation_errors=False)
+
+    def _update_navigation_mode(self) -> None:
+        compact = self.width() < 1080
+        if compact == self._compact_mode:
+            return
+        self._compact_mode = compact
+        self._compact_nav.setVisible(compact)
+        self._nav_panel.setVisible(not compact)
+        if not compact:
+            QTimer.singleShot(0, self._sync_nav_button_sizes)
+
+    def _sync_nav_button_sizes(self) -> None:
+        if self._compact_mode or not self._nav_buttons:
+            return
+
+        panel_width = self._nav_panel.width()
+        if panel_width <= 0:
+            return
+
+        inner_width = panel_width
+        nav_layout = self._nav_panel.layout()
+        if nav_layout is not None:
+            margins = nav_layout.contentsMargins()
+            inner_width -= margins.left() + margins.right()
+
+        target_width = max(1, inner_width - 2)
+        for button in self._nav_buttons.values():
+            button.setFixedWidth(target_width)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "midori-ai-agents-runner"
-version = "0.1.0.49"
+version = "0.1.0.50"
 description = "A GUI for running AI agents in Docker containers with workspace and GitHub management."
 readme = "README.md"
 requires-python = "==3.13.11"


### PR DESCRIPTION
## Summary
- refactor Environments to use a settings-style pane navigation layout with sectioned left nav and compact dropdown mode
- remove manual Save button and switch to autosave behavior (immediate + debounced) similar to Settings
- keep strict validation on navigation/switch/back while making timer-based autosave silent when fields are temporarily invalid
- preserve existing environment data model/persistence semantics and test preflight workflow
- bump project version from `0.1.0.49` to `0.1.0.50`

## Commits
- `1174fe9` `[UI] Align environments menu with settings-style panes`
- `6272ad1` `[CHORE] Bump project version to 0.1.0.50`

## Verification
- `uvx ruff format .`
- `uvx ruff check .`
- `uv run python -m compileall agents_runner/ui/pages/environments.py agents_runner/ui/pages/environments_form.py agents_runner/ui/pages/environments_navigation.py agents_runner/ui/pages/environments_actions.py`

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
