### PR TITLE
Add Tasks hub with conditional GitHub PR/Issue workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
       - name: Pull PixelArch Container
         run: docker pull lunamidori5/pixelarch:emerald
 
+      - name: Install Qt runtime dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libegl1
+
       - name: Sync
         run: uv sync --group lint --group test
 

--- a/agents_runner/environments/__init__.py
+++ b/agents_runner/environments/__init__.py
@@ -7,6 +7,8 @@ from agents_runner.environments.model import WORKSPACE_CLONED
 from agents_runner.environments.model import WORKSPACE_MOUNTED
 from agents_runner.environments.model import WORKSPACE_NONE
 from agents_runner.environments.model import Environment
+from agents_runner.environments.github_repo import GitHubRepoContext
+from agents_runner.environments.github_repo import resolve_environment_github_repo
 from agents_runner.environments.model import PromptConfig
 from agents_runner.environments.model import normalize_workspace_type
 from agents_runner.environments.parse import parse_env_vars_text
@@ -29,6 +31,7 @@ __all__ = [
     "WORKSPACE_MOUNTED",
     "WORKSPACE_NONE",
     "Environment",
+    "GitHubRepoContext",
     "PromptConfig",
     "default_data_dir",
     "delete_environment",
@@ -42,6 +45,7 @@ __all__ = [
     "parse_ports_text",
     "save_environment",
     "serialize_environment",
+    "resolve_environment_github_repo",
     "SYSTEM_ENV_ID",
     "SYSTEM_ENV_NAME",
 ]

--- a/agents_runner/environments/github_repo.py
+++ b/agents_runner/environments/github_repo.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from agents_runner.environments.git_operations import get_git_info
+from agents_runner.gh.git_ops import parse_github_url
+
+from .model import Environment
+from .model import WORKSPACE_CLONED
+from .model import WORKSPACE_MOUNTED
+
+
+@dataclass(frozen=True)
+class GitHubRepoContext:
+    repo_owner: str
+    repo_name: str
+    repo_url: str
+    source: str
+
+    @property
+    def repo_full_name(self) -> str:
+        return f"{self.repo_owner}/{self.repo_name}"
+
+
+def _parse_cloned_target(target: str) -> tuple[str | None, str | None]:
+    value = str(target or "").strip()
+    if not value:
+        return (None, None)
+
+    shorthand = re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", value)
+    if shorthand:
+        owner, repo = value.split("/", 1)
+        return (owner.strip(), repo.strip())
+
+    return parse_github_url(value)
+
+
+def resolve_environment_github_repo(
+    env: Environment | None,
+) -> GitHubRepoContext | None:
+    if env is None:
+        return None
+
+    workspace_type = str(getattr(env, "workspace_type", "") or "").strip().lower()
+
+    if workspace_type == WORKSPACE_CLONED:
+        owner, repo = _parse_cloned_target(str(getattr(env, "workspace_target", "")))
+        if not owner or not repo:
+            return None
+        return GitHubRepoContext(
+            repo_owner=owner,
+            repo_name=repo,
+            repo_url=f"https://github.com/{owner}/{repo}",
+            source="cloned",
+        )
+
+    if workspace_type == WORKSPACE_MOUNTED:
+        folder = str(getattr(env, "workspace_target", "") or "").strip()
+        if not folder:
+            return None
+        git_info = get_git_info(folder)
+        if git_info is None:
+            return None
+        owner = str(git_info.repo_owner or "").strip()
+        repo = str(git_info.repo_name or "").strip()
+        if not owner or not repo:
+            return None
+        repo_url = str(git_info.repo_url or "").strip() or (
+            f"https://github.com/{owner}/{repo}"
+        )
+        return GitHubRepoContext(
+            repo_owner=owner,
+            repo_name=repo,
+            repo_url=repo_url,
+            source="mounted",
+        )
+
+    return None

--- a/agents_runner/gh/work_items.py
+++ b/agents_runner/gh/work_items.py
@@ -1,0 +1,498 @@
+from __future__ import annotations
+
+import json
+
+from dataclasses import dataclass
+
+from .errors import GhManagementError
+from .process import _run
+
+
+@dataclass(frozen=True)
+class GitHubReactionSummary:
+    thumbs_up: int = 0
+    thumbs_down: int = 0
+    eyes: int = 0
+
+
+@dataclass(frozen=True)
+class GitHubComment:
+    comment_id: int
+    node_id: str
+    body: str
+    author: str
+    created_at: str
+    updated_at: str
+    url: str
+    reactions: GitHubReactionSummary
+
+
+@dataclass(frozen=True)
+class GitHubWorkItem:
+    item_type: str
+    number: int
+    title: str
+    state: str
+    url: str
+    author: str
+    created_at: str
+    updated_at: str
+    is_draft: bool = False
+
+
+@dataclass(frozen=True)
+class GitHubWorkroom:
+    item_type: str
+    repo_owner: str
+    repo_name: str
+    number: int
+    title: str
+    body: str
+    state: str
+    url: str
+    author: str
+    created_at: str
+    updated_at: str
+    is_draft: bool
+    comments: list[GitHubComment]
+
+
+def _safe_int(value: object, default: int = 0) -> int:
+    try:
+        return int(value)
+    except Exception:
+        return int(default)
+
+
+def _safe_text(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _run_gh_json(args: list[str], *, timeout_s: float = 45.0) -> object:
+    proc = _run(["gh", *args], timeout_s=timeout_s)
+    if proc.returncode != 0:
+        stderr = _safe_text(proc.stderr)
+        stdout = _safe_text(proc.stdout)
+        extra = stderr or stdout
+        if extra:
+            raise GhManagementError(f"gh command failed: {' '.join(args)}\n{extra}")
+        raise GhManagementError(f"gh command failed: {' '.join(args)}")
+
+    payload = _safe_text(proc.stdout)
+    if not payload:
+        return {}
+
+    try:
+        return json.loads(payload)
+    except Exception as exc:
+        raise GhManagementError(
+            f"failed to parse gh json output for: {' '.join(args)}"
+        ) from exc
+
+
+def _run_gh(args: list[str], *, timeout_s: float = 45.0) -> None:
+    proc = _run(["gh", *args], timeout_s=timeout_s)
+    if proc.returncode == 0:
+        return
+    stderr = _safe_text(proc.stderr)
+    stdout = _safe_text(proc.stdout)
+    extra = stderr or stdout
+    if extra:
+        raise GhManagementError(f"gh command failed: {' '.join(args)}\n{extra}")
+    raise GhManagementError(f"gh command failed: {' '.join(args)}")
+
+
+def _parse_reaction_summary(raw: object) -> GitHubReactionSummary:
+    if isinstance(raw, dict):
+        return GitHubReactionSummary(
+            thumbs_up=max(0, _safe_int(raw.get("+1"))),
+            thumbs_down=max(0, _safe_int(raw.get("-1"))),
+            eyes=max(0, _safe_int(raw.get("eyes"))),
+        )
+
+    groups = raw if isinstance(raw, list) else []
+    up = 0
+    down = 0
+    eyes = 0
+    for item in groups:
+        if not isinstance(item, dict):
+            continue
+        content = _safe_text(item.get("content")).upper()
+        total = 0
+        users = item.get("users")
+        if isinstance(users, dict):
+            total = _safe_int(users.get("totalCount"))
+        total = max(0, total)
+        if content == "THUMBS_UP":
+            up = total
+        elif content == "THUMBS_DOWN":
+            down = total
+        elif content == "EYES":
+            eyes = total
+
+    return GitHubReactionSummary(thumbs_up=up, thumbs_down=down, eyes=eyes)
+
+
+def _parse_work_item(item_type: str, raw: object) -> GitHubWorkItem | None:
+    if not isinstance(raw, dict):
+        return None
+
+    number = _safe_int(raw.get("number"))
+    if number <= 0:
+        return None
+
+    author = ""
+    raw_author = raw.get("author")
+    if isinstance(raw_author, dict):
+        author = _safe_text(raw_author.get("login"))
+
+    return GitHubWorkItem(
+        item_type=item_type,
+        number=number,
+        title=_safe_text(raw.get("title")) or f"#{number}",
+        state=_safe_text(raw.get("state")).lower() or "open",
+        url=_safe_text(raw.get("url")),
+        author=author,
+        created_at=_safe_text(raw.get("createdAt")),
+        updated_at=_safe_text(raw.get("updatedAt")),
+        is_draft=bool(raw.get("isDraft") or False),
+    )
+
+
+def _repo_full_name(repo_owner: str, repo_name: str) -> str:
+    owner = _safe_text(repo_owner)
+    name = _safe_text(repo_name)
+    if not owner or not name:
+        raise GhManagementError("missing repository owner/name")
+    return f"{owner}/{name}"
+
+
+def list_open_pull_requests(
+    repo_owner: str,
+    repo_name: str,
+    *,
+    limit: int = 30,
+) -> list[GitHubWorkItem]:
+    repo = _repo_full_name(repo_owner, repo_name)
+    data = _run_gh_json(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            str(max(1, int(limit))),
+            "--json",
+            "number,title,state,url,author,createdAt,updatedAt,isDraft",
+        ],
+        timeout_s=45.0,
+    )
+
+    rows = data if isinstance(data, list) else []
+    items: list[GitHubWorkItem] = []
+    for row in rows:
+        parsed = _parse_work_item("pr", row)
+        if parsed is None:
+            continue
+        items.append(parsed)
+    return items
+
+
+def list_open_issues(
+    repo_owner: str,
+    repo_name: str,
+    *,
+    limit: int = 30,
+) -> list[GitHubWorkItem]:
+    repo = _repo_full_name(repo_owner, repo_name)
+    data = _run_gh_json(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            str(max(1, int(limit))),
+            "--json",
+            "number,title,state,url,author,createdAt,updatedAt",
+        ],
+        timeout_s=45.0,
+    )
+
+    rows = data if isinstance(data, list) else []
+    items: list[GitHubWorkItem] = []
+    for row in rows:
+        parsed = _parse_work_item("issue", row)
+        if parsed is None:
+            continue
+        items.append(parsed)
+    return items
+
+
+def list_issue_comments(
+    repo_owner: str,
+    repo_name: str,
+    *,
+    issue_number: int,
+    limit: int = 100,
+) -> list[GitHubComment]:
+    repo = _repo_full_name(repo_owner, repo_name)
+    data = _run_gh_json(
+        [
+            "api",
+            f"repos/{repo}/issues/{int(issue_number)}/comments?per_page={max(1, int(limit))}",
+            "-H",
+            "Accept: application/vnd.github+json",
+        ],
+        timeout_s=45.0,
+    )
+
+    rows = data if isinstance(data, list) else []
+    comments: list[GitHubComment] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+
+        comment_id = _safe_int(row.get("id"))
+        if comment_id <= 0:
+            continue
+
+        user = row.get("user")
+        author = _safe_text(user.get("login") if isinstance(user, dict) else "")
+
+        comments.append(
+            GitHubComment(
+                comment_id=comment_id,
+                node_id=_safe_text(row.get("node_id")),
+                body=_safe_text(row.get("body")),
+                author=author,
+                created_at=_safe_text(row.get("created_at")),
+                updated_at=_safe_text(row.get("updated_at")),
+                url=_safe_text(row.get("html_url")),
+                reactions=_parse_reaction_summary(row.get("reactions")),
+            )
+        )
+
+    return comments
+
+
+def get_pull_request_workroom(
+    repo_owner: str,
+    repo_name: str,
+    *,
+    number: int,
+) -> GitHubWorkroom:
+    repo = _repo_full_name(repo_owner, repo_name)
+    data = _run_gh_json(
+        [
+            "pr",
+            "view",
+            str(int(number)),
+            "--repo",
+            repo,
+            "--json",
+            "number,title,body,state,url,author,createdAt,updatedAt,isDraft",
+        ],
+        timeout_s=45.0,
+    )
+    if not isinstance(data, dict):
+        raise GhManagementError("invalid pull request payload")
+
+    author = ""
+    raw_author = data.get("author")
+    if isinstance(raw_author, dict):
+        author = _safe_text(raw_author.get("login"))
+
+    comments = list_issue_comments(
+        repo_owner,
+        repo_name,
+        issue_number=int(number),
+        limit=100,
+    )
+
+    return GitHubWorkroom(
+        item_type="pr",
+        repo_owner=_safe_text(repo_owner),
+        repo_name=_safe_text(repo_name),
+        number=max(1, _safe_int(data.get("number"), int(number))),
+        title=_safe_text(data.get("title")) or f"PR #{int(number)}",
+        body=_safe_text(data.get("body")),
+        state=_safe_text(data.get("state")).lower() or "open",
+        url=_safe_text(data.get("url")),
+        author=author,
+        created_at=_safe_text(data.get("createdAt")),
+        updated_at=_safe_text(data.get("updatedAt")),
+        is_draft=bool(data.get("isDraft") or False),
+        comments=comments,
+    )
+
+
+def get_issue_workroom(
+    repo_owner: str,
+    repo_name: str,
+    *,
+    number: int,
+) -> GitHubWorkroom:
+    repo = _repo_full_name(repo_owner, repo_name)
+    data = _run_gh_json(
+        [
+            "issue",
+            "view",
+            str(int(number)),
+            "--repo",
+            repo,
+            "--json",
+            "number,title,body,state,url,author,createdAt,updatedAt",
+        ],
+        timeout_s=45.0,
+    )
+    if not isinstance(data, dict):
+        raise GhManagementError("invalid issue payload")
+
+    author = ""
+    raw_author = data.get("author")
+    if isinstance(raw_author, dict):
+        author = _safe_text(raw_author.get("login"))
+
+    comments = list_issue_comments(
+        repo_owner,
+        repo_name,
+        issue_number=int(number),
+        limit=100,
+    )
+
+    return GitHubWorkroom(
+        item_type="issue",
+        repo_owner=_safe_text(repo_owner),
+        repo_name=_safe_text(repo_name),
+        number=max(1, _safe_int(data.get("number"), int(number))),
+        title=_safe_text(data.get("title")) or f"Issue #{int(number)}",
+        body=_safe_text(data.get("body")),
+        state=_safe_text(data.get("state")).lower() or "open",
+        url=_safe_text(data.get("url")),
+        author=author,
+        created_at=_safe_text(data.get("createdAt")),
+        updated_at=_safe_text(data.get("updatedAt")),
+        is_draft=False,
+        comments=comments,
+    )
+
+
+def post_comment(
+    repo_owner: str,
+    repo_name: str,
+    *,
+    item_type: str,
+    number: int,
+    body: str,
+) -> None:
+    repo = _repo_full_name(repo_owner, repo_name)
+    text = _safe_text(body)
+    if not text:
+        raise GhManagementError("comment body is empty")
+
+    normalized = _safe_text(item_type).lower()
+    if normalized == "pr":
+        _run_gh(
+            [
+                "pr",
+                "comment",
+                str(int(number)),
+                "--repo",
+                repo,
+                "--body",
+                text,
+            ],
+            timeout_s=45.0,
+        )
+        return
+
+    if normalized == "issue":
+        _run_gh(
+            [
+                "issue",
+                "comment",
+                str(int(number)),
+                "--repo",
+                repo,
+                "--body",
+                text,
+            ],
+            timeout_s=45.0,
+        )
+        return
+
+    raise GhManagementError(f"unsupported item type: {item_type}")
+
+
+def set_item_open_state(
+    repo_owner: str,
+    repo_name: str,
+    *,
+    item_type: str,
+    number: int,
+    open_state: bool,
+) -> None:
+    repo = _repo_full_name(repo_owner, repo_name)
+    normalized = _safe_text(item_type).lower()
+
+    if normalized == "pr":
+        subcommand = "reopen" if bool(open_state) else "close"
+        _run_gh(
+            [
+                "pr",
+                subcommand,
+                str(int(number)),
+                "--repo",
+                repo,
+            ],
+            timeout_s=45.0,
+        )
+        return
+
+    if normalized == "issue":
+        subcommand = "reopen" if bool(open_state) else "close"
+        _run_gh(
+            [
+                "issue",
+                subcommand,
+                str(int(number)),
+                "--repo",
+                repo,
+            ],
+            timeout_s=45.0,
+        )
+        return
+
+    raise GhManagementError(f"unsupported item type: {item_type}")
+
+
+def add_issue_comment_reaction(
+    repo_owner: str,
+    repo_name: str,
+    *,
+    comment_id: int,
+    reaction: str,
+) -> None:
+    repo = _repo_full_name(repo_owner, repo_name)
+    reaction_value = _safe_text(reaction)
+    if reaction_value not in {"+1", "-1", "eyes"}:
+        raise GhManagementError(f"unsupported reaction: {reaction_value}")
+
+    _run_gh_json(
+        [
+            "api",
+            "--method",
+            "POST",
+            f"repos/{repo}/issues/comments/{int(comment_id)}/reactions",
+            "-H",
+            "Accept: application/vnd.github+json",
+            "-f",
+            f"content={reaction_value}",
+        ],
+        timeout_s=30.0,
+    )

