### PR TITLE
[UI] Move env controls into page headers

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -42,6 +42,21 @@ print_remediation_root() {
   log "  - Common destinations: agents_runner/ (code), .agents/implementation/ (notes), .agents/tasks/wip/ (work), .agents/temp/ (temporary artifacts)"
 }
 
+is_agents_md_path_ci() {
+  local path_lower="${1,,}"
+  case "${path_lower}" in
+    "agents.md"|\
+    ".agents/tasks/agents.md"|\
+    ".agents/tasks/wip/agents.md"|\
+    ".agents/tasks/done/agents.md"|\
+    ".agents/tasks/taskmaster/agents.md"|\
+    ".agents/tasks/not-ready/agents.md")
+      return 0
+      ;;
+  esac
+  return 1
+}
+
 repo_root="$(git rev-parse --show-toplevel)"
 cd "${repo_root}"
 
@@ -64,6 +79,9 @@ disallowed_staged_paths=()
 for path in "${staged_paths[@]}"; do
   [[ -z "${path}" ]] && continue
   top_level="${path%%/*}"
+  if [[ "${top_level,,}" == "agents.md" ]]; then
+    continue
+  fi
   if [[ -z "${root_allowlist["$top_level"]+x}" ]]; then
     disallowed_staged_paths+=("${path}")
   fi
@@ -82,6 +100,50 @@ had_structure_error=0
 audit_tracked=()
 mapfile -d '' -t audit_tracked < <(git ls-files -z -- .agents/audit)
 audit_required=".agents/audit/AGENTS.md"
