### PR TITLE
[FIX] Make task-start navigation settings-driven

### DIFF
--- a/agents_runner/ui/main_window.py
+++ b/agents_runner/ui/main_window.py
@@ -101,6 +101,8 @@ class MainWindow(
             "max_agents_running": -1,
             "append_pixelarch_context": False,
             "headless_desktop_enabled": False,
+            "auto_navigate_on_run_agent_start": False,
+            "auto_navigate_on_run_interactive_start": False,
             "ui_theme": "auto",
             "radio_enabled": False,
             "radio_channel": "",

--- a/agents_runner/ui/main_window_navigation.py
+++ b/agents_runner/ui/main_window_navigation.py
@@ -102,6 +102,18 @@ class _MainWindowNavigationMixin:
             return
         self._transition_to_page(self._dashboard)
 
+    def _should_auto_navigate_on_task_start(self, *, interactive: bool) -> bool:
+        key = (
+            "auto_navigate_on_run_interactive_start"
+            if interactive
+            else "auto_navigate_on_run_agent_start"
+        )
+        return bool(self._settings_data.get(key) or False)
+
+    def _maybe_auto_navigate_on_task_start(self, *, interactive: bool) -> None:
+        if self._should_auto_navigate_on_task_start(interactive=interactive):
+            self._show_dashboard()
+
     def _show_new_task(self) -> None:
         self._show_tasks()
 

--- a/agents_runner/ui/main_window_persistence.py
+++ b/agents_runner/ui/main_window_persistence.py
@@ -175,6 +175,8 @@ class _MainWindowPersistenceMixin:
             "--no-sandbox --approval-mode yolo --include-directories /home/midori-ai/workspace",
         )
         self._settings_data.setdefault("headless_desktop_enabled", False)
+        self._settings_data.setdefault("auto_navigate_on_run_agent_start", False)
+        self._settings_data.setdefault("auto_navigate_on_run_interactive_start", False)
         self._settings_data.setdefault("spellcheck_enabled", True)
         self._settings_data.setdefault("ui_theme", "auto")
         self._settings_data.setdefault("radio_enabled", False)
@@ -249,6 +251,12 @@ class _MainWindowPersistenceMixin:
             RadioController.normalize_loudness_boost_factor(
                 self._settings_data.get("radio_loudness_boost_factor")
             )
+        )
+        self._settings_data["auto_navigate_on_run_agent_start"] = bool(
+            self._settings_data.get("auto_navigate_on_run_agent_start") or False
+        )
+        self._settings_data["auto_navigate_on_run_interactive_start"] = bool(
+            self._settings_data.get("auto_navigate_on_run_interactive_start") or False
         )
 
         items = load_active_task_payloads(self._state_path)

--- a/agents_runner/ui/main_window_preflight.py
+++ b/agents_runner/ui/main_window_preflight.py
@@ -198,7 +198,7 @@ class _MainWindowPreflightMixin:
         self._run_started_s[task_id] = time.time()
 
         thread.start()
-        self._show_dashboard()
+        self._maybe_auto_navigate_on_task_start(interactive=False)
         self._schedule_save()
 
     def _on_settings_test_preflight(self, settings: dict) -> None:

--- a/agents_runner/ui/main_window_settings.py
+++ b/agents_runner/ui/main_window_settings.py
@@ -123,6 +123,12 @@ class _MainWindowSettingsMixin:
         merged["headless_desktop_enabled"] = bool(
             merged.get("headless_desktop_enabled") or False
         )