--- a/agents_runner/prompts/issue_fix_template.md
+++ b/agents_runner/prompts/issue_fix_template.md
@@ -1,0 +1,16 @@
+# Issue Fix Template
+
+Build a task prompt for fixing a GitHub issue from the Tasks -> Issues workflow.
+
+## Prompt
+Fix GitHub issue #{ISSUE_NUMBER} for repository {REPO_OWNER}/{REPO_NAME}.
+
+Issue URL: {ISSUE_URL}
+Issue title: {ISSUE_TITLE}
+
+Required workflow:
+1. Read the full issue details and reproduce the problem.
+2. Implement the fix with minimal, focused edits.
+3. Run relevant verification commands.
+4. Summarize what changed and why.
+5. If anything is still uncertain, list concrete follow-up checks.

--- a/agents_runner/prompts/issue_fix_template.md
+++ b/agents_runner/prompts/issue_fix_template.md
@@ -7,6 +7,8 @@ Fix GitHub issue #{ISSUE_NUMBER} for repository {REPO_OWNER}/{REPO_NAME}.
 
 Issue URL: {ISSUE_URL}
 Issue title: {ISSUE_TITLE}
+Trigger source: {TRIGGER_SOURCE}
+Mention comment ID: {MENTION_COMMENT_ID}
 
 Required workflow:
 1. Read the full issue details and reproduce the problem.

--- a/agents_runner/prompts/pr_review_template.md
+++ b/agents_runner/prompts/pr_review_template.md
@@ -1,0 +1,18 @@
+# Pull Request Review Template
+
+Build a task prompt for reviewing a GitHub pull request from the Tasks -> Pull Requests workflow.
+
+## Prompt
+Review GitHub pull request #{PR_NUMBER} for repository {REPO_OWNER}/{REPO_NAME}.
+
+PR URL: {PR_URL}
+PR title: {PR_TITLE}
+Mention comment ID: {MENTION_COMMENT_ID}
+
+Required workflow:
+1. Inspect the PR changes carefully for correctness, regressions, and missing tests.
+2. Use a reviewer mindset: findings first, ordered by severity, with file references.
+3. If no findings exist, explicitly say so and mention residual risks.
+4. If this review was triggered by @agentsnova mention and Mention comment ID is present:
+   - Add a +1 reaction to that comment when no issues are found.
+   - Add a -1 reaction to that comment when issues are found, and include review comments.

--- a/agents_runner/prompts/pr_review_template.md
+++ b/agents_runner/prompts/pr_review_template.md
@@ -7,6 +7,7 @@ Review GitHub pull request #{PR_NUMBER} for repository {REPO_OWNER}/{REPO_NAME}.
 
 PR URL: {PR_URL}
 PR title: {PR_TITLE}
+Trigger source: {TRIGGER_SOURCE}
 Mention comment ID: {MENTION_COMMENT_ID}
 
 Required workflow:

--- a/agents_runner/tests/test_tasks_nav_button_fade_behavior.py
+++ b/agents_runner/tests/test_tasks_nav_button_fade_behavior.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import os
+import time
+
+from PySide6.QtCore import Signal
+from PySide6.QtTest import QTest
+from PySide6.QtWidgets import QApplication
+from PySide6.QtWidgets import QWidget
+
+from agents_runner.environments import Environment
+from agents_runner.environments import WORKSPACE_CLONED
+from agents_runner.environments import WORKSPACE_NONE
+from agents_runner.ui.pages.tasks import TasksPage
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+class _DummyNewTaskPage(QWidget):
+    environment_changed = Signal(str)
+
+    def focus_prompt(self) -> None:
+        return
+
+    def set_environment_id(self, _env_id: str) -> None:
+        return
+
+    def append_prompt_text(self, _prompt: str) -> None:
+        return
+
+
+def _pump(app: QApplication, rounds: int = 10) -> None:
+    for _ in range(rounds):
+        app.processEvents()
+        QTest.qWait(20)
+
+
+def _wait_until(
+    app: QApplication,
+    predicate,
+    *,
+    timeout_ms: int = 2000,
+) -> bool:
+    deadline = time.monotonic() + (timeout_ms / 1000)
+    while time.monotonic() < deadline:
+        app.processEvents()
+        if predicate():
+            return True
+        QTest.qWait(20)
+    app.processEvents()
+    return bool(predicate())
+
+
+def _build_envs() -> dict[str, Environment]:
+    supported_a = Environment(
+        env_id="supported-a",
+        name="Supported A",
+        color="cyan",
+        workspace_type=WORKSPACE_CLONED,
+        workspace_target="owner/repo-a",
+    )
+    supported_b = Environment(
+        env_id="supported-b",
+        name="Supported B",
+        color="emerald",
+        workspace_type=WORKSPACE_CLONED,
+        workspace_target="owner/repo-b",
+    )
+    unsupported_a = Environment(
+        env_id="unsupported-a",
+        name="Unsupported A",
+        color="slate",
+        workspace_type=WORKSPACE_NONE,
+        workspace_target="",
+    )
+    unsupported_b = Environment(
+        env_id="unsupported-b",
+        name="Unsupported B",
+        color="amber",
+        workspace_type=WORKSPACE_NONE,
+        workspace_target="",
+    )
+    return {
+        supported_a.env_id: supported_a,
+        supported_b.env_id: supported_b,
+        unsupported_a.env_id: unsupported_a,
+        unsupported_b.env_id: unsupported_b,
+    }
+
+
+def test_tasks_github_buttons_fade_only_on_support_flip() -> None:
+    app = QApplication.instance() or QApplication([])
+
+    page = TasksPage(new_task_page=_DummyNewTaskPage())
+    page.resize(1400, 900)
+    envs = _build_envs()
+    page.set_environments(envs, "supported-a")
+    page.show()
+    _pump(app)
+
+    pull_requests_button = page._nav_buttons["pull_requests"]
+    issues_button = page._nav_buttons["issues"]
+
+    assert page._button_fade_animation is None
+    assert pull_requests_button.isVisible()
+    assert issues_button.isVisible()
+
+    page._new_task.environment_changed.emit("supported-b")
+    _pump(app, rounds=6)
+    assert page._button_fade_animation is None
+    assert pull_requests_button.isVisible()
+    assert issues_button.isVisible()
+
+    page._new_task.environment_changed.emit("unsupported-a")
+    _pump(app, rounds=2)
+    assert page._button_fade_animation is not None
+    assert _wait_until(app, lambda: page._button_fade_animation is None)
+    assert not pull_requests_button.isVisible()
+    assert not issues_button.isVisible()
+
+    page._new_task.environment_changed.emit("unsupported-b")
+    _pump(app, rounds=6)
+    assert page._button_fade_animation is None
+    assert not pull_requests_button.isVisible()
+    assert not issues_button.isVisible()
+
+    page._new_task.environment_changed.emit("supported-a")
+    _pump(app, rounds=2)
+    assert page._button_fade_animation is not None
+    assert _wait_until(app, lambda: page._button_fade_animation is None)
+    assert pull_requests_button.isVisible()
+    assert issues_button.isVisible()
+
+
+def test_tasks_github_button_fade_ignores_mid_animation_changes() -> None:
+    app = QApplication.instance() or QApplication([])
+
+    page = TasksPage(new_task_page=_DummyNewTaskPage())
+    page.resize(1400, 900)
+    envs = _build_envs()
+    page.set_environments(envs, "supported-a")
+    page.show()
+    _pump(app)
+
+    pull_requests_button = page._nav_buttons["pull_requests"]
+    issues_button = page._nav_buttons["issues"]
+
+    page._new_task.environment_changed.emit("unsupported-a")
+    _pump(app, rounds=2)
+    first_animation = page._button_fade_animation
+    assert first_animation is not None
+
+    page._new_task.environment_changed.emit("supported-b")
+    _pump(app, rounds=2)
+    assert page._button_fade_animation is first_animation
+
+    assert _wait_until(
+        app, lambda: page._button_fade_animation is None, timeout_ms=2500
+    )
+    assert pull_requests_button.isVisible()
+    assert issues_button.isVisible()

--- a/agents_runner/tests/test_tasks_nav_size_tracking.py
+++ b/agents_runner/tests/test_tasks_nav_size_tracking.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import os
+
+from PySide6.QtCore import QObject
+from PySide6.QtCore import QEvent
+from PySide6.QtCore import Signal
+from PySide6.QtTest import QTest
+from PySide6.QtWidgets import QApplication
+from PySide6.QtWidgets import QWidget
+
+from agents_runner.environments import Environment
+from agents_runner.environments import WORKSPACE_CLONED
+from agents_runner.ui.pages.tasks import TasksPage
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+class _DummyNewTaskPage(QWidget):
+    environment_changed = Signal(str)
+
+    def focus_prompt(self) -> None:
+        return
+
+    def set_environment_id(self, _env_id: str) -> None:
+        return
+
+    def append_prompt_text(self, _prompt: str) -> None:
+        return
+
+
+class _SizeTracker(QObject):
+    def __init__(self) -> None:
+        super().__init__()
+        self.samples: list[tuple[bool, int, int]] = []
+
+    def eventFilter(self, watched: QObject, event: QEvent) -> bool:
+        if event.type() == QEvent.Type.Resize and isinstance(watched, QWidget):
+            self.samples.append(
+                (watched.isVisible(), watched.width(), watched.height())
+            )
+        return False
+
+
+def _pump(app: QApplication, rounds: int = 8) -> None:
+    for _ in range(rounds):
+        app.processEvents()
+        QTest.qWait(20)
+
+
+def test_tasks_nav_panel_width_stays_stable_across_hide_show_cycles() -> None:
+    app = QApplication.instance() or QApplication([])
+
+    page = TasksPage(new_task_page=_DummyNewTaskPage())
+    page.resize(1400, 900)
+
+    env = Environment(
+        env_id="ui-test",
+        name="UI Test",
+        color="cyan",
+        workspace_type=WORKSPACE_CLONED,
+        workspace_target="owner/repo",
+    )
+    page.set_environments({env.env_id: env}, env.env_id)
+
+    host_tracker = _SizeTracker()
+    panel_tracker = _SizeTracker()
+    page._nav_host.installEventFilter(host_tracker)
+    page._nav_panel.installEventFilter(panel_tracker)
+
+    page.show()
+    _pump(app)
+
+    expected = int(page._nav_expanded_width)
+    host_widths: list[int] = [int(page._nav_host.width())]
+    panel_widths: list[int] = [int(page._nav_panel.width())]
+
+    page.hide()
+    _pump(app, rounds=4)
+    page.resize(760, 700)
+    _pump(app, rounds=4)
+    page.resize(1400, 900)
+    _pump(app, rounds=4)
+
+    page.show()
+    _pump(app)
+    host_widths.append(int(page._nav_host.width()))
+    panel_widths.append(int(page._nav_panel.width()))
+
+    page.hide()
+    _pump(app, rounds=4)
+    page.show()
+    _pump(app)
+    host_widths.append(int(page._nav_host.width()))
+    panel_widths.append(int(page._nav_panel.width()))
+
+    visible_host_samples = {w for visible, w, _h in host_tracker.samples if visible}
+    visible_panel_samples = {w for visible, w, _h in panel_tracker.samples if visible}
+    if visible_host_samples:
+        assert visible_host_samples == {expected}
+    if visible_panel_samples:
+        assert visible_panel_samples == {expected}
+
+    assert set(host_widths) == {expected}, (
+        f"nav host width changed across show/hide: {host_widths}; "
+        f"tracked={host_tracker.samples}"
+    )
+    assert set(panel_widths) == {expected}, (
+        f"nav panel width changed across show/hide: {panel_widths}; "
+        f"tracked={panel_tracker.samples}"
+    )