+
+staged_name_status=()
+mapfile -d '' -t staged_name_status < <(git diff --cached --name-status -z --diff-filter=DR)
+protected_agents_deletions=()
+status_idx=0
+while ((status_idx < ${#staged_name_status[@]})); do
+  status="${staged_name_status[$status_idx]}"
+  status_idx=$((status_idx + 1))
+  case "${status}" in
+    D*)
+      old_path="${staged_name_status[$status_idx]:-}"
+      status_idx=$((status_idx + 1))
+      if is_agents_md_path_ci "${old_path}"; then
+        protected_agents_deletions+=("${old_path}")
+      fi
+      ;;
+    R*)
+      old_path="${staged_name_status[$status_idx]:-}"
+      new_path="${staged_name_status[$((status_idx + 1))]:-}"
+      ((status_idx+=2))
+      if is_agents_md_path_ci "${old_path}" && ! is_agents_md_path_ci "${new_path}"; then
+        protected_agents_deletions+=("${old_path} -> ${new_path}")
+      fi
+      ;;
+    *)
+      status_idx=$((status_idx + 1))
+      ;;
+  esac
+done
+
+if ((${#protected_agents_deletions[@]} > 0)); then
+  log "ERROR: Protected AGENTS.md paths must never be deleted from task folders or repo root."
+  print_paths "Blocked AGENTS deletions/renames" "${protected_agents_deletions[@]}"
+  log "How to fix:"
+  log "  - Restore AGENTS.md files in protected locations and stage them."
+  log "  - Allowed protected locations (case-insensitive basename match):"
+  log "      AGENTS.md"
+  log "      .agents/tasks/AGENTS.md"
+  log "      .agents/tasks/wip/AGENTS.md"
+  log "      .agents/tasks/done/AGENTS.md"
+  log "      .agents/tasks/taskmaster/AGENTS.md"
+  log "      .agents/tasks/not-ready/AGENTS.md"
+  had_structure_error=1
+fi
 
 audit_missing=0
 audit_extra=()
@@ -123,13 +185,24 @@ tasks_required=(
 )
 
 declare -A tasks_required_set=()
+declare -A tasks_required_lower_set=()
 for path in "${tasks_required[@]}"; do
   tasks_required_set["$path"]=1
+  tasks_required_lower_set["${path,,}"]=1
 done
 
 tasks_missing=()
-for path in "${tasks_required[@]}"; do
-  if ! git ls-files --error-unmatch -- "$path" >/dev/null 2>&1; then
+for required_path in "${tasks_required[@]}"; do
+  required_lower="${required_path,,}"
+  required_found=0
+  for tracked_path in "${tasks_tracked[@]}"; do
+    if [[ "${tracked_path,,}" == "${required_lower}" ]]; then
+      required_found=1
+      break
+    fi
+  done
+  if [[ "${required_found}" -eq 0 ]]; then
+    path="${required_path}"
     tasks_missing+=("$path")
   fi
 done
@@ -137,7 +210,7 @@ done
 tasks_invalid=()
 tasks_has_task_files=0
 for path in "${tasks_tracked[@]}"; do
-  if [[ -n "${tasks_required_set["$path"]+x}" ]]; then
+  if [[ -n "${tasks_required_set["$path"]+x}" || -n "${tasks_required_lower_set["${path,,}"]+x}" ]]; then
     continue
   fi
   if [[ "${path}" =~ ^\.agents/tasks/not-ready/[^/]+\.(md|txt)$ ]]; then

--- a/agents_runner/tests/test_tasks_nav_button_fade_behavior.py
+++ b/agents_runner/tests/test_tasks_nav_button_fade_behavior.py
@@ -28,6 +28,12 @@ class _DummyNewTaskPage(QWidget):
     def append_prompt_text(self, _prompt: str) -> None:
         return
 
+    def base_branch_controls_widget(self) -> QWidget:
+        return QWidget()
+
+    def set_base_branch_host_active(self, _active: bool) -> None:
+        return
+
 
 def _pump(app: QApplication, rounds: int = 10) -> None:
     for _ in range(rounds):

--- a/agents_runner/ui/pages/environments.py
+++ b/agents_runner/ui/pages/environments.py
@@ -20,7 +20,6 @@ from agents_runner.environments import WORKSPACE_NONE
 from agents_runner.gh_management import is_gh_available
 from agents_runner.persistence import default_state_path
 from agents_runner.ui.constants import (
-    BUTTON_ROW_SPACING,
     CARD_MARGINS,
     CARD_SPACING,
     HEADER_MARGINS,
@@ -88,25 +87,8 @@ class EnvironmentsPage(
         )
         title.setToolTip(f"Environments are saved locally in:\n{envs_path}")
 
-        back = QToolButton()
-        back.setText("Back")
-        back.setToolButtonStyle(Qt.ToolButtonTextOnly)
-        back.clicked.connect(self._on_back)
-
-        header_layout.addWidget(title)
-        header_layout.addStretch(1)
-        header_layout.addWidget(back, 0, Qt.AlignRight)
-        layout.addWidget(header)
-
-        card = GlassCard()
-        card_layout = QVBoxLayout(card)
-        card_layout.setContentsMargins(*CARD_MARGINS)
-        card_layout.setSpacing(CARD_SPACING)
-
-        top_row = QHBoxLayout()
-        top_row.setSpacing(BUTTON_ROW_SPACING)
-
         self._env_select = QComboBox()
+        self._env_select.setFixedWidth(240)
         self._env_select.currentIndexChanged.connect(self._on_env_selected)
 
         new_btn = QToolButton()
@@ -124,12 +106,19 @@ class EnvironmentsPage(
         test_btn.setToolButtonStyle(Qt.ToolButtonTextOnly)
         test_btn.clicked.connect(self._on_test_preflight)
 
-        top_row.addWidget(QLabel("Environment"))
-        top_row.addWidget(self._env_select, 1)
-        top_row.addWidget(new_btn)
-        top_row.addWidget(delete_btn)
-        top_row.addWidget(test_btn)
-        card_layout.addLayout(top_row)
+        header_layout.addWidget(title)
+        header_layout.addStretch(1)
+        header_layout.addWidget(QLabel("Env"))
+        header_layout.addWidget(self._env_select)
+        header_layout.addWidget(new_btn)
+        header_layout.addWidget(delete_btn)
+        header_layout.addWidget(test_btn)
+        layout.addWidget(header)
+
+        card = GlassCard()
+        card_layout = QVBoxLayout(card)
+        card_layout.setContentsMargins(*CARD_MARGINS)
+        card_layout.setSpacing(CARD_SPACING)
 
         self._compact_nav = QComboBox()
         self._compact_nav.setObjectName("SettingsCompactNav")

--- a/agents_runner/ui/pages/settings.py
+++ b/agents_runner/ui/pages/settings.py
@@ -6,7 +6,6 @@ from PySide6.QtCore import (
     QPoint,
     QPropertyAnimation,
     QSignalBlocker,
-    Qt,
     QTimer,
     Signal,
 )
@@ -78,14 +77,8 @@ class SettingsPage(QWidget, _SettingsFormMixin):
             "Settings are saved locally in:\n~/.midoriai/agents-runner/state.json"
         )
 
-        back = QToolButton()
-        back.setText("Back")
-        back.setToolButtonStyle(Qt.ToolButtonTextOnly)
-        back.clicked.connect(self._on_back)
-
         header_layout.addWidget(title)
         header_layout.addStretch(1)
-        header_layout.addWidget(back, 0, Qt.AlignRight)
         layout.addWidget(header)
 
         card = GlassCard()

--- a/agents_runner/ui/pages/task_details.py
+++ b/agents_runner/ui/pages/task_details.py
@@ -69,11 +69,6 @@ class TaskDetailsPage(QWidget):
         self._subtitle = QLabel("—")
         self._subtitle.setStyleSheet("color: rgba(237, 239, 245, 160);")
 
-        back = QToolButton()
-        back.setText("Back")
-        back.setToolButtonStyle(Qt.ToolButtonTextOnly)
-        back.clicked.connect(self.back_requested.emit)
-
         self._review_menu = QMenu(self)
         self._review_pr = self._review_menu.addAction("Create PR")
         self._review_pr.triggered.connect(self._on_pr_triggered)
@@ -94,7 +89,6 @@ class TaskDetailsPage(QWidget):
         header_layout.addWidget(self._subtitle, 1)
         header_layout.addWidget(self._review, 0, Qt.AlignRight)
         header_layout.addWidget(self._desktop_btn, 0, Qt.AlignRight)
-        header_layout.addWidget(back, 0, Qt.AlignRight)
         layout.addWidget(header)
 
         self._tabs = QTabWidget()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "midori-ai-agents-runner"
-version = "0.1.0.51"
+version = "0.1.0.52"
 description = "A GUI for running AI agents in Docker containers with workspace and GitHub management."
 readme = "README.md"
 requires-python = "==3.13.11"


### PR DESCRIPTION
## Summary
- Moved Tasks environment selection into the Tasks header and made it the shared selector for New Task, Issues, and Pull Requests.
- Moved New Task base-branch controls into the Tasks header area while preserving existing base-branch behavior.
- Removed per-subpage environment dropdowns from Issues/Pull Requests and kept environment APIs wired through Tasks.
- Moved Environments selector and actions (New/Delete/Test preflight) into the Environments header.
- Removed header Back buttons from Environments, Settings, and Task Details pages.

## Files
- agents_runner/ui/pages/tasks.py
- agents_runner/ui/pages/new_task.py
- agents_runner/ui/pages/github_work_list.py
- agents_runner/ui/pages/environments.py
- agents_runner/ui/pages/settings.py
- agents_runner/ui/pages/task_details.py

## Validation
- uv run --with ruff ruff format .
- uv run --with ruff ruff check .

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
