### PR TITLE
Fix CI Qt tests: install libEGL and stub radio probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
       - name: Pull PixelArch Container
         run: docker pull lunamidori5/pixelarch:emerald
 
+      - name: Install Qt runtime dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libegl1
+
       - name: Sync
         run: uv sync --group lint --group test
 

--- a/agents_runner/tests/test_tasks_nav_transition_size_tracking.py
+++ b/agents_runner/tests/test_tasks_nav_transition_size_tracking.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 
+import pytest
 from PySide6.QtCore import QObject
 from PySide6.QtCore import QEvent
 from PySide6.QtTest import QTest
@@ -11,6 +12,7 @@ from PySide6.QtWidgets import QWidget
 from agents_runner.environments import Environment
 from agents_runner.environments import WORKSPACE_CLONED
 from agents_runner.ui.main_window import MainWindow
+from agents_runner.ui.radio.controller import RadioController
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
@@ -34,7 +36,14 @@ def _pump(app: QApplication, rounds: int = 15) -> None:
         QTest.qWait(20)
 
 
-def test_tasks_nav_width_stable_during_main_window_page_transitions() -> None:
+def test_tasks_nav_width_stable_during_main_window_page_transitions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        RadioController,
+        "probe_qt_multimedia_available",
+        classmethod(lambda cls: False),
+    )
     app = QApplication.instance() or QApplication([])
 
     win = MainWindow()


### PR DESCRIPTION
## Summary
- install `libegl1` in CI before dependency sync/tests so `PySide6.QtTest` can import on Ubuntu runners
- stabilize the tasks nav transition test by stubbing the radio multimedia capability probe, keeping the test focused on nav sizing behavior

## Verification
- `uv sync --group lint --group test`
- `uv run pytest --collect-only -q agents_runner/tests/test_tasks_nav_button_fade_behavior.py agents_runner/tests/test_tasks_nav_size_tracking.py agents_runner/tests/test_tasks_nav_transition_size_tracking.py`
- `uv run ruff format agents_runner/tests/test_tasks_nav_transition_size_tracking.py`
- `uv run ruff check agents_runner/tests/test_tasks_nav_transition_size_tracking.py`
- `uv run pytest -q agents_runner/tests/test_tasks_nav_transition_size_tracking.py::test_tasks_nav_width_stable_during_main_window_page_transitions`

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