--- a/agents_runner/tests/test_tasks_nav_transition_size_tracking.py
+++ b/agents_runner/tests/test_tasks_nav_transition_size_tracking.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import os
+
+from PySide6.QtCore import QObject
+from PySide6.QtCore import QEvent
+from PySide6.QtTest import QTest
+from PySide6.QtWidgets import QApplication
+from PySide6.QtWidgets import QWidget
+
+from agents_runner.environments import Environment
+from agents_runner.environments import WORKSPACE_CLONED
+from agents_runner.ui.main_window import MainWindow
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+class _ResizeTracker(QObject):
+    def __init__(self) -> None:
+        super().__init__()
+        self.samples: list[tuple[bool, int, int]] = []
+
+    def eventFilter(self, watched: QObject, event: QEvent) -> bool:
+        if event.type() == QEvent.Type.Resize and isinstance(watched, QWidget):
+            self.samples.append(
+                (watched.isVisible(), watched.width(), watched.height())
+            )
+        return False
+
+
+def _pump(app: QApplication, rounds: int = 15) -> None:
+    for _ in range(rounds):
+        app.processEvents()
+        QTest.qWait(20)
+
+
+def test_tasks_nav_width_stable_during_main_window_page_transitions() -> None:
+    app = QApplication.instance() or QApplication([])
+
+    win = MainWindow()
+    win.resize(1280, 720)
+    win.show()
+    _pump(app)
+
+    env = Environment(
+        env_id="transition-test",
+        name="Transition Test",
+        color="cyan",
+        workspace_type=WORKSPACE_CLONED,
+        workspace_target="owner/repo",
+    )
+    win._tasks_page.set_environments({env.env_id: env}, env.env_id)
+    _pump(app)
+
+    tracker = _ResizeTracker()
+    win._tasks_page._nav_host.installEventFilter(tracker)
+
+    expected = int(win._tasks_page._nav_expanded_width)
+
+    win._show_tasks()
+    _pump(app, rounds=30)
+    assert win._tasks_page.isVisible()
+    assert int(win._tasks_page._nav_host.width()) == expected
+
+    win._show_dashboard()
+    _pump(app, rounds=30)
+    assert win._dashboard.isVisible()
+
+    win._show_tasks()
+    _pump(app, rounds=30)
+    assert win._tasks_page.isVisible()
+    assert int(win._tasks_page._nav_host.width()) == expected
+
+    visible_widths = {w for visible, w, _h in tracker.samples if visible}
+    if visible_widths:
+        assert visible_widths == {expected}, (
+            f"nav width changed during transitions: {sorted(visible_widths)}; "
+            f"tracked={tracker.samples}"
+        )

--- a/agents_runner/tests/test_tasks_nav_transition_size_tracking.py
+++ b/agents_runner/tests/test_tasks_nav_transition_size_tracking.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 
+import pytest
 from PySide6.QtCore import QObject
 from PySide6.QtCore import QEvent
 from PySide6.QtTest import QTest
@@ -11,6 +12,7 @@ from PySide6.QtWidgets import QWidget
 from agents_runner.environments import Environment
 from agents_runner.environments import WORKSPACE_CLONED
 from agents_runner.ui.main_window import MainWindow
+from agents_runner.ui.radio.controller import RadioController
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
@@ -34,7 +36,14 @@ def _pump(app: QApplication, rounds: int = 15) -> None:
         QTest.qWait(20)
 
 
-def test_tasks_nav_width_stable_during_main_window_page_transitions() -> None:
+def test_tasks_nav_width_stable_during_main_window_page_transitions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        RadioController,
+        "probe_qt_multimedia_available",
+        classmethod(lambda cls: False),
+    )
     app = QApplication.instance() or QApplication([])
 
     win = MainWindow()

--- a/agents_runner/ui/dialogs/github_workroom_dialog.py
+++ b/agents_runner/ui/dialogs/github_workroom_dialog.py
@@ -305,6 +305,7 @@ class GitHubWorkroomDialog(QDialog):
                 PR_URL=room.url,
                 PR_TITLE=room.title,
                 MENTION_COMMENT_ID="",
+                TRIGGER_SOURCE="manual",
             )
 
         return load_prompt(
@@ -314,6 +315,8 @@ class GitHubWorkroomDialog(QDialog):
             ISSUE_NUMBER=room.number,
             ISSUE_URL=room.url,
             ISSUE_TITLE=room.title,
+            MENTION_COMMENT_ID="",
+            TRIGGER_SOURCE="manual",
         )
 
     def _on_primary(self) -> None:

--- a/agents_runner/ui/dialogs/github_workroom_dialog.py
+++ b/agents_runner/ui/dialogs/github_workroom_dialog.py
@@ -326,6 +326,7 @@ class GitHubWorkroomDialog(QDialog):
             )
             return
         self.prompt_requested.emit(prompt)
+        self.accept()
 
     def _on_toggle_open_state(self) -> None:
         room = self._room

--- a/agents_runner/ui/dialogs/github_workroom_dialog.py
+++ b/agents_runner/ui/dialogs/github_workroom_dialog.py
@@ -1,0 +1,395 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from PySide6.QtCore import Qt
+from PySide6.QtCore import QUrl
+from PySide6.QtCore import Signal
+from PySide6.QtGui import QDesktopServices
+from PySide6.QtGui import QTextCursor
+from PySide6.QtWidgets import QApplication
+from PySide6.QtWidgets import QDialog
+from PySide6.QtWidgets import QHBoxLayout
+from PySide6.QtWidgets import QLabel
+from PySide6.QtWidgets import QLineEdit
+from PySide6.QtWidgets import QMessageBox
+from PySide6.QtWidgets import QPlainTextEdit
+from PySide6.QtWidgets import QToolButton
+from PySide6.QtWidgets import QVBoxLayout
+
+from agents_runner.gh.work_items import GitHubWorkroom
+from agents_runner.gh.work_items import get_issue_workroom
+from agents_runner.gh.work_items import get_pull_request_workroom
+from agents_runner.gh.work_items import post_comment
+from agents_runner.gh.work_items import set_item_open_state
+from agents_runner.prompts import load_prompt
+from agents_runner.ui.lucide_icons import lucide_icon
+from agents_runner.ui.widgets import GlassCard
+
+
+class GitHubWorkroomDialog(QDialog):
+    prompt_requested = Signal(str)
+
+    def __init__(
+        self,
+        *,
+        repo_owner: str,
+        repo_name: str,
+        item_type: str,
+        number: int,
+        confirmation_mode: str,
+        parent=None,
+    ) -> None:
+        super().__init__(parent)
+        self._repo_owner = str(repo_owner or "").strip()
+        self._repo_name = str(repo_name or "").strip()
+        self._item_type = str(item_type or "").strip().lower()
+        self._number = max(1, int(number))
+        self._confirmation_mode = str(confirmation_mode or "always").strip().lower()
+        self._room: GitHubWorkroom | None = None
+
+        self.setWindowTitle("GitHub Workroom")
+        self.setMinimumSize(860, 620)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(10)
+
+        header = GlassCard()
+        header_layout = QHBoxLayout(header)
+        header_layout.setContentsMargins(16, 14, 16, 14)
+        header_layout.setSpacing(10)
+
+        self._title = QLabel("Loading...")
+        self._title.setStyleSheet("font-size: 16px; font-weight: 750;")
+        self._subtitle = QLabel("—")
+        self._subtitle.setStyleSheet("color: rgba(237, 239, 245, 160);")
+
+        self._btn_primary = QToolButton()
+        self._btn_primary.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        self._btn_primary.clicked.connect(self._on_primary)
+
+        self._btn_toggle_state = QToolButton()
+        self._btn_toggle_state.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        self._btn_toggle_state.clicked.connect(self._on_toggle_open_state)
+
+        self._btn_refresh = QToolButton()
+        self._btn_refresh.setText("Refresh")
+        self._btn_refresh.setIcon(lucide_icon("refresh-cw"))
+        self._btn_refresh.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        self._btn_refresh.clicked.connect(self.refresh)
+
+        self._btn_browser = QToolButton()
+        self._btn_browser.setText("Browser")
+        self._btn_browser.setIcon(lucide_icon("external-link"))
+        self._btn_browser.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        self._btn_browser.clicked.connect(self._open_in_browser)
+
+        header_layout.addWidget(self._title)
+        header_layout.addWidget(self._subtitle, 1)
+        header_layout.addWidget(self._btn_primary)
+        header_layout.addWidget(self._btn_toggle_state)
+        header_layout.addWidget(self._btn_refresh)
+        header_layout.addWidget(self._btn_browser)
+        layout.addWidget(header)
+
+        timeline_card = GlassCard()
+        timeline_layout = QVBoxLayout(timeline_card)
+        timeline_layout.setContentsMargins(16, 14, 16, 14)
+        timeline_layout.setSpacing(8)
+
+        timeline_title = QLabel("Timeline")
+        timeline_title.setStyleSheet("font-size: 13px; font-weight: 700;")
+
+        self._timeline = QPlainTextEdit()
+        self._timeline.setReadOnly(True)
+        self._timeline.setObjectName("LogsView")
+
+        timeline_layout.addWidget(timeline_title)
+        timeline_layout.addWidget(self._timeline, 1)
+        layout.addWidget(timeline_card, 1)
+
+        composer = GlassCard()
+        composer_layout = QVBoxLayout(composer)
+        composer_layout.setContentsMargins(16, 14, 16, 14)
+        composer_layout.setSpacing(8)
+
+        composer_title = QLabel("Comment")
+        composer_title.setStyleSheet("font-size: 13px; font-weight: 700;")
+
+        row = QHBoxLayout()
+        row.setSpacing(8)
+
+        self._comment = QLineEdit()
+        self._comment.setPlaceholderText("Write a comment...")
+
+        self._btn_send = QToolButton()
+        self._btn_send.setText("Comment")
+        self._btn_send.setIcon(lucide_icon("file-pen-line"))
+        self._btn_send.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        self._btn_send.clicked.connect(self._on_send_comment)
+
+        row.addWidget(self._comment, 1)
+        row.addWidget(self._btn_send)
+
+        self._status = QLabel("Loading...")
+        self._status.setStyleSheet("color: rgba(237, 239, 245, 160);")
+
+        composer_layout.addWidget(composer_title)
+        composer_layout.addLayout(row)
+        composer_layout.addWidget(self._status)
+
+        layout.addWidget(composer)
+
+        self._sync_primary_button()
+        self._sync_open_state_button("open")
+        self.refresh()
+
+    def _sync_primary_button(self) -> None:
+        if self._item_type == "pr":
+            self._btn_primary.setText("Review PR")
+            self._btn_primary.setIcon(lucide_icon("git-pull-request"))
+            self._btn_primary.setToolTip(
+                "Create a review task prompt from this pull request"
+            )
+            return
+
+        self._btn_primary.setText("Fix Issue")
+        self._btn_primary.setIcon(lucide_icon("bug"))
+        self._btn_primary.setToolTip("Create a fix task prompt from this issue")
+
+    def _sync_open_state_button(self, state: str) -> None:
+        normalized = str(state or "").strip().lower()
+        if normalized == "open":
+            self._btn_toggle_state.setText("Close")
+            self._btn_toggle_state.setIcon(lucide_icon("square"))
+            self._btn_toggle_state.setToolTip("Close this item")
+            return
+
+        self._btn_toggle_state.setText("Reopen")
+        self._btn_toggle_state.setIcon(lucide_icon("play"))
+        self._btn_toggle_state.setToolTip("Reopen this item")
+
+    def _format_time(self, value: str) -> str:
+        text = str(value or "").strip()
+        if not text:
+            return "—"
+        try:
+            parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+            return parsed.strftime("%Y-%m-%d %H:%M")
+        except Exception:
+            return text
+
+    def _render_room(self) -> None:
+        room = self._room
+        if room is None:
+            return
+
+        kind = "PR" if room.item_type == "pr" else "Issue"
+        draft_suffix = " (draft)" if room.is_draft else ""
+        self._title.setText(f"{kind} #{room.number}: {room.title}{draft_suffix}")
+        self._subtitle.setText(
+            f"{room.repo_owner}/{room.repo_name}  |  by {room.author or 'unknown'}  |  {self._format_time(room.updated_at)}"
+        )
+        self._sync_open_state_button(room.state)
+
+        lines: list[str] = []
+        lines.append(f"{kind} #{room.number}")
+        lines.append(f"State: {room.state}")
+        lines.append(f"URL: {room.url}")
+        lines.append("")
+        lines.append("Description")
+        lines.append(room.body or "(empty)")
+        lines.append("")
+        lines.append("Comments")
+        if not room.comments:
+            lines.append("(no comments)")
+        else:
+            for comment in room.comments:
+                reactions = comment.reactions
+                reaction_bits: list[str] = []
+                if reactions.thumbs_up > 0:
+                    reaction_bits.append(f"+1={reactions.thumbs_up}")
+                if reactions.thumbs_down > 0:
+                    reaction_bits.append(f"-1={reactions.thumbs_down}")
+                if reactions.eyes > 0:
+                    reaction_bits.append(f"eyes={reactions.eyes}")
+                reaction_text = (
+                    f" | reactions: {', '.join(reaction_bits)}" if reaction_bits else ""
+                )
+                lines.append(
+                    f"- {comment.author or 'unknown'} @ {self._format_time(comment.created_at)}{reaction_text}"
+                )
+                lines.append(comment.body or "(empty)")
+                lines.append("")
+
+        self._timeline.setPlainText("\n".join(lines).rstrip())
+        cursor = self._timeline.textCursor()
+        cursor.movePosition(QTextCursor.End)
+        self._timeline.setTextCursor(cursor)
+        self._status.setText(f"Loaded {len(room.comments)} comment(s).")
+
+    def _with_wait_cursor(self, fn) -> None:
+        QApplication.setOverrideCursor(Qt.WaitCursor)
+        try:
+            fn()
+        finally:
+            QApplication.restoreOverrideCursor()
+
+    def _confirm_write(self, *, message: str, destructive: bool) -> bool:
+        mode = self._confirmation_mode
+        if mode == "never":
+            return True
+        if mode == "destructive_only" and not destructive:
+            return True
+
+        answer = QMessageBox.question(
+            self,
+            "Confirm GitHub action",
+            message,
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        return answer == QMessageBox.Yes
+
+    def refresh(self) -> None:
+        self._status.setText("Refreshing...")
+
+        def _load() -> None:
+            if self._item_type == "pr":
+                self._room = get_pull_request_workroom(
+                    self._repo_owner,
+                    self._repo_name,
+                    number=self._number,
+                )
+                return
+            self._room = get_issue_workroom(
+                self._repo_owner,
+                self._repo_name,
+                number=self._number,
+            )
+
+        try:
+            self._with_wait_cursor(_load)
+        except Exception as exc:
+            self._status.setText(f"Failed to load: {exc}")
+            QMessageBox.warning(self, "GitHub load failed", str(exc))
+            return
+
+        self._render_room()
+
+    def _open_in_browser(self) -> None:
+        room = self._room
+        if room is None:
+            return
+        if not room.url:
+            return
+        QDesktopServices.openUrl(QUrl(room.url))
+
+    def _build_prompt(self) -> str:
+        room = self._room
+        if room is None:
+            return ""
+
+        if room.item_type == "pr":
+            return load_prompt(
+                "pr_review_template",
+                REPO_OWNER=room.repo_owner,
+                REPO_NAME=room.repo_name,
+                PR_NUMBER=room.number,
+                PR_URL=room.url,
+                PR_TITLE=room.title,
+                MENTION_COMMENT_ID="",
+            )
+
+        return load_prompt(
+            "issue_fix_template",
+            REPO_OWNER=room.repo_owner,
+            REPO_NAME=room.repo_name,
+            ISSUE_NUMBER=room.number,
+            ISSUE_URL=room.url,
+            ISSUE_TITLE=room.title,
+        )
+
+    def _on_primary(self) -> None:
+        prompt = self._build_prompt().strip()
+        if not prompt:
+            QMessageBox.warning(
+                self,
+                "Prompt unavailable",
+                "Could not build a task prompt for this item.",
+            )
+            return
+        self.prompt_requested.emit(prompt)
+
+    def _on_toggle_open_state(self) -> None:
+        room = self._room
+        if room is None:
+            return
+
+        currently_open = room.state == "open"
+        target_open = not currently_open
+        action = "reopen" if target_open else "close"
+
+        if not self._confirm_write(
+            message=(
+                f"Do you want to {action} {room.item_type} #{room.number} in "
+                f"{room.repo_owner}/{room.repo_name}?"
+            ),
+            destructive=True,
+        ):
+            return
+
+        def _write() -> None:
+            set_item_open_state(
+                room.repo_owner,
+                room.repo_name,
+                item_type=room.item_type,
+                number=room.number,
+                open_state=target_open,
+            )
+
+        try:
+            self._with_wait_cursor(_write)
+        except Exception as exc:
+            QMessageBox.warning(self, "GitHub update failed", str(exc))
+            return
+
+        self.refresh()
+
+    def _on_send_comment(self) -> None:
+        room = self._room
+        if room is None:
+            return
+
+        comment = str(self._comment.text() or "").strip()
+        if not comment:
+            QMessageBox.warning(self, "Missing comment", "Enter a comment first.")
+            return
+
+        if not self._confirm_write(
+            message=(
+                f"Post this comment to {room.item_type} #{room.number} in "
+                f"{room.repo_owner}/{room.repo_name}?"
+            ),
+            destructive=False,
+        ):
+            return
+
+        def _write() -> None:
+            post_comment(
+                room.repo_owner,
+                room.repo_name,
+                item_type=room.item_type,
+                number=room.number,
+                body=comment,
+            )
+
+        try:
+            self._with_wait_cursor(_write)
+        except Exception as exc:
+            QMessageBox.warning(self, "Comment failed", str(exc))
+            return
+
+        self._comment.clear()
+        self.refresh()

--- a/agents_runner/ui/dialogs/github_workroom_dialog.py
+++ b/agents_runner/ui/dialogs/github_workroom_dialog.py
@@ -37,6 +37,7 @@ class GitHubWorkroomDialog(QDialog):
         repo_name: str,
         item_type: str,
         number: int,
+        item_url: str = "",
         confirmation_mode: str,
         parent=None,
     ) -> None:
