### PR TITLE
[FIX] Align Prompt label with Run Agent source

### DIFF
--- a/agents_runner/ui/main_window_environment.py
+++ b/agents_runner/ui/main_window_environment.py
@@ -231,98 +231,12 @@ class _MainWindowEnvironmentMixin:
         self._new_task.set_defaults(host_codex=host_codex)
         self._new_task.set_workspace_status(path=workdir, ready=ready, message=message)
         self._new_task.set_agent_info(agent=current_agent, next_agent=next_agent)
-        self._update_new_task_agent_chain(env)
         self._sync_new_task_repo_controls(env)
         self._new_task.set_interactive_defaults(
             terminal_id=str(self._settings_data.get("interactive_terminal_id") or ""),
             command=self._default_interactive_command(agent_cli),
         )
         self._populate_environment_pickers()
-
-    def _update_new_task_agent_chain(self, env: Environment | None) -> None:
-        """Update the agent chain display in the new task page.
-
-        Args:
-            env: Current environment, or None for default
-        """
-        from agents_runner.agent_cli import normalize_agent
-
-        # Get agent chain from environment or settings
-        selection_mode = ""
-        if env and env.agent_selection and env.agent_selection.agents:
-            # Environment has custom agent configuration
-            selection = env.agent_selection
-            mode = str(selection.selection_mode or "round-robin")
-            selection_mode = mode
-
-            if mode == "fallback":
-                # Build fallback chain
-                agent_ids = {a.agent_id for a in selection.agents}
-                fallback_targets = set(selection.agent_fallbacks.values())
-                primary_agents = agent_ids - fallback_targets
-
-                # Build chain from first primary agent
-                chains: list[list[str]] = []
-                for primary in primary_agents:
-                    chain = [primary]
-                    current = primary
-                    visited = {primary}
-                    while current in selection.agent_fallbacks:
-                        next_id = selection.agent_fallbacks[current]
-                        if next_id in visited:
-                            break  # Circular reference
-                        chain.append(next_id)
-                        visited.add(next_id)
-                        current = next_id
-                    chains.append(chain)
-
-                # Convert agent IDs to CLI names
-                id_to_cli = {a.agent_id: a.agent_cli for a in selection.agents}
-                if chains:
-                    agent_names = [
-                        normalize_agent(id_to_cli.get(agent_id, agent_id))
-                        for agent_id in chains[0]
-                    ]
-                else:
-                    agent_names = []
-            elif mode == "pinned":
-                pinned_id = str(getattr(selection, "pinned_agent_id", "") or "").strip()
-                pinned_inst = None
-                if pinned_id:
-                    pinned_lower = pinned_id.lower()
-                    pinned_inst = next(
-                        (a for a in selection.agents if a.agent_id == pinned_id), None
-                    ) or next(
-                        (
-                            a
-                            for a in selection.agents
-                            if str(a.agent_id or "").lower() == pinned_lower
-                        ),
-                        None,
-                    )
-                if pinned_inst is not None:
-                    agent_names = [normalize_agent(pinned_inst.agent_cli)]
-                else:
-                    agent_names = []
-            else:
-                # Round-robin or least-used: show all agents in priority order
-                agent_names = [normalize_agent(a.agent_cli) for a in selection.agents]
-
-            # If environment config produced no agents, fall back to default
-            if not agent_names:
-                default_agent = normalize_agent(
-                    str(self._settings_data.get("agent_cli") or "codex")
-                )
-                agent_names = [default_agent]
-                selection_mode = ""  # Reset mode for default agent
-        else:
-            # No environment or no agents configured: use global default
-            default_agent = normalize_agent(
-                str(self._settings_data.get("agent_cli") or "codex")
-            )
-            agent_names = [default_agent]
-
-        self._new_task.set_agent_chain(agent_names, selection_mode)
 
     def _on_new_task_env_changed(self, env_id: str) -> None:
         if self._syncing_environment:


### PR DESCRIPTION
## Summary
- Unifies the inline `Prompt ::` label with the same current/next source used by the `Run Agent` button tooltip.
- Replaces chain-preview-only rendering with a single display path driven by `set_agent_info(...)`.
- Normalizes agent names to friendly labels (for example, `codex` -> `OpenAI Codex`) while preserving suffix details like `(agent-id)` or `(model)`.
- Uses a clean `|` separator for current/next display, including fallback output.

## Changes
- `agents_runner/ui/pages/new_task.py`
  - Added shared label formatting helpers for friendly, clean current/next display.
  - Updated `set_agent_info(...)` to drive both:
    - inline `Prompt ::` text
    - `Run Agent` / `Run Interactive` tooltips
- `agents_runner/ui/main_window_environment.py`
  - Removed the old `_update_new_task_agent_chain(...)` call so inline prompt text no longer comes from a separate chain-preview path.

## Verification
- `uvx ruff format agents_runner/ui/pages/new_task.py agents_runner/ui/main_window_environment.py`
- `uvx ruff check agents_runner/ui/pages/new_task.py agents_runner/ui/main_window_environment.py`

## Result
- `Prompt ::` now shows the same source-of-truth agent info as `Run Agent`, with cleaner naming and formatting.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
