### PR TITLE
[FEAT] Add channel-aware Midori radio settings and playback

### DIFF
--- a/agents_runner/ui/main_window_navigation.py
+++ b/agents_runner/ui/main_window_navigation.py
@@ -120,6 +120,8 @@ class _MainWindowNavigationMixin:
         if not self._try_autosave_before_navigation():
             return
         self._settings.set_settings(self._settings_data)
+        if hasattr(self, "_refresh_radio_channel_options"):
+            self._refresh_radio_channel_options(disable_on_failure=True)
         self._transition_to_page(self._settings)
 
     def _try_autosave_before_navigation(self) -> bool:

--- a/agents_runner/ui/main_window_persistence.py
+++ b/agents_runner/ui/main_window_persistence.py
@@ -178,6 +178,7 @@ class _MainWindowPersistenceMixin:
         self._settings_data.setdefault("spellcheck_enabled", True)
         self._settings_data.setdefault("ui_theme", "auto")
         self._settings_data.setdefault("radio_enabled", False)
+        self._settings_data.setdefault("radio_channel", "")
         self._settings_data.setdefault("radio_quality", "medium")
         self._settings_data.setdefault("radio_volume", 70)
         self._settings_data.setdefault("radio_autostart", False)
@@ -226,6 +227,9 @@ class _MainWindowPersistenceMixin:
         )
         self._settings_data["radio_autostart"] = bool(
             self._settings_data.get("radio_autostart") or False
+        )
+        self._settings_data["radio_channel"] = RadioController.normalize_channel(
+            self._settings_data.get("radio_channel")
         )
         self._settings_data["radio_quality"] = RadioController.normalize_quality(
             self._settings_data.get("radio_quality")

--- a/agents_runner/ui/main_window_settings.py
+++ b/agents_runner/ui/main_window_settings.py
@@ -99,6 +99,9 @@ class _MainWindowSettingsMixin:
         )
         merged["radio_enabled"] = bool(merged.get("radio_enabled") or False)
         merged["radio_autostart"] = bool(merged.get("radio_autostart") or False)
+        merged["radio_channel"] = RadioController.normalize_channel(
+            merged.get("radio_channel")
+        )
         merged["radio_quality"] = RadioController.normalize_quality(
             merged.get("radio_quality")
         )

--- a/agents_runner/ui/pages/settings.py
+++ b/agents_runner/ui/pages/settings.py
@@ -140,7 +140,13 @@ class SettingsPage(QWidget, _SettingsFormMixin):
         QTimer.singleShot(0, self._sync_nav_button_sizes)
 
     def _connect_autosave_signals(self) -> None:
-        for combo in (self._use, self._shell, self._ui_theme, self._radio_quality):
+        for combo in (
+            self._use,
+            self._shell,
+            self._ui_theme,
+            self._radio_channel,
+            self._radio_quality,
+        ):
             combo.currentIndexChanged.connect(self._trigger_immediate_autosave)
 
         for checkbox in (


### PR DESCRIPTION
## Summary
- add persisted `radio_channel` settings support across load/apply/save flows
- add a Radio settings channel dropdown with `All channels`, dynamic `/radio/v1/channels` options, and custom-value retention when missing from the fetched list
- apply selected channel to radio API usage (`/radio/v1/current` polling and `/radio/v1/stream` playback URLs)
- add immediate channel switching while playing with best-effort long fade-out/fade-in and reconnect fallback
- include channel label in radio state text and window-title rendering

## Validation
- `uvx ruff format agents_runner/ui/radio/controller.py agents_runner/ui/main_window.py agents_runner/ui/main_window_navigation.py agents_runner/ui/main_window_settings.py agents_runner/ui/main_window_persistence.py agents_runner/ui/pages/settings.py agents_runner/ui/pages/settings_form.py`
- `uvx ruff check agents_runner/ui/radio/controller.py agents_runner/ui/main_window.py agents_runner/ui/main_window_navigation.py agents_runner/ui/main_window_settings.py agents_runner/ui/main_window_persistence.py agents_runner/ui/pages/settings.py agents_runner/ui/pages/settings_form.py`
- `python -m py_compile agents_runner/ui/radio/controller.py agents_runner/ui/main_window.py agents_runner/ui/main_window_navigation.py agents_runner/ui/main_window_settings.py agents_runner/ui/main_window_persistence.py agents_runner/ui/pages/settings.py agents_runner/ui/pages/settings_form.py`

## Notes
- scope intentionally limited to Agents Runner (no Website-Blog changes)
- no push performed

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