@@ -45,6 +46,7 @@ class GitHubWorkroomDialog(QDialog):
         self._repo_name = str(repo_name or "").strip()
         self._item_type = str(item_type or "").strip().lower()
         self._number = max(1, int(number))
+        self._item_url = str(item_url or "").strip()
         self._confirmation_mode = str(confirmation_mode or "always").strip().lower()
         self._room: GitHubWorkroom | None = None
 
@@ -280,11 +282,14 @@ class GitHubWorkroomDialog(QDialog):
 
     def _open_in_browser(self) -> None:
         room = self._room
-        if room is None:
+        url = ""
+        if room is not None:
+            url = str(room.url or "").strip()
+        if not url:
+            url = str(self._item_url or "").strip()
+        if not url:
             return
-        if not room.url:
-            return
-        QDesktopServices.openUrl(QUrl(room.url))
+        QDesktopServices.openUrl(QUrl(url))
 
     def _build_prompt(self) -> str:
         room = self._room

--- a/agents_runner/ui/main_window_environment.py
+++ b/agents_runner/ui/main_window_environment.py
@@ -178,6 +178,8 @@ class _MainWindowEnvironmentMixin:
         self._dashboard.set_environment_filter_options(
             [(e.env_id, e.name or e.env_id) for e in envs]
         )
+        if hasattr(self, "_tasks_page"):
+            self._tasks_page.set_environments(self._user_environment_map(), active_id)
 
         self._syncing_environment = True
         try:

