### PR TITLE
Align Tasks theming with Environments/Settings

### DIFF
--- a/agents_runner/ui/pages/github_work_list.py
+++ b/agents_runner/ui/pages/github_work_list.py
@@ -32,7 +32,6 @@ from agents_runner.ui.dialogs.github_workroom_dialog import GitHubWorkroomDialog
 from agents_runner.ui.lucide_icons import lucide_icon
 from agents_runner.ui.utils import _apply_environment_combo_tint
 from agents_runner.ui.utils import _stain_color
-from agents_runner.ui.widgets import GlassCard
 from midori_ai_logger import MidoriAiLogger
 
 logger = MidoriAiLogger(channel=None, name=__name__)
@@ -162,11 +161,10 @@ class GitHubWorkListPage(QWidget):
         root.setContentsMargins(0, 0, 0, 0)
         root.setSpacing(14)
 
-        header = GlassCard()
+        header = QWidget()
         header_layout = QHBoxLayout(header)
         header_layout.setContentsMargins(16, 14, 16, 14)
         header_layout.setSpacing(10)
-        self._header_card = header
 
         title = "Pull Requests" if self._item_type == "pr" else "Issues"
         self._title = QLabel(title)
@@ -188,11 +186,10 @@ class GitHubWorkListPage(QWidget):
         header_layout.addWidget(self._refresh)
         root.addWidget(header)
 
-        card = GlassCard()
+        card = QWidget()
         card_layout = QVBoxLayout(card)
         card_layout.setContentsMargins(0, 12, 0, 12)
         card_layout.setSpacing(8)
-        self._list_card = card
 
         columns = QWidget()
         columns_layout = QHBoxLayout(columns)
@@ -769,8 +766,6 @@ class GitHubWorkListPage(QWidget):
         if not stain:
             self._environment.setStyleSheet("")
             self._refresh.setStyleSheet("")
-            self._header_card.setStyleSheet("")
-            self._list_card.setStyleSheet("")
             self._list.setStyleSheet("")
             return
 
@@ -799,29 +794,7 @@ class GitHubWorkListPage(QWidget):
                 ]
             )
         )
-        self._header_card.setStyleSheet(
-            "\n".join(
-                [
-                    "QFrame#GlassCard {",
-                    f"  background-color: rgba({r}, {g}, {b}, 20);",
-                    f"  border: 1px solid rgba({r}, {g}, {b}, 90);",
-                    "  border-radius: 0px;",
-                    "}",
-                ]
-            )
-        )
-        self._list_card.setStyleSheet(
-            "\n".join(
-                [
-                    "QFrame#GlassCard {",
-                    f"  background-color: rgba({r}, {g}, {b}, 16);",
-                    f"  border: 1px solid rgba({r}, {g}, {b}, 78);",
-                    "  border-radius: 0px;",
-                    "}",
-                ]
-            )
-        )
-        self._list.setStyleSheet(f"background-color: rgba({r}, {g}, {b}, 10);")
+        self._list.setStyleSheet("")
 
     def _log_fetch_issue_once(self, message: str, *, mode: str) -> None:
         text = str(message or "").strip()

--- a/agents_runner/ui/pages/new_task.py
+++ b/agents_runner/ui/pages/new_task.py
@@ -32,7 +32,6 @@ from agents_runner.ui.graphics import _EnvironmentTintOverlay
 from agents_runner.ui.lucide_icons import lucide_icon
 from agents_runner.ui.utils import _apply_environment_combo_tint
 from agents_runner.ui.utils import _stain_color
-from agents_runner.ui.widgets import GlassCard
 from agents_runner.ui.widgets import SpellTextEdit
 from agents_runner.ui.widgets import StainedGlassButton
 from agents_runner.stt.mic_recorder import FfmpegPulseRecorder
@@ -76,7 +75,7 @@ class NewTaskPage(QWidget):
         self._environment.setFixedWidth(240)
         self._environment.currentIndexChanged.connect(self._on_environment_changed)
 