+        merged["auto_navigate_on_run_agent_start"] = bool(
+            merged.get("auto_navigate_on_run_agent_start") or False
+        )
+        merged["auto_navigate_on_run_interactive_start"] = bool(
+            merged.get("auto_navigate_on_run_interactive_start") or False
+        )
         merged["radio_enabled"] = bool(merged.get("radio_enabled") or False)
         merged["radio_autostart"] = bool(merged.get("radio_autostart") or False)
         merged["radio_channel"] = RadioController.normalize_channel(

--- a/agents_runner/ui/main_window_tasks_agent.py
+++ b/agents_runner/ui/main_window_tasks_agent.py
@@ -746,7 +746,7 @@ class _MainWindowTasksAgentMixin:
             self._dashboard.upsert_task(task, stain=stain, spinner_color=spinner)
             self._schedule_save()
 
-        self._show_dashboard()
+        self._maybe_auto_navigate_on_task_start(interactive=False)
         self._new_task.reset_for_new_run()
         return task_id
 

--- a/agents_runner/ui/main_window_tasks_interactive.py
+++ b/agents_runner/ui/main_window_tasks_interactive.py
@@ -292,7 +292,7 @@ class _MainWindowTasksInteractiveMixin:
             task.workspace_type = env.workspace_type
 
         prep_id = uuid4().hex[:8]
-        self._show_dashboard()
+        self._maybe_auto_navigate_on_task_start(interactive=True)
         self._new_task.reset_for_new_run()
 
         prep_worker = InteractivePrepWorker(

--- a/agents_runner/ui/main_window_tasks_interactive_docker.py
+++ b/agents_runner/ui/main_window_tasks_interactive_docker.py
@@ -458,7 +458,7 @@ def launch_docker_terminal_task(
 
         # Launch terminal
         launch_in_terminal(terminal_opt, host_script, cwd=host_workdir)
-        main_window._show_dashboard()
+        main_window._maybe_auto_navigate_on_task_start(interactive=True)
         main_window._new_task.reset_for_new_run()
 
     except Exception as exc:

--- a/agents_runner/ui/pages/settings.py
+++ b/agents_runner/ui/pages/settings.py
@@ -148,6 +148,8 @@ class SettingsPage(QWidget, _SettingsFormMixin):
             self._github_workroom_prefer_browser,
             self._agentsnova_auto_review_enabled,
             self._headless_desktop_enabled,
+            self._auto_navigate_on_run_agent_start,
+            self._auto_navigate_on_run_interactive_start,
             self._gh_context_default,
             self._spellcheck_enabled,
             self._mount_host_cache,

--- a/agents_runner/ui/pages/settings_form.py
+++ b/agents_runner/ui/pages/settings_form.py
@@ -166,6 +166,18 @@ class _SettingsFormMixin:
         self._headless_desktop_enabled.setToolTip(
             "When enabled, this overrides per-environment headless desktop settings."
         )
+        self._auto_navigate_on_run_agent_start = QCheckBox(
+            "Auto-navigate to Home when Run Agent starts"
+        )
+        self._auto_navigate_on_run_agent_start.setToolTip(
+            "When enabled, starting a Run Agent task switches to the Home dashboard."
+        )
+        self._auto_navigate_on_run_interactive_start = QCheckBox(
+            "Auto-navigate to Home when Run Interactive starts"
+        )
+        self._auto_navigate_on_run_interactive_start.setToolTip(
+            "When enabled, starting a Run Interactive task switches to the Home dashboard."
+        )
 
         self._gh_context_default = QCheckBox(
             "Enable GitHub context by default for new environments"
@@ -374,6 +386,8 @@ class _SettingsFormMixin:
 
         runtime_page, runtime_body = self._create_page(specs_by_key["runtime_behavior"])
         runtime_body.addWidget(self._headless_desktop_enabled)
+        runtime_body.addWidget(self._auto_navigate_on_run_agent_start)
+        runtime_body.addWidget(self._auto_navigate_on_run_interactive_start)
         runtime_body.addWidget(self._mount_host_cache)
         runtime_body.addStretch(1)
         self._register_page("runtime_behavior", runtime_page)
@@ -745,6 +759,12 @@ class _SettingsFormMixin:
             self._headless_desktop_enabled.setChecked(
                 bool(settings.get("headless_desktop_enabled") or False)
             )
+            self._auto_navigate_on_run_agent_start.setChecked(
+                bool(settings.get("auto_navigate_on_run_agent_start") or False)
+            )
+            self._auto_navigate_on_run_interactive_start.setChecked(
+                bool(settings.get("auto_navigate_on_run_interactive_start") or False)
+            )
             confirmation_mode = str(
                 settings.get("github_write_confirmation_mode") or "always"
             ).strip()
@@ -838,6 +858,12 @@ class _SettingsFormMixin:
             ),
             "headless_desktop_enabled": bool(
                 self._headless_desktop_enabled.isChecked()
+            ),
+            "auto_navigate_on_run_agent_start": bool(
+                self._auto_navigate_on_run_agent_start.isChecked()
+            ),
+            "auto_navigate_on_run_interactive_start": bool(
+                self._auto_navigate_on_run_interactive_start.isChecked()
             ),
             "gh_context_default_enabled": bool(self._gh_context_default.isChecked()),
             "spellcheck_enabled": bool(self._spellcheck_enabled.isChecked()),


### PR DESCRIPTION
## Summary
- remove forced Home redirects when tasks start by replacing hardcoded dashboard navigation with settings-driven behavior
- add two runtime preferences:
  - Auto-navigate to Home when Run Agent starts
  - Auto-navigate to Home when Run Interactive starts
- default both preferences to disabled (never auto-navigate)
- apply Run Agent preference to preflight task starts

## Changes
- add new settings keys with defaults and migration-safe normalization:
  - `auto_navigate_on_run_agent_start`
  - `auto_navigate_on_run_interactive_start`
- wire settings UI controls + autosave in Runtime settings pane
- introduce `_maybe_auto_navigate_on_task_start(interactive: bool)` navigation helper
- switch task start call sites (Run Agent, Run Interactive, interactive launch finalizer, preflight) to the helper

## Validation
- `QT_QPA_PLATFORM=offscreen uv run --with pytest pytest agents_runner/tests/test_tasks_nav_button_fade_behavior.py -q`
- `QT_QPA_PLATFORM=offscreen uv run --with pytest pytest agents_runner/tests/test_env_parse.py agents_runner/tests/test_token_redaction.py agents_runner/tests/test_tasks_nav_button_fade_behavior.py -q`
- `uvx ruff format .`
- `uvx ruff check .`

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