--- a/agents_runner/ui/main_window_navigation.py
+++ b/agents_runner/ui/main_window_navigation.py
@@ -19,7 +19,7 @@ class _MainWindowNavigationMixin:
         """Smooth cross-fade transition between pages."""
         pages = [
             self._dashboard,
-            self._new_task,
+            self._tasks_page,
             self._details,
             self._envs_page,
             self._settings,
@@ -91,10 +91,13 @@ class _MainWindowNavigationMixin:
         self._transition_to_page(self._dashboard)
 
     def _show_new_task(self) -> None:
+        self._show_tasks()
+
+    def _show_tasks(self) -> None:
         if not self._try_autosave_before_navigation():
             return
-        self._new_task.focus_prompt()
-        self._transition_to_page(self._new_task)
+        self._tasks_page.show_new_task_tab(focus_prompt=True)
+        self._transition_to_page(self._tasks_page)
 
     def _show_task_details(self) -> None:
         if not self._try_autosave_before_navigation():

--- a/agents_runner/ui/main_window_navigation.py
+++ b/agents_runner/ui/main_window_navigation.py
@@ -35,6 +35,13 @@ class _MainWindowNavigationMixin:
             target_page.show()
             return
 
+        # Prime hidden page geometry to avoid first-frame size pop during cross-fade.
+        try:
+            target_page.setGeometry(current_page.geometry())
+            target_page.updateGeometry()
+        except Exception:
+            pass
+
         effect_out = current_page.graphicsEffect()
         if not isinstance(effect_out, QGraphicsOpacityEffect):
             effect_out = QGraphicsOpacityEffect(current_page)
@@ -72,6 +79,11 @@ class _MainWindowNavigationMixin:
 
         def start_fade_in() -> None:
             current_page.hide()
+            try:
+                target_page.setGeometry(current_page.geometry())
+                target_page.updateGeometry()
+            except Exception:
+                pass
             target_page.show()
             anim_in.start()
 

--- a/agents_runner/ui/main_window_persistence.py
+++ b/agents_runner/ui/main_window_persistence.py
@@ -184,6 +184,11 @@ class _MainWindowPersistenceMixin:
         self._settings_data.setdefault("radio_autostart", False)
         self._settings_data.setdefault("radio_loudness_boost_enabled", False)
         self._settings_data.setdefault("radio_loudness_boost_factor", 2.2)
+        self._settings_data.setdefault("github_workroom_prefer_browser", False)
+        self._settings_data.setdefault("github_write_confirmation_mode", "always")
+        self._settings_data.setdefault("github_poll_interval_s", 30)
+        self._settings_data.setdefault("agentsnova_auto_review_enabled", True)
+        self._settings_data.setdefault("agentsnova_review_guard_mode", "reaction")
         host_codex_dir = os.path.normpath(
             os.path.expanduser(
                 str(self._settings_data.get("host_codex_dir") or "").strip()

--- a/agents_runner/ui/main_window_settings.py
+++ b/agents_runner/ui/main_window_settings.py
@@ -23,6 +23,8 @@ class _MainWindowSettingsMixin:
         self._envs_page.set_settings_data(
             self._settings_data
         )  # Pass settings to environments page
+        if hasattr(self, "_tasks_page"):
+            self._tasks_page.set_settings_data(self._settings_data)
         self._apply_active_environment_to_new_task()
 
         # Apply spellcheck setting to new task page
@@ -93,6 +95,30 @@ class _MainWindowSettingsMixin:
             merged[key] = self._sanitize_interactive_command_value(key, merged.get(key))
         merged["append_pixelarch_context"] = bool(
             merged.get("append_pixelarch_context") or False
+        )
+        merged["github_workroom_prefer_browser"] = bool(
+            merged.get("github_workroom_prefer_browser") or False
+        )
+        confirmation_mode = (
+            str(merged.get("github_write_confirmation_mode") or "always")
+            .strip()
+            .lower()
+        )
+        if confirmation_mode not in {"always", "destructive_only", "never"}:
+            confirmation_mode = "always"
+        merged["github_write_confirmation_mode"] = confirmation_mode
+        merged["agentsnova_auto_review_enabled"] = bool(
+            merged.get("agentsnova_auto_review_enabled", True)
+        )
+        try:
+            merged["github_poll_interval_s"] = max(
+                5, int(merged.get("github_poll_interval_s", 30))
+            )
+        except Exception:
+            merged["github_poll_interval_s"] = 30
+        merged["agentsnova_review_guard_mode"] = (
+            str(merged.get("agentsnova_review_guard_mode") or "reaction").strip()
+            or "reaction"
         )
         merged["headless_desktop_enabled"] = bool(
             merged.get("headless_desktop_enabled") or False

--- a/agents_runner/ui/pages/__init__.py
+++ b/agents_runner/ui/pages/__init__.py
@@ -4,12 +4,14 @@ from agents_runner.ui.pages.dashboard import DashboardPage
 from agents_runner.ui.pages.environments import EnvironmentsPage
 from agents_runner.ui.pages.new_task import NewTaskPage
 from agents_runner.ui.pages.settings import SettingsPage
+from agents_runner.ui.pages.tasks import TasksPage
 from agents_runner.ui.pages.task_details import TaskDetailsPage
 
 __all__ = [
     "DashboardPage",
     "TaskDetailsPage",
     "NewTaskPage",
+    "TasksPage",
     "EnvironmentsPage",
     "SettingsPage",
 ]

--- a/agents_runner/ui/pages/github_work_list.py
+++ b/agents_runner/ui/pages/github_work_list.py
@@ -63,10 +63,6 @@ class _GitHubWorkRow(QWidget):
         self._title.setStyleSheet("font-weight: 650; color: rgba(237, 239, 245, 235);")
         self._title.setMinimumWidth(260)
 
-        self._state = QLabel("—")
-        self._state.setStyleSheet("color: rgba(237, 239, 245, 190); font-weight: 700;")
-        self._state.setMinimumWidth(110)
-
         self._meta = QLabel("—")
         self._meta.setStyleSheet("color: rgba(237, 239, 245, 160);")
 
@@ -82,9 +78,8 @@ class _GitHubWorkRow(QWidget):
         self._btn_open.setToolButtonStyle(Qt.ToolButtonIconOnly)
         self._btn_open.clicked.connect(lambda: self.open_requested.emit(self._item))
 
-        layout.addWidget(self._title, 5)
-        layout.addWidget(self._state, 0)
-        layout.addWidget(self._meta, 4)
+        layout.addWidget(self._title, 6)
+        layout.addWidget(self._meta, 5)
         layout.addWidget(self._btn_primary, 0)
         layout.addWidget(self._btn_open, 0)
 
@@ -119,12 +114,6 @@ class _GitHubWorkRow(QWidget):
         self._item = item
         prefix = "PR" if item.item_type == "pr" else "Issue"
         self._title.setText(f"{prefix} #{item.number}: {item.title}")
-
-        state = str(item.state or "").strip().lower()
-        if item.item_type == "pr" and item.is_draft and state == "open":
-            self._state.setText("Draft")
-        else:
-            self._state.setText(state.title() if state else "—")
 
         self._meta.setText(meta_text)
 
@@ -212,16 +201,12 @@ class GitHubWorkListPage(QWidget):
         c1 = QLabel("Item")
         c1.setStyleSheet("color: rgba(237, 239, 245, 150); font-weight: 650;")
         c1.setMinimumWidth(260)
-        c2 = QLabel("State")
-        c2.setStyleSheet("color: rgba(237, 239, 245, 150); font-weight: 650;")
-        c2.setMinimumWidth(110)
         c3 = QLabel("Info")
         c3.setStyleSheet("color: rgba(237, 239, 245, 150); font-weight: 650;")
-        self._column_labels = (c1, c2, c3)
+        self._column_labels = (c1, c3)
 
-        columns_layout.addWidget(c1, 5)
-        columns_layout.addWidget(c2, 0)
-        columns_layout.addWidget(c3, 4)
+        columns_layout.addWidget(c1, 6)
+        columns_layout.addWidget(c3, 5)
 
         self._scroll = QScrollArea()
         self._scroll.setWidgetResizable(True)
@@ -646,10 +631,6 @@ class GitHubWorkListPage(QWidget):
             self._header_card.setStyleSheet("")
             self._list_card.setStyleSheet("")
             self._list.setStyleSheet("")
-            for label in self._column_labels:
-                label.setStyleSheet(
-                    "color: rgba(237, 239, 245, 150); font-weight: 650;"
-                )
             return
 
         _apply_environment_combo_tint(self._environment, stain)
@@ -700,8 +681,6 @@ class GitHubWorkListPage(QWidget):
             )
         )
         self._list.setStyleSheet(f"background-color: rgba({r}, {g}, {b}, 10);")
-        for label in self._column_labels:
-            label.setStyleSheet(f"color: rgba({r}, {g}, {b}, 215); font-weight: 650;")
 
     def _log_fetch_issue_once(self, message: str, *, mode: str) -> None:
         text = str(message or "").strip()

--- a/agents_runner/ui/pages/github_work_list.py
+++ b/agents_runner/ui/pages/github_work_list.py
@@ -493,6 +493,7 @@ class GitHubWorkListPage(QWidget):
             repo_name=repo_context.repo_name,
             item_type=item.item_type,
             number=item.number,
+            item_url=item.url,
             confirmation_mode=self._confirmation_mode,
             parent=self,
         )

--- a/agents_runner/ui/pages/github_work_list.py
+++ b/agents_runner/ui/pages/github_work_list.py
@@ -141,6 +141,7 @@ class GitHubWorkListPage(QWidget):
     environment_changed = Signal(str)
     prompt_append_requested = Signal(str, str)
     auto_review_requested = Signal(str, str)
+    status_text_changed = Signal(str)
 
     _fetch_completed = Signal(int, object, str, object, object)
 
@@ -170,10 +171,6 @@ class GitHubWorkListPage(QWidget):
         header_layout.setContentsMargins(16, 14, 16, 14)
         header_layout.setSpacing(10)
 
-        title = "Pull Requests" if self._item_type == "pr" else "Issues"
-        self._title = QLabel(title)
-        self._title.setStyleSheet("font-size: 16px; font-weight: 750;")
-
         self._environment = QComboBox()
         self._environment.setFixedWidth(260)
         self._environment.currentIndexChanged.connect(self._on_environment_changed)
@@ -184,7 +181,6 @@ class GitHubWorkListPage(QWidget):
         self._refresh.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
         self._refresh.clicked.connect(self.refresh)
 
-        header_layout.addWidget(self._title)
         header_layout.addStretch(1)
         header_layout.addWidget(self._environment)
         header_layout.addWidget(self._refresh)
@@ -229,10 +225,10 @@ class GitHubWorkListPage(QWidget):
 
         self._status = QLabel("Select an environment to load data.")
         self._status.setStyleSheet("color: rgba(237, 239, 245, 160);")
+        self._status.setVisible(False)
 
         card_layout.addWidget(columns)
         card_layout.addWidget(self._scroll, 1)
-        card_layout.addWidget(self._status)
         root.addWidget(card, 1)
 
         self._poll_timer = QTimer(self)
@@ -310,12 +306,20 @@ class GitHubWorkListPage(QWidget):
         self.environment_changed.emit(self._active_env_id)
         self.refresh()
 
+    def current_status_text(self) -> str:
+        return str(self._status.text() or "")
+
+    def _set_status_text(self, text: str) -> None:
+        value = str(text or "")
+        self._status.setText(value)
+        self.status_text_changed.emit(value)
+
     def refresh(self) -> None:
         env_id = str(
             self._active_env_id or self._environment.currentData() or ""
         ).strip()
         if not env_id:
-            self._status.setText("Select an environment to load data.")
+            self._set_status_text("Select an environment to load data.")
             self._clear_rows()
             return
 
@@ -326,7 +330,7 @@ class GitHubWorkListPage(QWidget):
             self._auto_review_enabled and self._item_type == "pr"
         )
 