-        header = GlassCard()
+        header = QWidget()
         header_layout = QVBoxLayout(header)
         header_layout.setContentsMargins(18, 16, 18, 16)
         header_layout.setSpacing(6)
@@ -110,7 +109,7 @@ class NewTaskPage(QWidget):
         header_layout.addLayout(top_row)
         layout.addWidget(header)
 
-        card = GlassCard()
+        card = QWidget()
         card_layout = QVBoxLayout(card)
         card_layout.setContentsMargins(18, 16, 18, 16)
         card_layout.setSpacing(10)

--- a/agents_runner/ui/pages/tasks.py
+++ b/agents_runner/ui/pages/tasks.py
@@ -403,61 +403,16 @@ class TasksPage(QWidget):
 
         if not stain:
             self._compact_nav.setStyleSheet("")
-            self._apply_nav_tint("")
             self._tint_overlay.set_tint_color(None)
             self._prs.set_environment_stain("")
             self._issues.set_environment_stain("")
             return
 
-        self._apply_nav_tint(stain)
         _apply_environment_combo_tint(self._compact_nav, stain)
         tint = _stain_color(stain)
         self._tint_overlay.set_tint_color(tint)
         self._prs.set_environment_stain(stain)
         self._issues.set_environment_stain(stain)
-
-    def _apply_nav_tint(self, stain: str) -> None:
-        stain = str(stain or "").strip().lower()
-        if not stain:
-            self._nav_panel.setStyleSheet("")
-            return
-
-        tint = _stain_color(stain)
-        r = int(tint.red())
-        g = int(tint.green())
-        b = int(tint.blue())
-        self._nav_panel.setStyleSheet(
-            "\n".join(
-                [
-                    "QWidget#SettingsNavPanel {",
-                    "  background-color: rgba(18, 20, 28, 185);",
-                    f"  border: 1px solid rgba({r}, {g}, {b}, 110);",
-                    "  border-radius: 0px;",
-                    "}",
-                    "QToolButton#SettingsNavButton {",
-                    f"  border: 1px solid rgba({r}, {g}, {b}, 88);",
-                    "  background-color: rgba(18, 20, 28, 148);",
-                    "  color: rgba(237, 239, 245, 220);",
-                    "  border-radius: 0px;",
-                    "  text-align: left;",
-                    "  padding: 9px 10px;",
-                    "  font-weight: 620;",
-                    "}",
-                    "QToolButton#SettingsNavButton:hover {",
-                    f"  border: 1px solid rgba({r}, {g}, {b}, 140);",
-                    f"  background-color: rgba({r}, {g}, {b}, 28);",
-                    "}",
-                    "QToolButton#SettingsNavButton:checked {",
-                    f"  border: 1px solid rgba({r}, {g}, {b}, 176);",
-                    f"  background-color: rgba({r}, {g}, {b}, 54);",
-                    "}",
-                    "QToolButton#SettingsNavButton:checked:hover {",
-                    f"  border: 1px solid rgba({r}, {g}, {b}, 194);",
-                    f"  background-color: rgba({r}, {g}, {b}, 72);",
-                    "}",
-                ]
-            )
-        )
 
     def _ensure_button_opacity_effect(
         self, button: QToolButton


### PR DESCRIPTION
## Summary
Align the Tasks page visual styling with Environments/Settings, while preserving environment tint behavior where intended.

## What changed
- Removed Tasks-only sidebar tint stylesheet override so the left nav now uses shared Settings/Environments styling.
- Flattened inner right-pane wrappers in New Task and GitHub work list pages to remove the extra dark underpanel effect.
- Removed container-level PR/Issue tint-outline styling while keeping row accents and control tinting.

## Files changed
- agents_runner/ui/pages/tasks.py
- agents_runner/ui/pages/new_task.py
- agents_runner/ui/pages/github_work_list.py

## Validation
- `uv run python -m py_compile agents_runner/ui/pages/tasks.py agents_runner/ui/pages/new_task.py agents_runner/ui/pages/github_work_list.py`
- Note: `ruff` and `pytest` were not available in this environment.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
