### PR TITLE
Rewrite shared issue fix prompt checklist

### DIFF
--- a/agents_runner/prompts/issue_fix_template.md
+++ b/agents_runner/prompts/issue_fix_template.md
@@ -7,12 +7,11 @@ Fix GitHub issue #{ISSUE_NUMBER} for repository {REPO_OWNER}/{REPO_NAME}.
 
 Issue URL: {ISSUE_URL}
 Issue title: {ISSUE_TITLE}
-Trigger source: {TRIGGER_SOURCE}
-Mention comment ID: {MENTION_COMMENT_ID}
 
 Required workflow:
-1. Read the full issue details and reproduce the problem.
-2. Implement the fix with minimal, focused edits.
-3. Run relevant verification commands.
-4. Summarize what changed and why.
-5. If anything is still uncertain, list concrete follow-up checks.
+1. Read the full issue details (description, linked context, and comments) and restate the problem in your own words.
+2. Reproduce the issue or, if reproduction is not possible, explain exactly why and identify the most probable failure path from code inspection.
+3. Identify root cause with file-level evidence before making changes.
+4. Implement a minimal, focused fix that addresses root cause without unrelated refactors.
+5. Verify behavior with the most relevant checks for the changed area and report concrete results.
+6. Summarize what changed, why it solves the issue, and any remaining risks or follow-up checks.


### PR DESCRIPTION
## Summary
- rewrite the shared GitHub issue prompt template with a detailed 6-step workflow
- remove `Trigger source` and `Mention comment ID` lines from issue prompts
- keep issue prompt callsites unchanged so manual and mention-triggered issue flows share the same template

## Verification
- confirmed `issue_fix_template` callsites remain in:
  - `agents_runner/ui/dialogs/github_workroom_dialog.py`
  - `agents_runner/ui/pages/github_work_list.py`
- confirmed `agents_runner/prompts/issue_fix_template.md` no longer contains `Trigger source` or `Mention comment ID`

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