-        self._status.setText("Loading...")
+        self._set_status_text("Loading...")
 
         worker = threading.Thread(
             target=self._fetch_worker,
@@ -552,7 +556,7 @@ class GitHubWorkListPage(QWidget):
 
         if repo_context is None:
             self._clear_rows()
-            self._status.setText("GitHub is unavailable for this environment.")
+            self._set_status_text("GitHub is unavailable for this environment.")
             return
 
         rows = [
@@ -565,15 +569,15 @@ class GitHubWorkListPage(QWidget):
 
         if error:
             self._clear_rows()
-            self._status.setText(f"Load failed: {error}")
+            self._set_status_text(f"Load failed: {error}")
             return
 
         self._render_rows(rows, stain=stain)
         kind = "pull request" if self._item_type == "pr" else "issue"
         if rows:
-            self._status.setText(f"Loaded {len(rows)} open {kind}(s).")
+            self._set_status_text(f"Loaded {len(rows)} open {kind}(s).")
         else:
-            self._status.setText(f"No open {kind}s found.")
+            self._set_status_text(f"No open {kind}s found.")
 
         reviews = auto_reviews if isinstance(auto_reviews, list) else []
         for review in reviews:

--- a/agents_runner/ui/pages/github_work_list.py
+++ b/agents_runner/ui/pages/github_work_list.py
@@ -1,0 +1,603 @@
+from __future__ import annotations
+
+import threading
+
+from datetime import datetime
+
+from PySide6.QtCore import Qt
+from PySide6.QtCore import QTimer
+from PySide6.QtCore import Signal
+from PySide6.QtGui import QDesktopServices
+from PySide6.QtGui import QEnterEvent
+from PySide6.QtGui import QMouseEvent
+from PySide6.QtCore import QUrl
+from PySide6.QtWidgets import QComboBox
+from PySide6.QtWidgets import QHBoxLayout
+from PySide6.QtWidgets import QLabel
+from PySide6.QtWidgets import QScrollArea
+from PySide6.QtWidgets import QSizePolicy
+from PySide6.QtWidgets import QToolButton
+from PySide6.QtWidgets import QVBoxLayout
+from PySide6.QtWidgets import QWidget
+
+from agents_runner.environments import Environment
+from agents_runner.environments import resolve_environment_github_repo
+from agents_runner.gh.work_items import GitHubWorkItem
+from agents_runner.gh.work_items import add_issue_comment_reaction
+from agents_runner.gh.work_items import list_issue_comments
+from agents_runner.gh.work_items import list_open_issues
+from agents_runner.gh.work_items import list_open_pull_requests
+from agents_runner.prompts import load_prompt
+from agents_runner.ui.dialogs.github_workroom_dialog import GitHubWorkroomDialog
+from agents_runner.ui.lucide_icons import lucide_icon
+from agents_runner.ui.widgets import GlassCard
+
+
+class _GitHubWorkRow(QWidget):
+    clicked = Signal(object)
+    primary_requested = Signal(object)
+    open_requested = Signal(object)
+
+    def __init__(self, *, item_type: str, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._item = None
+        self._item_type = str(item_type or "issue").strip().lower()
+
+        self.setObjectName("TaskRow")
+        self.setAttribute(Qt.WA_StyledBackground, True)
+        self.setProperty("stain", "slate")
+        self.setCursor(Qt.PointingHandCursor)
+        self.setFixedHeight(56)
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(12, 8, 12, 8)
+        layout.setSpacing(10)
+
+        self._title = QLabel("—")
+        self._title.setStyleSheet("font-weight: 650; color: rgba(237, 239, 245, 235);")
+        self._title.setMinimumWidth(260)
+
+        self._state = QLabel("—")
+        self._state.setStyleSheet("color: rgba(237, 239, 245, 190); font-weight: 700;")
+        self._state.setMinimumWidth(110)
+
+        self._meta = QLabel("—")
+        self._meta.setStyleSheet("color: rgba(237, 239, 245, 160);")
+
+        self._btn_primary = QToolButton()
+        self._btn_primary.setObjectName("RowTrash")
+        self._btn_primary.setToolButtonStyle(Qt.ToolButtonIconOnly)
+        self._btn_primary.clicked.connect(
+            lambda: self.primary_requested.emit(self._item)
+        )
+
+        self._btn_open = QToolButton()
+        self._btn_open.setObjectName("RowTrash")
+        self._btn_open.setToolButtonStyle(Qt.ToolButtonIconOnly)
+        self._btn_open.clicked.connect(lambda: self.open_requested.emit(self._item))
+
+        layout.addWidget(self._title, 5)
+        layout.addWidget(self._state, 0)
+        layout.addWidget(self._meta, 4)
+        layout.addWidget(self._btn_primary, 0)
+        layout.addWidget(self._btn_open, 0)
+
+        self._configure_actions()
+        self._set_actions_visible(False)
+
+    def _configure_actions(self) -> None:
+        if self._item_type == "pr":
+            self._btn_primary.setIcon(lucide_icon("git-pull-request"))
+            self._btn_primary.setToolTip("Review PR")
+        else:
+            self._btn_primary.setIcon(lucide_icon("bug"))
+            self._btn_primary.setToolTip("Fix Issue")
+
+        self._btn_open.setIcon(lucide_icon("eye"))
+        self._btn_open.setToolTip("Open workroom")
+
+    def _set_actions_visible(self, visible: bool) -> None:
+        self._btn_primary.setVisible(bool(visible))
+        self._btn_open.setVisible(bool(visible))
+
+    def set_stain(self, stain: str) -> None:
+        value = str(stain or "slate").strip().lower() or "slate"
+        if str(self.property("stain") or "") == value:
+            return
+        self.setProperty("stain", value)
+        self.style().unpolish(self)
+        self.style().polish(self)
+        self.update()
+
+    def set_item(self, item: GitHubWorkItem, *, meta_text: str) -> None:
+        self._item = item
+        prefix = "PR" if item.item_type == "pr" else "Issue"
+        self._title.setText(f"{prefix} #{item.number}: {item.title}")
+
+        state = str(item.state or "").strip().lower()
+        if item.item_type == "pr" and item.is_draft and state == "open":
+            self._state.setText("Draft")
+        else:
+            self._state.setText(state.title() if state else "—")
+
+        self._meta.setText(meta_text)
+
+    def mousePressEvent(self, event: QMouseEvent) -> None:
+        if event.button() == Qt.LeftButton:
+            self.clicked.emit(self._item)
+        super().mousePressEvent(event)
+
+    def enterEvent(self, event: QEnterEvent) -> None:
+        self._set_actions_visible(True)
+        super().enterEvent(event)
+
+    def leaveEvent(self, event) -> None:
+        self._set_actions_visible(False)
+        super().leaveEvent(event)
+
+
+class GitHubWorkListPage(QWidget):
+    environment_changed = Signal(str)
+    prompt_append_requested = Signal(str, str)
+    auto_review_requested = Signal(str, str)
+
+    _fetch_completed = Signal(int, object, str, object, object)
+
+    def __init__(self, *, item_type: str, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        normalized = str(item_type or "").strip().lower()
+        self._item_type = "pr" if normalized == "pr" else "issue"
+
+        self._environments: dict[str, Environment] = {}
+        self._active_env_id = ""
+        self._fetch_seq = 0
+        self._polling_enabled = False
+        self._prefer_browser = False
+        self._confirmation_mode = "always"
+        self._auto_review_enabled = True
+        self._poll_interval_s = 30
+        self._auto_review_seen_comment_ids: set[int] = set()
+
+        self._rows: dict[int, _GitHubWorkRow] = {}
+
+        root = QVBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+        root.setSpacing(14)
+
+        header = GlassCard()
+        header_layout = QHBoxLayout(header)
+        header_layout.setContentsMargins(16, 14, 16, 14)
+        header_layout.setSpacing(10)
+
+        title = "Pull Requests" if self._item_type == "pr" else "Issues"
+        self._title = QLabel(title)
+        self._title.setStyleSheet("font-size: 16px; font-weight: 750;")
+
+        self._environment = QComboBox()
+        self._environment.setFixedWidth(260)
+        self._environment.currentIndexChanged.connect(self._on_environment_changed)
+
+        self._refresh = QToolButton()
+        self._refresh.setText("Refresh")
+        self._refresh.setIcon(lucide_icon("refresh-cw"))
+        self._refresh.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        self._refresh.clicked.connect(self.refresh)
+
+        header_layout.addWidget(self._title)
+        header_layout.addStretch(1)
+        header_layout.addWidget(self._environment)
+        header_layout.addWidget(self._refresh)
+        root.addWidget(header)
+
+        card = GlassCard()
+        card_layout = QVBoxLayout(card)
+        card_layout.setContentsMargins(0, 12, 0, 12)
+        card_layout.setSpacing(8)
+
+        columns = QWidget()
+        columns_layout = QHBoxLayout(columns)
+        columns_layout.setContentsMargins(12, 0, 12, 0)
+        columns_layout.setSpacing(12)
+
+        c1 = QLabel("Item")
+        c1.setStyleSheet("color: rgba(237, 239, 245, 150); font-weight: 650;")
+        c1.setMinimumWidth(260)
+        c2 = QLabel("State")
+        c2.setStyleSheet("color: rgba(237, 239, 245, 150); font-weight: 650;")
+        c2.setMinimumWidth(110)
+        c3 = QLabel("Info")
+        c3.setStyleSheet("color: rgba(237, 239, 245, 150); font-weight: 650;")
+
+        columns_layout.addWidget(c1, 5)
+        columns_layout.addWidget(c2, 0)
+        columns_layout.addWidget(c3, 4)
+
+        self._scroll = QScrollArea()
+        self._scroll.setWidgetResizable(True)
+        self._scroll.setFrameShape(QScrollArea.NoFrame)
+        self._scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self._scroll.setObjectName("TaskScroll")
+
+        self._list = QWidget()
+        self._list.setObjectName("TaskList")
+        self._list_layout = QVBoxLayout(self._list)
+        self._list_layout.setContentsMargins(12, 8, 12, 8)
+        self._list_layout.setSpacing(6)
+        self._list_layout.addStretch(1)
+        self._scroll.setWidget(self._list)
+
+        self._status = QLabel("Select an environment to load data.")
+        self._status.setStyleSheet("color: rgba(237, 239, 245, 160);")
+
+        card_layout.addWidget(columns)
+        card_layout.addWidget(self._scroll, 1)
+        card_layout.addWidget(self._status)
+        root.addWidget(card, 1)
+
+        self._poll_timer = QTimer(self)
+        self._poll_timer.setInterval(max(5, int(self._poll_interval_s)) * 1000)
+        self._poll_timer.timeout.connect(self.refresh)
+
+        self._fetch_completed.connect(self._on_fetch_completed)
+
+    def set_settings_data(self, settings_data: dict[str, object]) -> None:
+        settings = dict(settings_data or {})
+        self._prefer_browser = bool(
+            settings.get("github_workroom_prefer_browser") or False
+        )
+        self._confirmation_mode = (
+            str(settings.get("github_write_confirmation_mode") or "always")
+            .strip()
+            .lower()
+        )
+        self._auto_review_enabled = bool(
+            settings.get("agentsnova_auto_review_enabled", True)
+        )
+
+        try:
+            interval = int(settings.get("github_poll_interval_s", 30))
+        except Exception:
+            interval = 30
+        self._poll_interval_s = max(5, interval)
+        self._poll_timer.setInterval(self._poll_interval_s * 1000)
+
+    def set_polling_enabled(self, enabled: bool) -> None:
+        self._polling_enabled = bool(enabled)
+        if self._polling_enabled:
+            self._poll_timer.start()
+            self.refresh()
+            return
+        self._poll_timer.stop()
+
+    def set_environments(self, envs: dict[str, Environment], active_id: str) -> None:
+        self._environments = dict(envs or {})
+        desired = str(active_id or "").strip()
+
+        self._environment.blockSignals(True)
+        try:
+            self._environment.clear()
+            ordered = sorted(
+                self._environments.values(),
+                key=lambda e: (str(e.name or e.env_id).lower(), str(e.env_id).lower()),
+            )
+            for env in ordered:
+                self._environment.addItem(env.name or env.env_id, env.env_id)
+
+            idx = self._environment.findData(desired)
+            if idx < 0 and self._environment.count() > 0:
+                idx = 0
+            if idx >= 0:
+                self._environment.setCurrentIndex(idx)
+        finally:
+            self._environment.blockSignals(False)
+
+        if self._environment.count() > 0:
+            self._active_env_id = str(self._environment.currentData() or "")
+
+    def set_active_environment_id(self, env_id: str) -> None:
+        desired = str(env_id or "").strip()
+        if not desired:
+            return
+        idx = self._environment.findData(desired)
+        if idx >= 0 and self._environment.currentIndex() != idx:
+            self._environment.setCurrentIndex(idx)
+            return
+        self._active_env_id = desired
+
+    def _on_environment_changed(self, _index: int) -> None:
+        self._active_env_id = str(self._environment.currentData() or "")
+        self.environment_changed.emit(self._active_env_id)
+        self.refresh()
+
+    def refresh(self) -> None:
+        env_id = str(
+            self._active_env_id or self._environment.currentData() or ""
+        ).strip()
+        if not env_id:
+            self._status.setText("Select an environment to load data.")
+            self._clear_rows()
+            return
+
+        self._fetch_seq += 1
+        seq = int(self._fetch_seq)
+        queued_snapshot = set(self._auto_review_seen_comment_ids)
+        auto_review_enabled = bool(
+            self._auto_review_enabled and self._item_type == "pr"
+        )
+
+        self._status.setText("Loading...")
+
+        worker = threading.Thread(
+            target=self._fetch_worker,
+            args=(seq, env_id, queued_snapshot, auto_review_enabled),
+            daemon=True,
+        )
+        worker.start()
+
+    def _fetch_worker(
+        self,
+        seq: int,
+        env_id: str,
+        queued_snapshot: set[int],
+        auto_review_enabled: bool,
+    ) -> None:
+        repo_context = None
+        items: list[GitHubWorkItem] = []
+        auto_reviews: list[dict[str, object]] = []
+        error = ""
+
+        try:
+            env = self._environments.get(env_id)
+            repo_context = resolve_environment_github_repo(env)
+            if repo_context is None:
+                self._fetch_completed.emit(seq, items, "", None, auto_reviews)
+                return
+
+            if self._item_type == "pr":
+                items = list_open_pull_requests(
+                    repo_context.repo_owner,
+                    repo_context.repo_name,
+                    limit=30,
+                )
+            else:
+                items = list_open_issues(
+                    repo_context.repo_owner,
+                    repo_context.repo_name,
+                    limit=30,
+                )
+
+            if auto_review_enabled:
+                auto_reviews = self._collect_auto_reviews(
+                    repo_owner=repo_context.repo_owner,
+                    repo_name=repo_context.repo_name,
+                    items=items,
+                    queued_snapshot=queued_snapshot,
+                )
+        except Exception as exc:
+            error = str(exc)
+
+        self._fetch_completed.emit(seq, items, error, repo_context, auto_reviews)
+
+    def _collect_auto_reviews(
+        self,
+        *,
+        repo_owner: str,
+        repo_name: str,
+        items: list[GitHubWorkItem],
+        queued_snapshot: set[int],
+    ) -> list[dict[str, object]]:
+        results: list[dict[str, object]] = []
+
+        for item in items:
+            comments = list_issue_comments(
+                repo_owner,
+                repo_name,
+                issue_number=item.number,
+                limit=100,
+            )
+            comments = list(comments)
+            comments.reverse()
+
+            for comment in comments:
+                body = str(comment.body or "")
+                if "@agentsnova" not in body.lower():
+                    continue
+
+                if comment.comment_id in queued_snapshot:
+                    continue
+
+                reactions = comment.reactions
+                if reactions.thumbs_up > 0 or reactions.thumbs_down > 0:
+                    continue
+                if reactions.eyes > 0:
+                    continue
+
+                try:
+                    add_issue_comment_reaction(
+                        repo_owner,
+                        repo_name,
+                        comment_id=comment.comment_id,
+                        reaction="eyes",
+                    )
+                except Exception:
+                    continue
+
+                results.append(
+                    {
+                        "comment_id": comment.comment_id,
+                        "pr_number": item.number,
+                        "pr_url": item.url,
+                        "pr_title": item.title,
+                    }
+                )
+
+                if len(results) >= 3:
+                    return results
+                break
+
+        return results
+
+    def _format_time(self, value: str) -> str:
+        text = str(value or "").strip()
+        if not text:
+            return "—"
+        try:
+            parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+            return parsed.strftime("%Y-%m-%d %H:%M")
+        except Exception:
+            return text
+
+    def _clear_rows(self) -> None:
+        while self._list_layout.count() > 1:
+            item = self._list_layout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
+        self._rows.clear()
+
+    def _render_rows(self, items: list[GitHubWorkItem], *, stain: str) -> None:
+        self._clear_rows()
+
+        for item in items:
+            row = _GitHubWorkRow(item_type=self._item_type)
+            row.set_stain(stain)
+            row.set_item(
+                item,
+                meta_text=(
+                    f"by {item.author or 'unknown'}  |  updated {self._format_time(item.updated_at)}"
+                ),
+            )
+            row.clicked.connect(self._open_item)
+            row.open_requested.connect(self._open_item)
+            row.primary_requested.connect(self._request_prompt_from_item)
+            self._list_layout.insertWidget(self._list_layout.count() - 1, row)
+            self._rows[item.number] = row
+
+    def _open_item(self, item: object) -> None:
+        if not isinstance(item, GitHubWorkItem):
+            return
+
+        if self._prefer_browser and item.url:
+            QDesktopServices.openUrl(QUrl(item.url))
+            return
+
+        repo_context = resolve_environment_github_repo(
+            self._environments.get(self._active_env_id)
+        )
+        if repo_context is None:
+            return
+
+        dialog = GitHubWorkroomDialog(
+            repo_owner=repo_context.repo_owner,
+            repo_name=repo_context.repo_name,
+            item_type=item.item_type,
+            number=item.number,
+            confirmation_mode=self._confirmation_mode,
+            parent=self,
+        )
+        dialog.prompt_requested.connect(
+            lambda prompt: self.prompt_append_requested.emit(
+                self._active_env_id, prompt
+            )
+        )
+        dialog.exec()
+
+    def _request_prompt_from_item(self, item: object) -> None:
+        if not isinstance(item, GitHubWorkItem):
+            return
+
+        repo_context = resolve_environment_github_repo(
+            self._environments.get(self._active_env_id)
+        )
+        repo_owner = str(getattr(repo_context, "repo_owner", "") or "")
+        repo_name = str(getattr(repo_context, "repo_name", "") or "")
+
+        if item.item_type == "pr":
+            prompt = load_prompt(
+                "pr_review_template",
+                REPO_OWNER=repo_owner,
+                REPO_NAME=repo_name,
+                PR_NUMBER=item.number,
+                PR_URL=item.url,
+                PR_TITLE=item.title,
+                MENTION_COMMENT_ID="",
+            ).strip()
+        else:
+            prompt = load_prompt(
+                "issue_fix_template",
+                REPO_OWNER=repo_owner,
+                REPO_NAME=repo_name,
+                ISSUE_NUMBER=item.number,
+                ISSUE_URL=item.url,
+                ISSUE_TITLE=item.title,
+            ).strip()
+
+        if not prompt:
+            return
+
+        self.prompt_append_requested.emit(self._active_env_id, prompt)
+
+    def _on_fetch_completed(
+        self,
+        seq: int,
+        items: object,
+        error: str,
+        repo_context: object,
+        auto_reviews: object,
+    ) -> None:
+        if int(seq) != int(self._fetch_seq):
+            return
+
+        if repo_context is None:
+            self._clear_rows()
+            self._status.setText("GitHub is unavailable for this environment.")
+            return
+
+        rows = [
+            item
+            for item in (items if isinstance(items, list) else [])
+            if isinstance(item, GitHubWorkItem)
+        ]
+        env = self._environments.get(self._active_env_id)
+        stain = str(getattr(env, "color", "slate") or "slate").strip().lower()
+
+        if error:
+            self._clear_rows()
+            self._status.setText(f"Load failed: {error}")
+            return
+
+        self._render_rows(rows, stain=stain)
+        kind = "pull request" if self._item_type == "pr" else "issue"
+        if rows:
+            self._status.setText(f"Loaded {len(rows)} open {kind}(s).")
+        else:
+            self._status.setText(f"No open {kind}s found.")
+
+        reviews = auto_reviews if isinstance(auto_reviews, list) else []
+        for review in reviews:
+            if not isinstance(review, dict):
+                continue
+
+            comment_id = int(review.get("comment_id") or 0)
+            if comment_id <= 0 or comment_id in self._auto_review_seen_comment_ids:
+                continue
+
+            pr_number = int(review.get("pr_number") or 0)
+            pr_url = str(review.get("pr_url") or "").strip()
+            pr_title = str(review.get("pr_title") or "").strip()
+
+            prompt = load_prompt(
+                "pr_review_template",
+                REPO_OWNER=str(getattr(repo_context, "repo_owner", "") or ""),
+                REPO_NAME=str(getattr(repo_context, "repo_name", "") or ""),
+                PR_NUMBER=pr_number,
+                PR_URL=pr_url,
+                PR_TITLE=pr_title,
+                MENTION_COMMENT_ID=comment_id,
+            ).strip()
+            if not prompt:
+                continue
+
+            self._auto_review_seen_comment_ids.add(comment_id)
+            self.auto_review_requested.emit(self._active_env_id, prompt)

--- a/agents_runner/ui/pages/new_task.py
+++ b/agents_runner/ui/pages/new_task.py
@@ -933,5 +933,21 @@ class NewTaskPage(QWidget):
         self._prompt.setPlainText("")
         self._prompt.setFocus(Qt.OtherFocusReason)
 
+    def append_prompt_text(self, text: str) -> None:
+        addition = str(text or "").strip()
+        if not addition:
+            return
+
+        current = str(self._prompt.toPlainText() or "").rstrip()
+        if current:
+            combined = f"{current}\n\n{addition}"
+        else:
+            combined = addition
+        self._prompt.setPlainText(combined)
+        cursor = self._prompt.textCursor()
+        cursor.movePosition(QTextCursor.End)
+        self._prompt.setTextCursor(cursor)
+        self._prompt.setFocus(Qt.OtherFocusReason)
+
     def focus_prompt(self) -> None:
         self._prompt.setFocus(Qt.OtherFocusReason)

--- a/agents_runner/ui/pages/settings.py
+++ b/agents_runner/ui/pages/settings.py
@@ -146,12 +146,15 @@ class SettingsPage(QWidget, _SettingsFormMixin):
             self._ui_theme,
             self._radio_channel,
             self._radio_quality,
+            self._github_write_confirmation_mode,
         ):
             combo.currentIndexChanged.connect(self._trigger_immediate_autosave)
 
         for checkbox in (
             self._preflight_enabled,
             self._append_pixelarch_context,
+            self._github_workroom_prefer_browser,
+            self._agentsnova_auto_review_enabled,
             self._headless_desktop_enabled,
             self._gh_context_default,
             self._spellcheck_enabled,

--- a/agents_runner/ui/pages/settings_form.py
+++ b/agents_runner/ui/pages/settings_form.py
@@ -184,6 +184,32 @@ class _SettingsFormMixin:
             "Mounts ~/.cache to speed up package manager installs across environments."
         )
 
+        self._github_workroom_prefer_browser = QCheckBox(
+            "Prefer browser for GitHub workroom"
+        )
+        self._github_workroom_prefer_browser.setToolTip(
+            "When enabled, opening an issue or pull request goes directly to the system browser."
+        )
+
+        self._github_write_confirmation_mode = QComboBox()
+        self._github_write_confirmation_mode.addItem("Always confirm", "always")
+        self._github_write_confirmation_mode.addItem(
+            "Confirm destructive only",
+            "destructive_only",
+        )
+        self._github_write_confirmation_mode.addItem("No confirmations", "never")
+        self._github_write_confirmation_mode.setToolTip(
+            "Controls confirmation prompts for GitHub write actions "
+            "(open/close, comments, reaction markers)."
+        )
+
+        self._agentsnova_auto_review_enabled = QCheckBox(
+            "Enable @agentsnova auto-review queueing"
+        )
+        self._agentsnova_auto_review_enabled.setToolTip(
+            "When enabled, PR comments that mention @agentsnova can auto-queue review tasks."
+        )
+
         self._preflight_script = QPlainTextEdit()
         self._preflight_script.setPlaceholderText(
             "#!/usr/bin/env bash\n"
@@ -276,6 +302,16 @@ class _SettingsFormMixin:
         general_body.addWidget(self._spellcheck_enabled)
         general_body.addWidget(self._gh_context_default)
         general_body.addWidget(self._append_pixelarch_context)
+        general_body.addWidget(self._github_workroom_prefer_browser)
+        general_body.addWidget(self._agentsnova_auto_review_enabled)
+
+        github_write_layout = QGridLayout()
+        github_write_layout.setHorizontalSpacing(GRID_HORIZONTAL_SPACING)
+        github_write_layout.setVerticalSpacing(GRID_VERTICAL_SPACING)
+        github_write_layout.setColumnStretch(1, 1)
+        github_write_layout.addWidget(QLabel("GitHub write confirmations"), 0, 0)
+        github_write_layout.addWidget(self._github_write_confirmation_mode, 0, 1)
+        general_body.addLayout(github_write_layout)
         general_body.addStretch(1)
         self._register_page("general_preferences", general_page)
 
@@ -700,8 +736,22 @@ class _SettingsFormMixin:
             self._append_pixelarch_context.setChecked(
                 bool(settings.get("append_pixelarch_context") or False)
             )
+            self._github_workroom_prefer_browser.setChecked(
+                bool(settings.get("github_workroom_prefer_browser") or False)
+            )
+            self._agentsnova_auto_review_enabled.setChecked(
+                bool(settings.get("agentsnova_auto_review_enabled", True))
+            )
             self._headless_desktop_enabled.setChecked(
                 bool(settings.get("headless_desktop_enabled") or False)
+            )
+            confirmation_mode = str(
+                settings.get("github_write_confirmation_mode") or "always"
+            ).strip()
+            self._set_combo_value(
+                self._github_write_confirmation_mode,
+                confirmation_mode,
+                fallback="always",
             )
             self._gh_context_default.setChecked(
                 bool(settings.get("gh_context_default_enabled") or False)
@@ -776,6 +826,15 @@ class _SettingsFormMixin:
             "preflight_script": str(self._preflight_script.toPlainText() or ""),
             "append_pixelarch_context": bool(
                 self._append_pixelarch_context.isChecked()
+            ),
+            "github_workroom_prefer_browser": bool(
+                self._github_workroom_prefer_browser.isChecked()
+            ),
+            "github_write_confirmation_mode": str(
+                self._github_write_confirmation_mode.currentData() or "always"
+            ),
+            "agentsnova_auto_review_enabled": bool(
+                self._agentsnova_auto_review_enabled.isChecked()
             ),
             "headless_desktop_enabled": bool(
                 self._headless_desktop_enabled.isChecked()

--- a/agents_runner/ui/pages/settings_form.py
+++ b/agents_runner/ui/pages/settings_form.py
@@ -207,7 +207,7 @@ class _SettingsFormMixin:
             "Enable @agentsnova auto-review queueing"
         )
         self._agentsnova_auto_review_enabled.setToolTip(
-            "When enabled, PR comments that mention @agentsnova can auto-queue review tasks."
+            "When enabled, PR/Issue mentions of @agentsnova can auto-queue tasks."
         )
 
         self._preflight_script = QPlainTextEdit()

--- a/agents_runner/ui/pages/tasks.py
+++ b/agents_runner/ui/pages/tasks.py
@@ -417,34 +417,44 @@ class TasksPage(QWidget):
             "\n".join(
                 [
                     "QWidget#SettingsNavPanel {",
-                    f"  background-color: rgba({r}, {g}, {b}, 26);",
-                    f"  border: 1px solid rgba({r}, {g}, {b}, 92);",
+                    "  background-color: rgba(18, 20, 28, 185);",
+                    f"  border: 1px solid rgba({r}, {g}, {b}, 110);",
                     "  border-radius: 0px;",
                     "}",
                     "QToolButton#SettingsNavButton {",
-                    f"  border: 1px solid rgba({r}, {g}, {b}, 76);",
-                    f"  background-color: rgba({r}, {g}, {b}, 18);",
-                    "  color: rgba(237, 239, 245, 224);",
+                    f"  border: 1px solid rgba({r}, {g}, {b}, 88);",
+                    "  background-color: rgba(18, 20, 28, 148);",
+                    "  color: rgba(237, 239, 245, 220);",
                     "  border-radius: 0px;",
                     "  text-align: left;",
                     "  padding: 9px 10px;",
                     "  font-weight: 620;",
                     "}",
                     "QToolButton#SettingsNavButton:hover {",
-                    f"  border: 1px solid rgba({r}, {g}, {b}, 132);",
-                    f"  background-color: rgba({r}, {g}, {b}, 34);",
+                    f"  border: 1px solid rgba({r}, {g}, {b}, 140);",
+                    f"  background-color: rgba({r}, {g}, {b}, 28);",
                     "}",
                     "QToolButton#SettingsNavButton:checked {",
-                    f"  border: 1px solid rgba({r}, {g}, {b}, 170);",
-                    f"  background-color: rgba({r}, {g}, {b}, 62);",
+                    f"  border: 1px solid rgba({r}, {g}, {b}, 176);",
+                    f"  background-color: rgba({r}, {g}, {b}, 54);",
                     "}",
                     "QToolButton#SettingsNavButton:checked:hover {",
-                    f"  border: 1px solid rgba({r}, {g}, {b}, 190);",
-                    f"  background-color: rgba({r}, {g}, {b}, 82);",
+                    f"  border: 1px solid rgba({r}, {g}, {b}, 194);",
+                    f"  background-color: rgba({r}, {g}, {b}, 72);",
                     "}",
                 ]
             )
         )
+
+    def _effective_page_width(self) -> int:
+        width = int(self.width())
+        win = self.window()
+        if win is not None and win is not self:
+            try:
+                width = max(width, int(win.width()))
+            except Exception:
+                pass
+        return max(width, 0)
 
     def _set_nav_panel_visible(
         self, visible: bool, *, animate: bool, collapse_host: bool
@@ -647,7 +657,7 @@ class TasksPage(QWidget):
             )
             return
 
-        compact = self.width() < 1080
+        compact = self._effective_page_width() < 1080
         mode_changed = compact != self._compact_mode
         self._compact_mode = compact
 

--- a/agents_runner/ui/pages/tasks.py
+++ b/agents_runner/ui/pages/tasks.py
@@ -64,8 +64,6 @@ class TasksPage(QWidget):
         self._last_support_state: bool | None = None
         self._has_animated_supported_slide_in = False
         self._pending_supported_slide_in = False
-        self._pr_status_text = "Select an environment to load data."
-        self._issue_status_text = "Select an environment to load data."
 
         self._pane_animation: QParallelAnimationGroup | None = None
         self._pane_rest_pos: QPoint | None = None
@@ -92,13 +90,9 @@ class TasksPage(QWidget):
         self._title.setStyleSheet("font-size: 18px; font-weight: 750;")
         self._subtitle = QLabel("Workflow")
         self._subtitle.setObjectName("SettingsPaneSubtitle")
-        self._sub_subtitle = QLabel("")
-        self._sub_subtitle.setObjectName("SettingsPaneSubtitle")
-        self._sub_subtitle.setStyleSheet("color: rgba(237, 239, 245, 145);")
 
         header_layout.addWidget(self._title)
         header_layout.addWidget(self._subtitle)
-        header_layout.addWidget(self._sub_subtitle)
         header_layout.addStretch(1)
         layout.addWidget(header)
 
@@ -152,8 +146,6 @@ class TasksPage(QWidget):
 
         self._prs = GitHubWorkListPage(item_type="pr")
         self._issues = GitHubWorkListPage(item_type="issue")
-        self._pr_status_text = self._prs.current_status_text()
-        self._issue_status_text = self._issues.current_status_text()
 
         self._build_pages()
         self._build_navigation(nav_layout)
@@ -164,8 +156,6 @@ class TasksPage(QWidget):
         )
         self._prs.environment_changed.connect(self._on_work_environment_changed)
         self._issues.environment_changed.connect(self._on_work_environment_changed)
-        self._prs.status_text_changed.connect(self._on_pr_status_text_changed)
-        self._issues.status_text_changed.connect(self._on_issue_status_text_changed)
 
         self._prs.prompt_append_requested.connect(self._append_prompt_to_new_task)
         self._issues.prompt_append_requested.connect(self._append_prompt_to_new_task)
@@ -330,26 +320,6 @@ class TasksPage(QWidget):
             self._subtitle.setText("Issues")
         else:
             self._subtitle.setText("Workflow")
-        self._sync_sub_subtitle()
-
-    def _sync_sub_subtitle(self) -> None:
-        if self._active_pane_key == "pull_requests":
-            self._sub_subtitle.setText(self._pr_status_text)
-            return
-        if self._active_pane_key == "issues":
-            self._sub_subtitle.setText(self._issue_status_text)
-            return
-        self._sub_subtitle.setText("")
-
-    def _on_pr_status_text_changed(self, text: str) -> None:
-        self._pr_status_text = str(text or "")
-        if self._active_pane_key == "pull_requests":
-            self._sync_sub_subtitle()
-
-    def _on_issue_status_text_changed(self, text: str) -> None:
-        self._issue_status_text = str(text or "")
-        if self._active_pane_key == "issues":
-            self._sync_sub_subtitle()
 
     def _set_current_pane(self, key: str, *, animate: bool) -> None:
         target_index = self._pane_index_by_key.get(key)

--- a/agents_runner/ui/pages/tasks.py
+++ b/agents_runner/ui/pages/tasks.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import QTabWidget
+from PySide6.QtWidgets import QVBoxLayout
+from PySide6.QtWidgets import QWidget
+
+from agents_runner.environments import Environment
+from agents_runner.environments import resolve_environment_github_repo
+from agents_runner.ui.pages.github_work_list import GitHubWorkListPage
+from agents_runner.ui.pages.new_task import NewTaskPage
+
+
+class TasksPage(QWidget):
+    auto_review_requested = Signal(str, str)
+
+    def __init__(
+        self,
+        *,
+        new_task_page: NewTaskPage,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._new_task = new_task_page
+        self._environments: dict[str, Environment] = {}
+        self._active_env_id = ""
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        self._tabs = QTabWidget()
+        self._tabs.setDocumentMode(True)
+        self._tabs.tabBar().setDrawBase(False)
+        self._tabs.currentChanged.connect(self._on_tab_changed)
+
+        self._prs = GitHubWorkListPage(item_type="pr")
+        self._issues = GitHubWorkListPage(item_type="issue")
+
+        self._new_task_tab_index = self._tabs.addTab(self._new_task, "New Task")
+        self._pr_tab_index = self._tabs.addTab(self._prs, "Pull Requests")
+        self._issues_tab_index = self._tabs.addTab(self._issues, "Issues")
+
+        self._new_task.environment_changed.connect(
+            self._on_new_task_environment_changed
+        )
+        self._prs.environment_changed.connect(self._on_work_environment_changed)
+        self._issues.environment_changed.connect(self._on_work_environment_changed)
+
+        self._prs.prompt_append_requested.connect(self._append_prompt_to_new_task)
+        self._issues.prompt_append_requested.connect(self._append_prompt_to_new_task)
+
+        self._prs.auto_review_requested.connect(self.auto_review_requested.emit)
+        self._issues.auto_review_requested.connect(self.auto_review_requested.emit)
+
+        layout.addWidget(self._tabs, 1)
+        self._set_work_tabs_visible(False)
+
+    def _set_work_tabs_visible(self, visible: bool) -> None:
+        tab_bar = self._tabs.tabBar()
+        if hasattr(tab_bar, "setTabVisible"):
+            tab_bar.setTabVisible(self._pr_tab_index, bool(visible))
+            tab_bar.setTabVisible(self._issues_tab_index, bool(visible))
+        else:
+            self._tabs.setTabEnabled(self._pr_tab_index, bool(visible))
+            self._tabs.setTabEnabled(self._issues_tab_index, bool(visible))
+
+        if not visible and self._tabs.currentIndex() != self._new_task_tab_index:
+            self._tabs.setCurrentIndex(self._new_task_tab_index)
+
+        self._on_tab_changed(self._tabs.currentIndex())
+
+    def _on_tab_changed(self, index: int) -> None:
+        self._prs.set_polling_enabled(index == self._pr_tab_index)
+        self._issues.set_polling_enabled(index == self._issues_tab_index)
+
+    def _sync_visibility_for_active_environment(self) -> None:
+        env = self._environments.get(self._active_env_id)
+        is_supported = resolve_environment_github_repo(env) is not None
+        self._set_work_tabs_visible(is_supported)
+
+    def set_environments(self, envs: dict[str, Environment], active_id: str) -> None:
+        self._environments = dict(envs or {})
+        self._active_env_id = str(active_id or "").strip()
+
+        self._prs.set_environments(self._environments, self._active_env_id)
+        self._issues.set_environments(self._environments, self._active_env_id)
+
+        self._sync_visibility_for_active_environment()
+
+    def set_settings_data(self, settings_data: dict[str, object]) -> None:
+        self._prs.set_settings_data(settings_data)
+        self._issues.set_settings_data(settings_data)
+
+    def show_new_task_tab(self, *, focus_prompt: bool = True) -> None:
+        self._tabs.setCurrentIndex(self._new_task_tab_index)
+        if focus_prompt:
+            self._new_task.focus_prompt()
+
+    def _append_prompt_to_new_task(self, env_id: str, prompt: str) -> None:
+        target_env_id = str(env_id or "").strip()
+        if target_env_id:
+            self._new_task.set_environment_id(target_env_id)
+
+        self._new_task.append_prompt_text(prompt)
+        self.show_new_task_tab(focus_prompt=True)
+
+    def _on_new_task_environment_changed(self, env_id: str) -> None:
+        env_id = str(env_id or "").strip()
+        self._active_env_id = env_id
+        self._prs.set_active_environment_id(env_id)
+        self._issues.set_active_environment_id(env_id)
+        self._sync_visibility_for_active_environment()
+
+    def _on_work_environment_changed(self, env_id: str) -> None:
+        env_id = str(env_id or "").strip()
+        if env_id:
+            self._new_task.set_environment_id(env_id)
+
+    def is_new_task_tab_active(self) -> bool:
+        return self._tabs.currentIndex() == self._new_task_tab_index

--- a/agents_runner/ui/pages/tasks.py
+++ b/agents_runner/ui/pages/tasks.py
@@ -182,6 +182,11 @@ class TasksPage(QWidget):
             ),
         ]
 
+    def _left_nav_specs(self) -> list[_TasksPaneSpec]:
+        by_key = {spec.key: spec for spec in self._pane_specs}
+        order = ("new_task", "issues", "pull_requests")
+        return [by_key[key] for key in order if key in by_key]
+
     def _visible_pane_specs(self) -> list[_TasksPaneSpec]:
         if self._github_supported:
             return list(self._pane_specs)
@@ -205,7 +210,7 @@ class TasksPage(QWidget):
             self._pane_index_by_key[spec.key] = index
 
     def _build_navigation(self, nav_layout: QVBoxLayout) -> None:
-        for spec in self._pane_specs:
+        for spec in self._left_nav_specs():
             button = QToolButton()
             button.setObjectName("SettingsNavButton")
             button.setText(spec.title)

--- a/agents_runner/ui/pages/tasks.py
+++ b/agents_runner/ui/pages/tasks.py
@@ -32,7 +32,6 @@ class TasksPage(QWidget):
         self._tabs = QTabWidget()
         self._tabs.setDocumentMode(True)
         self._tabs.tabBar().setDrawBase(False)
-        self._tabs.currentChanged.connect(self._on_tab_changed)
 
         self._prs = GitHubWorkListPage(item_type="pr")
         self._issues = GitHubWorkListPage(item_type="issue")
@@ -40,6 +39,7 @@ class TasksPage(QWidget):
         self._new_task_tab_index = self._tabs.addTab(self._new_task, "New Task")
         self._pr_tab_index = self._tabs.addTab(self._prs, "Pull Requests")
         self._issues_tab_index = self._tabs.addTab(self._issues, "Issues")
+        self._tabs.currentChanged.connect(self._on_tab_changed)
 
         self._new_task.environment_changed.connect(
             self._on_new_task_environment_changed

--- a/agents_runner/ui/pages/tasks.py
+++ b/agents_runner/ui/pages/tasks.py
@@ -64,6 +64,8 @@ class TasksPage(QWidget):
         self._last_support_state: bool | None = None
         self._has_animated_supported_slide_in = False
         self._pending_supported_slide_in = False
+        self._pr_status_text = "Select an environment to load data."
+        self._issue_status_text = "Select an environment to load data."
 
         self._pane_animation: QParallelAnimationGroup | None = None
         self._pane_rest_pos: QPoint | None = None
@@ -90,9 +92,13 @@ class TasksPage(QWidget):
         self._title.setStyleSheet("font-size: 18px; font-weight: 750;")
         self._subtitle = QLabel("Workflow")
         self._subtitle.setObjectName("SettingsPaneSubtitle")
+        self._sub_subtitle = QLabel("")
+        self._sub_subtitle.setObjectName("SettingsPaneSubtitle")
+        self._sub_subtitle.setStyleSheet("color: rgba(237, 239, 245, 145);")
 
         header_layout.addWidget(self._title)
         header_layout.addWidget(self._subtitle)
+        header_layout.addWidget(self._sub_subtitle)
         header_layout.addStretch(1)
         layout.addWidget(header)
 
@@ -146,6 +152,8 @@ class TasksPage(QWidget):
 
         self._prs = GitHubWorkListPage(item_type="pr")
         self._issues = GitHubWorkListPage(item_type="issue")
+        self._pr_status_text = self._prs.current_status_text()
+        self._issue_status_text = self._issues.current_status_text()
 
         self._build_pages()
         self._build_navigation(nav_layout)
@@ -156,6 +164,8 @@ class TasksPage(QWidget):
         )
         self._prs.environment_changed.connect(self._on_work_environment_changed)
         self._issues.environment_changed.connect(self._on_work_environment_changed)
+        self._prs.status_text_changed.connect(self._on_pr_status_text_changed)
+        self._issues.status_text_changed.connect(self._on_issue_status_text_changed)
 
         self._prs.prompt_append_requested.connect(self._append_prompt_to_new_task)
         self._issues.prompt_append_requested.connect(self._append_prompt_to_new_task)
@@ -320,6 +330,26 @@ class TasksPage(QWidget):
             self._subtitle.setText("Issues")
         else:
             self._subtitle.setText("Workflow")
+        self._sync_sub_subtitle()
+
+    def _sync_sub_subtitle(self) -> None:
+        if self._active_pane_key == "pull_requests":
+            self._sub_subtitle.setText(self._pr_status_text)
+            return
+        if self._active_pane_key == "issues":
+            self._sub_subtitle.setText(self._issue_status_text)
+            return
+        self._sub_subtitle.setText("")
+
+    def _on_pr_status_text_changed(self, text: str) -> None:
+        self._pr_status_text = str(text or "")
+        if self._active_pane_key == "pull_requests":
+            self._sync_sub_subtitle()
+
+    def _on_issue_status_text_changed(self, text: str) -> None:
+        self._issue_status_text = str(text or "")
+        if self._active_pane_key == "issues":
+            self._sync_sub_subtitle()
 
     def _set_current_pane(self, key: str, *, animate: bool) -> None:
         target_index = self._pane_index_by_key.get(key)


### PR DESCRIPTION
## Summary
- Replaced top-nav `New task` flow with a `Tasks` hub while preserving existing New Task behavior.
- Added `Tasks` tabs: `New Task`, `Pull Requests`, and `Issues`.
- `Pull Requests` and `Issues` tabs are conditionally visible only when the selected environment resolves to a GitHub repository.
- Mounted environments are git-checked; mounted non-GitHub repos are treated as unsupported and PR/Issues tabs are hidden.
- Added GitHub work item integration for listing/opening PRs and issues, reading comments/reactions, posting comments, and open/close actions.
- Added a native GitHub workroom dialog with timeline view, comment bar, open/close actions, and prompt handoff actions (`Fix Issue` / `Review PR`).
- Added baked prompt templates for issue-fix and PR-review task generation.
- Added auto-queue support for `@agentsnova` mentions across both PRs and issues.
  - comment mentions use reaction guard markers to avoid retrigger
  - body/title mentions are supported with item-level dedupe guard
- Mention-triggered flows now auto-start tasks directly (not New Task draft append).
- Manual `Fix Issue` / `Review PR` flows remain draft-style prompt append to New Task.
- Added settings for:
  - prefer browser for workroom opening
  - GitHub write confirmation mode (`always`, `destructive_only`, `never`)
  - enable/disable `@agentsnova` auto-review queueing
- Added browser fallback resilience so opening in browser remains available if native workroom loading fails.
- Fixed a startup init-order crash in Tasks tab wiring (`_pr_tab_index` access before initialization).

## UI/UX Notes
- Refactored Tasks page to match Settings/Environments 2-panel navigation behavior.
- In unsupported environments, PR/Issues nav is removed and Tasks cleanly falls back to one-panel New Task view.
- Updated Tasks nav transition behavior so panel jitter/grow artifacts are eliminated.
- PR/Issues nav buttons now fade only on real GitHub support state flips.
- Reordered left Tasks nav to `New Task`, `Issues`, `Pull Requests` (compact dropdown order unchanged).
- Workroom primary actions (`Fix Issue` / `Review PR`) now close the workroom after prompt handoff.
- Added Environments-style task-level tint overlay and compact selector tinting so Tasks-internal surfaces inherit active environment stain while leaving the app's top nav bar unchanged.
- Reused Active Tasks visual language for PR/Issue rows and list scaffolding.
- Kept square-corner styling behavior consistent with existing UI standards.

## Prompting Contract
- `pr_review_template` now includes `TRIGGER_SOURCE` and `MENTION_COMMENT_ID`.
- `issue_fix_template` now includes `TRIGGER_SOURCE` and `MENTION_COMMENT_ID`.
- PR mention-comment guard remains `eyes` + thumbs-up/down check.
- Issue mention-comment guard uses `rocket`/`hooray` + thumbs-up/down check and writes `rocket` marker when claiming.

## Validation
- `uv run ruff check agents_runner/gh/work_items.py agents_runner/ui/pages/github_work_list.py agents_runner/ui/dialogs/github_workroom_dialog.py agents_runner/ui/pages/settings_form.py`
- `QT_QPA_PLATFORM=offscreen uv run --group test pytest agents_runner/tests/test_tasks_nav_size_tracking.py agents_runner/tests/test_tasks_nav_transition_size_tracking.py agents_runner/tests/test_tasks_nav_button_fade_behavior.py -q`

## Manual noVNC QA Focus
1. Open `Tasks` and verify left nav order:
   - `New Task`
   - `Issues`
   - `Pull Requests`
2. Verify PR/Issues visibility is still conditioned on GitHub-supported environment.
3. Open a PR/Issue workroom and click `Fix Issue` / `Review PR`:
   - prompt is handed off
   - workroom closes
4. From PR/Issue list row manual action, verify prompt still appends to New Task draft.
5. Post `@agentsnova` mention on a PR comment and verify task auto-starts without draft append.
6. Post `@agentsnova` mention on an Issue comment and verify task auto-starts without draft append.
7. Add `@agentsnova` to PR/Issue body/title and verify one-time auto-start (no retrigger loop on refresh).
8. Confirm marker guards prevent duplicate triggering (`eyes` for PR comments, `rocket`/`hooray` handling for issue comments).

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
