### PR TITLE
Standardize themed dialog backgrounds and popup animation control

### DIFF
--- a/agents_runner/ui/dialogs/cooldown_modal.py
+++ b/agents_runner/ui/dialogs/cooldown_modal.py
@@ -7,7 +7,6 @@ Shown when user tries to run an agent that is on cooldown.
 from __future__ import annotations
 
 from PySide6.QtCore import QTimer
-from PySide6.QtWidgets import QDialog
 from PySide6.QtWidgets import QHBoxLayout
 from PySide6.QtWidgets import QLabel
 from PySide6.QtWidgets import QPushButton
@@ -15,6 +14,7 @@ from PySide6.QtWidgets import QVBoxLayout
 from PySide6.QtWidgets import QWidget
 
 from agents_runner.core.agent.watch_state import AgentWatchState
+from agents_runner.ui.dialogs.themed_dialog import ThemedDialog
 from agents_runner.ui.widgets import GlassCard
 
 
@@ -26,7 +26,7 @@ class CooldownAction:
     CANCEL = "cancel"
 
 
-class CooldownModal(QDialog):
+class CooldownModal(ThemedDialog):
     """Modal dialog shown when agent is on cooldown."""
 
     def __init__(
@@ -55,7 +55,7 @@ class CooldownModal(QDialog):
         self.setMinimumHeight(400)
 
         # Main layout
-        layout = QVBoxLayout(self)
+        layout = self.content_layout()
         layout.setContentsMargins(20, 20, 20, 20)
         layout.setSpacing(15)
 

--- a/agents_runner/ui/dialogs/first_run_setup.py
+++ b/agents_runner/ui/dialogs/first_run_setup.py
@@ -29,9 +29,10 @@ from agents_runner.setup.orchestrator import (
     mark_setup_skipped,
 )
 from agents_runner.ui.dialogs.docker_validator import DockerValidator
+from agents_runner.ui.dialogs.themed_dialog import ThemedDialog
 
 
-class FirstRunSetupDialog(QDialog):
+class FirstRunSetupDialog(ThemedDialog):
     """First-run setup dialog shown on app launch if setup incomplete."""
 
     def __init__(self, parent: QWidget | None = None):
@@ -56,8 +57,7 @@ class FirstRunSetupDialog(QDialog):
 
     def _setup_ui(self) -> None:
         """Set up the dialog UI."""
-        layout = QVBoxLayout()
-        self.setLayout(layout)
+        layout = self.content_layout()
 
         # Welcome message
         welcome_label = QLabel("Welcome to Agents Runner!")
@@ -267,7 +267,7 @@ class FirstRunSetupDialog(QDialog):
             self.reject()
 
 
-class SetupProgressDialog(QDialog):
+class SetupProgressDialog(ThemedDialog):
     """Progress dialog shown during sequential agent setup."""
 
     def __init__(self, agents: list[str], parent: QWidget | None = None):
@@ -293,8 +293,7 @@ class SetupProgressDialog(QDialog):
 
     def _setup_ui(self) -> None:
         """Set up the progress dialog UI."""
-        layout = QVBoxLayout()
-        self.setLayout(layout)
+        layout = self.content_layout()
 
         # Title
         self._title_label = QLabel("Setting up agents...")

--- a/agents_runner/ui/dialogs/github_workroom_dialog.py
+++ b/agents_runner/ui/dialogs/github_workroom_dialog.py
@@ -8,7 +8,6 @@ from PySide6.QtCore import Signal
 from PySide6.QtGui import QDesktopServices
 from PySide6.QtGui import QTextCursor
 from PySide6.QtWidgets import QApplication
-from PySide6.QtWidgets import QDialog
 from PySide6.QtWidgets import QHBoxLayout
 from PySide6.QtWidgets import QLabel
 from PySide6.QtWidgets import QLineEdit
@@ -23,11 +22,12 @@ from agents_runner.gh.work_items import get_pull_request_workroom
 from agents_runner.gh.work_items import post_comment
 from agents_runner.gh.work_items import set_item_open_state
 from agents_runner.prompts import load_prompt
+from agents_runner.ui.dialogs.themed_dialog import ThemedDialog
 from agents_runner.ui.lucide_icons import lucide_icon
 from agents_runner.ui.widgets import GlassCard
 
 
-class GitHubWorkroomDialog(QDialog):
+class GitHubWorkroomDialog(ThemedDialog):
     prompt_requested = Signal(str)
 
     def __init__(
@@ -53,7 +53,7 @@ class GitHubWorkroomDialog(QDialog):
         self.setWindowTitle("GitHub Workroom")
         self.setMinimumSize(860, 620)
 
-        layout = QVBoxLayout(self)
+        layout = self.content_layout()
         layout.setContentsMargins(12, 12, 12, 12)
         layout.setSpacing(10)
 

--- a/agents_runner/ui/dialogs/new_environment_wizard.py
+++ b/agents_runner/ui/dialogs/new_environment_wizard.py
@@ -12,7 +12,6 @@ from PySide6.QtGui import QResizeEvent
 from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
-    QDialog,
     QFileDialog,
     QHBoxLayout,
     QLabel,
@@ -33,12 +32,13 @@ from agents_runner.environments import (
     WORKSPACE_MOUNTED,
 )
 from agents_runner.terminal_apps import detect_terminal_options, launch_in_terminal
+from agents_runner.ui.dialogs.themed_dialog import ThemedDialog
 from agents_runner.ui.graphics import _EnvironmentTintOverlay
 from agents_runner.ui.utils import _apply_environment_combo_tint, _stain_color
 from agents_runner.ui.widgets import GlassCard
 
 
-class NewEnvironmentWizard(QDialog):
+class NewEnvironmentWizard(ThemedDialog):
     environment_created = Signal(object)
 
     TEST_DIR_BASE = "/tmp/agent-runner-env-test"
@@ -46,15 +46,6 @@ class NewEnvironmentWizard(QDialog):
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setObjectName("NewEnvironmentWizard")
-        self.setStyleSheet(
-            "\n".join(
-                [
-                    "#NewEnvironmentWizard {",
-                    "  background-color: rgba(10, 12, 18, 255);",
-                    "}",
-                ]
-            )
-        )
         self._clone_test_passed = False
         self._test_folder = ""
         self._advanced_modified = False
@@ -63,7 +54,8 @@ class NewEnvironmentWizard(QDialog):
         self.setWindowTitle("New Environment Wizard")
         self.setMinimumWidth(600)
         self.setMinimumHeight(500)
-        layout = QVBoxLayout(self)
+        layout = self.content_layout()
+        layout.setContentsMargins(10, 10, 10, 10)
         self._stack = QStackedWidget()
         layout.addWidget(self._stack)
         self._step1_widget = self._setup_step1()

--- a/agents_runner/ui/dialogs/test_chain_dialog.py
+++ b/agents_runner/ui/dialogs/test_chain_dialog.py
@@ -7,13 +7,12 @@ from __future__ import annotations
 
 from PySide6.QtCore import QThread
 from PySide6.QtCore import Signal
-from PySide6.QtWidgets import QDialog
 from PySide6.QtWidgets import QDialogButtonBox
 from PySide6.QtWidgets import QLabel
-from PySide6.QtWidgets import QVBoxLayout
 
 from agents_runner.setup.agent_status import AgentStatus
 from agents_runner.setup.agent_status import detect_all_agents
+from agents_runner.ui.dialogs.themed_dialog import ThemedDialog
 from agents_runner.ui.widgets import AgentChainStatusWidget
 
 
@@ -33,7 +32,7 @@ class AgentStatusCheckThread(QThread):
         self.status_ready.emit(status_map)
 
 
-class TestChainDialog(QDialog):
+class TestChainDialog(ThemedDialog):
     """Dialog for testing agent chain availability."""
 
     def __init__(
@@ -51,7 +50,7 @@ class TestChainDialog(QDialog):
         self.setMinimumWidth(500)
         self.setMinimumHeight(300)
 
-        layout = QVBoxLayout(self)
+        layout = self.content_layout()
         layout.setContentsMargins(16, 16, 16, 16)
         layout.setSpacing(12)
 

--- a/agents_runner/ui/dialogs/theme_preview_dialog.py
+++ b/agents_runner/ui/dialogs/theme_preview_dialog.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
 from PySide6.QtWidgets import (
-    QDialog,
     QHBoxLayout,
     QLabel,
     QPushButton,
-    QVBoxLayout,
     QWidget,
 )
 
-from agents_runner.ui.widgets.theme_preview import ThemePreviewWidget
+from agents_runner.ui.dialogs.themed_dialog import ThemedDialog
 
 
-class ThemePreviewDialog(QDialog):
+class ThemePreviewDialog(ThemedDialog):
     """Modal dialog that previews and optionally applies a single theme."""
 
     def __init__(
@@ -22,16 +20,16 @@ class ThemePreviewDialog(QDialog):
         theme_label: str,
         parent: QWidget | None = None,
     ) -> None:
-        super().__init__(parent)
         self._theme_name = str(theme_name or "").strip().lower()
         self._applied = False
+        super().__init__(parent, theme_name=self._theme_name)
 
         self.setWindowTitle(f"Theme Preview - {theme_label}")
         self.setModal(True)
-        self.setMinimumSize(760, 460)
-        self.resize(940, 560)
+        self.setMinimumSize(760, 360)
+        self.resize(940, 420)
 
-        layout = QVBoxLayout(self)
+        layout = self.content_layout()
         layout.setContentsMargins(16, 16, 16, 16)
         layout.setSpacing(10)
 
@@ -43,18 +41,15 @@ class ThemePreviewDialog(QDialog):
         subtitle.setObjectName("SettingsPaneSubtitle")
         layout.addWidget(subtitle)
 
-        preview_frame = QWidget(self)
-        preview_frame.setObjectName("ThemePreviewDialogFrame")
-        preview_layout = QVBoxLayout(preview_frame)
-        preview_layout.setContentsMargins(8, 8, 8, 8)
-        preview_layout.setSpacing(0)
+        details = QLabel(
+            "This dialog surface is the live theme preview. "
+            "Apply to switch the app background."
+        )
+        details.setWordWrap(True)
+        details.setObjectName("SettingsPaneSubtitle")
+        layout.addWidget(details)
 
-        self._preview = ThemePreviewWidget(self._theme_name, preview_frame)
-        self._preview.setObjectName("ThemePreviewDialogCanvas")
-        self._preview.setMinimumHeight(380)
-        preview_layout.addWidget(self._preview, 1)
-
-        layout.addWidget(preview_frame, 1)
+        layout.addStretch(1)
 
         actions = QHBoxLayout()
         actions.setSpacing(10)

--- a/agents_runner/ui/dialogs/themed_dialog.py
+++ b/agents_runner/ui/dialogs/themed_dialog.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from PySide6.QtWidgets import QDialog
+from PySide6.QtWidgets import QVBoxLayout
+from PySide6.QtWidgets import QWidget
+
+from agents_runner.persistence import default_state_path
+from agents_runner.persistence import load_state
+from agents_runner.ui.graphics import GlassRoot
+from agents_runner.ui.graphics import resolve_effective_ui_theme_name
+
+
+def _as_settings_dict(value: object) -> dict[str, object] | None:
+    if not isinstance(value, Mapping):
+        return None
+    return {str(key): item for key, item in value.items()}
+
+
+def _load_persisted_settings() -> dict[str, object]:
+    try:
+        payload = load_state(default_state_path())
+    except Exception:
+        return {}
+    settings = payload.get("settings") if isinstance(payload, dict) else None
+    parsed = _as_settings_dict(settings)
+    return parsed or {}
+
+
+def _find_parent_settings(parent: QWidget | None) -> dict[str, object] | None:
+    if parent is None:
+        return None
+
+    visited: set[int] = set()
+    cursor: QWidget | None = parent
+    while cursor is not None and id(cursor) not in visited:
+        visited.add(id(cursor))
+        parsed = _as_settings_dict(getattr(cursor, "_settings_data", None))
+        if parsed is not None:
+            return parsed
+        cursor = cursor.parentWidget()
+
+    window = parent.window()
+    if window is not None and id(window) not in visited:
+        parsed = _as_settings_dict(getattr(window, "_settings_data", None))
+        if parsed is not None:
+            return parsed
+
+    return None
+
+
+class ThemedDialog(QDialog):
+    """Dialog wrapper that renders the active UI theme behind its content."""
+
+    def __init__(
+        self,
+        parent: QWidget | None = None,
+        *,
+        theme_name: str | None = None,
+        settings_data: Mapping[str, object] | None = None,
+    ) -> None:
+        super().__init__(parent)
+
+        settings = _as_settings_dict(settings_data)
+        if settings is None:
+            settings = _find_parent_settings(parent)
+        if settings is None:
+            settings = _load_persisted_settings()
+        self._settings_data = settings
+
+        resolved_theme = str(theme_name or "").strip()
+        if not resolved_theme:
+            resolved_theme = resolve_effective_ui_theme_name(settings)
+        animation_enabled = bool(settings.get("popup_theme_animation_enabled", True))
+
+        dialog_layout = QVBoxLayout(self)
+        dialog_layout.setContentsMargins(0, 0, 0, 0)
+        dialog_layout.setSpacing(0)
+
+        self._background_root = GlassRoot(self)
+        self._background_root.set_animation_enabled(animation_enabled)
+        self._background_root.set_theme_name(resolved_theme)
+        dialog_layout.addWidget(self._background_root, 1)
+
+        root_layout = QVBoxLayout(self._background_root)
+        root_layout.setContentsMargins(0, 0, 0, 0)
+        root_layout.setSpacing(0)
+
+        self._content_host = QWidget(self._background_root)
+        self._content_host.setObjectName("ThemedDialogContentHost")
+        root_layout.addWidget(self._content_host, 1)
+
+        self._content_layout = QVBoxLayout(self._content_host)
+        self._content_layout.setContentsMargins(16, 16, 16, 16)
+        self._content_layout.setSpacing(10)
+
+    def content_layout(self) -> QVBoxLayout:
+        return self._content_layout
+
+    def set_dialog_theme_name(self, theme_name: str) -> None:
+        self._background_root.set_theme_name(theme_name)
+
+    def set_dialog_theme_animation_enabled(self, enabled: bool) -> None:
+        self._background_root.set_animation_enabled(enabled)

--- a/agents_runner/ui/main_window.py
+++ b/agents_runner/ui/main_window.py
@@ -102,6 +102,7 @@ class MainWindow(
             "append_pixelarch_context": False,
             "headless_desktop_enabled": False,
             "ui_theme": "auto",
+            "popup_theme_animation_enabled": True,
             "radio_enabled": False,
             "radio_channel": "",
             "radio_quality": "medium",

--- a/agents_runner/ui/main_window_persistence.py
+++ b/agents_runner/ui/main_window_persistence.py
@@ -177,6 +177,7 @@ class _MainWindowPersistenceMixin:
         self._settings_data.setdefault("headless_desktop_enabled", False)
         self._settings_data.setdefault("spellcheck_enabled", True)
         self._settings_data.setdefault("ui_theme", "auto")
+        self._settings_data.setdefault("popup_theme_animation_enabled", True)
         self._settings_data.setdefault("radio_enabled", False)
         self._settings_data.setdefault("radio_channel", "")
         self._settings_data.setdefault("radio_quality", "medium")
@@ -229,6 +230,9 @@ class _MainWindowPersistenceMixin:
 
         self._settings_data["radio_enabled"] = bool(
             self._settings_data.get("radio_enabled") or False
+        )
+        self._settings_data["popup_theme_animation_enabled"] = bool(
+            self._settings_data.get("popup_theme_animation_enabled", True)
         )
         self._settings_data["radio_autostart"] = bool(
             self._settings_data.get("radio_autostart") or False

--- a/agents_runner/ui/main_window_settings.py
+++ b/agents_runner/ui/main_window_settings.py
@@ -123,6 +123,9 @@ class _MainWindowSettingsMixin:
         merged["headless_desktop_enabled"] = bool(
             merged.get("headless_desktop_enabled") or False
         )
+        merged["popup_theme_animation_enabled"] = bool(
+            merged.get("popup_theme_animation_enabled", True)
+        )
         merged["radio_enabled"] = bool(merged.get("radio_enabled") or False)
         merged["radio_autostart"] = bool(merged.get("radio_autostart") or False)
         merged["radio_channel"] = RadioController.normalize_channel(

--- a/agents_runner/ui/pages/settings.py
+++ b/agents_runner/ui/pages/settings.py
@@ -148,6 +148,7 @@ class SettingsPage(QWidget, _SettingsFormMixin):
             self._github_workroom_prefer_browser,
             self._agentsnova_auto_review_enabled,
             self._headless_desktop_enabled,
+            self._popup_theme_animation_enabled,
             self._gh_context_default,
             self._spellcheck_enabled,
             self._mount_host_cache,

--- a/agents_runner/ui/pages/settings_form.py
+++ b/agents_runner/ui/pages/settings_form.py
@@ -116,6 +116,12 @@ class _SettingsFormMixin:
             "Auto syncs background theme to the active agent.\n"
             "Select a specific theme to force an override."
         )
+        self._popup_theme_animation_enabled = QCheckBox("Animate popup backgrounds")
+        self._popup_theme_animation_enabled.setToolTip(
+            "When enabled, themed popup backgrounds stay animated. "
+            "Disable to render popups as static backgrounds."
+        )
+        self._popup_theme_animation_enabled.setChecked(True)
         self._theme_preview_tiles: dict[str, ThemePreviewTile] = {}
         self._theme_preview_order: list[str] = []
         self._theme_preview_grid: QGridLayout | None = None
@@ -323,6 +329,7 @@ class _SettingsFormMixin:
         themes_grid.addWidget(QLabel("Theme"), 0, 0)
         themes_grid.addWidget(self._ui_theme, 0, 1)
         themes_body.addLayout(themes_grid)
+        themes_body.addWidget(self._popup_theme_animation_enabled)
         previews_heading = QLabel("Theme previews")
         previews_heading.setObjectName("SettingsPaneSubtitle")
         themes_body.addWidget(previews_heading)
@@ -767,6 +774,9 @@ class _SettingsFormMixin:
                 settings.get("ui_theme"), allow_auto=True
             )
             self._refresh_theme_options(selected=theme_value)
+            self._popup_theme_animation_enabled.setChecked(
+                bool(settings.get("popup_theme_animation_enabled", True))
+            )
 
             radio_enabled = bool(settings.get("radio_enabled") or False)
             self._radio_enabled.setChecked(radio_enabled)
@@ -809,6 +819,9 @@ class _SettingsFormMixin:
             "shell": str(self._shell.currentData() or "bash"),
             "ui_theme": normalize_ui_theme_name(
                 str(self._ui_theme.currentData() or "auto"), allow_auto=True
+            ),
+            "popup_theme_animation_enabled": bool(
+                self._popup_theme_animation_enabled.isChecked()
             ),
             "host_codex_dir": os.path.expanduser(
                 str(self._host_codex_dir.text() or "").strip()


### PR DESCRIPTION
## Summary
- add a shared `ThemedDialog` base that renders `GlassRoot` backgrounds for popup dialogs
- migrate all `QDialog` popups to the shared themed container (setup, wizard, theme preview, test chain, cooldown, and GitHub workroom)
- resolve startup popup theme from persisted settings (including `ui_theme = "auto"` agent-derived behavior)
- add `popup_theme_animation_enabled` (default `true`) and wire it through defaults, persistence, and Settings UI
- update Theme Preview popup to use full-surface themed preview and remove the nested preview box

## Validation
- `uvx ruff format .`
- `uvx ruff check .`
- `uv run python -c "import agents_runner.ui.dialogs.themed_dialog as td; import agents_runner.ui.dialogs.theme_preview_dialog as tp; import agents_runner.ui.graphics as g; print('ok')"`

## Commit
- `fe2849c`

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
