### PR TITLE
Refine Review PR template to enforce repo standards and local tests

### DIFF
--- a/agents_runner/prompts/pr_review_template.md
+++ b/agents_runner/prompts/pr_review_template.md
@@ -5,15 +5,13 @@ Build a task prompt for reviewing a GitHub pull request from the Tasks -> Pull R
 ## Prompt
 Review GitHub pull request #{PR_NUMBER} for repository {REPO_OWNER}/{REPO_NAME}.
 
-PR URL: {PR_URL}
 PR title: {PR_TITLE}
-Trigger source: {TRIGGER_SOURCE}
-Mention comment ID: {MENTION_COMMENT_ID}
+PR URL: {PR_URL}
 
 Required workflow:
-1. Inspect the PR changes carefully for correctness, regressions, and missing tests.
-2. Use a reviewer mindset: findings first, ordered by severity, with file references.
-3. If no findings exist, explicitly say so and mention residual risks.
-4. If this review was triggered by @agentsnova mention and Mention comment ID is present:
-   - Add a +1 reaction to that comment when no issues are found.
-   - Add a -1 reaction to that comment when issues are found, and include review comments.
+1. Read and follow this repository's standards first, especially AGENTS.md and any repo-specific contribution/review instructions.
+2. Review the pull request against those repository standards.
+3. Run full local verification/tests.
+4. You are running in a PixelArch container with passwordless sudo available.
+5. Produce your review using the target repository's required format.
+6. If repository standards are missing or unclear, choose a clear review format and proceed.


### PR DESCRIPTION
## Summary
- Update `agents_runner/prompts/pr_review_template.md`.
- Keep PR context fields for number/title/URL.
- Require standards-first review using `AGENTS.md` and repo-specific review instructions.
- Require full local verification/tests.
- State PixelArch container context with passwordless sudo.
- Remove trigger/comment metadata and mention-reaction directives from the Review PR prompt.
- Require repo-defined review format; when standards are unclear, choose a clear format and proceed.

## Validation
- Prompt-only change.
- Tests not run.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
