### PR TITLE
Fix issue #220 UI polish across tasks, settings, and environments

### DIFF
--- a/agents_runner/ui/main_window_settings.py
+++ b/agents_runner/ui/main_window_settings.py
@@ -74,6 +74,9 @@ class _MainWindowSettingsMixin:
 
         merged["preflight_enabled"] = bool(merged.get("preflight_enabled") or False)
         merged["preflight_script"] = str(merged.get("preflight_script") or "")
+        merged["interactive_terminal_id"] = str(
+            merged.get("interactive_terminal_id") or ""
+        ).strip()
         merged["interactive_command"] = str(
             merged.get("interactive_command") or "--sandbox danger-full-access"
         )

--- a/agents_runner/ui/pages/environments.py
+++ b/agents_runner/ui/pages/environments.py
@@ -108,7 +108,7 @@ class EnvironmentsPage(
 
         header_layout.addWidget(title)
         header_layout.addStretch(1)
-        header_layout.addWidget(QLabel("Env"))
+        header_layout.addWidget(QLabel("Environments"))
         header_layout.addWidget(self._env_select)
         header_layout.addWidget(new_btn)
         header_layout.addWidget(delete_btn)
@@ -256,8 +256,8 @@ class EnvironmentsPage(
                 self._cache_settings_preflight_enabled.setChecked(False)
                 self._cache_environment_preflight_enabled.setChecked(False)
                 self._on_container_caching_toggled(Qt.CheckState.Unchecked.value)
-                self._env_vars.setPlainText("")
-                self._mounts.setPlainText("")
+                self._env_vars_tab.set_env_vars({})
+                self._mounts_tab.set_mounts([])
                 self._ports_tab.set_desktop_effective_enabled(
                     self._effective_desktop_enabled()
                 )
@@ -336,9 +336,8 @@ class EnvironmentsPage(
                 else Qt.CheckState.Unchecked.value
             )
 
-            env_lines = "\n".join(f"{k}={v}" for k, v in sorted(env.env_vars.items()))
-            self._env_vars.setPlainText(env_lines)
-            self._mounts.setPlainText("\n".join(env.extra_mounts))
+            self._env_vars_tab.set_env_vars(env.env_vars)
+            self._mounts_tab.set_mounts(env.extra_mounts)
             self._ports_tab.set_ports(
                 getattr(env, "ports", []) or [],
                 bool(getattr(env, "ports_unlocked", False)),

--- a/agents_runner/ui/pages/environments_actions.py
+++ b/agents_runner/ui/pages/environments_actions.py
@@ -11,8 +11,6 @@ from agents_runner.environments import WORKSPACE_MOUNTED
 from agents_runner.environments import WORKSPACE_NONE
 from agents_runner.environments import delete_environment
 from agents_runner.environments import load_environments
-from agents_runner.environments import parse_env_vars_text
-from agents_runner.environments import parse_mounts_text
 from agents_runner.environments import save_environment
 from agents_runner.gh_management import is_gh_available
 from agents_runner.ui.dialogs.new_environment_wizard import NewEnvironmentWizard
@@ -152,7 +150,7 @@ class _EnvironmentsPageActionsMixin:
         else:
             gh_context_enabled = False
 
-        env_vars, errors = parse_env_vars_text(self._env_vars.toPlainText() or "")
+        env_vars, errors = self._env_vars_tab.get_env_vars()
         if errors:
             if show_validation_errors:
                 QMessageBox.warning(
@@ -160,7 +158,15 @@ class _EnvironmentsPageActionsMixin:
                 )
             return False
 
-        mounts = parse_mounts_text(self._mounts.toPlainText() or "")
+        mounts, mount_errors = self._mounts_tab.get_mounts()
+        if mount_errors:
+            if show_validation_errors:
+                QMessageBox.warning(
+                    self,
+                    "Invalid mounts",
+                    "Fix mounts:\n" + "\n".join(mount_errors[:12]),
+                )
+            return False
         ports, ports_unlocked, ports_advanced_acknowledged, port_errors = (
             self._ports_tab.get_ports()
         )
@@ -304,14 +310,19 @@ class _EnvironmentsPageActionsMixin:
         else:
             gh_context_enabled = False
 
-        env_vars, errors = parse_env_vars_text(self._env_vars.toPlainText() or "")
+        env_vars, errors = self._env_vars_tab.get_env_vars()
         if errors:
             QMessageBox.warning(
                 self, "Invalid env vars", "Fix env vars:\n" + "\n".join(errors[:12])
             )
             return None
 
-        mounts = parse_mounts_text(self._mounts.toPlainText() or "")
+        mounts, mount_errors = self._mounts_tab.get_mounts()
+        if mount_errors:
+            QMessageBox.warning(
+                self, "Invalid mounts", "Fix mounts:\n" + "\n".join(mount_errors[:12])
+            )
+            return None
         ports, ports_unlocked, ports_advanced_acknowledged, port_errors = (
             self._ports_tab.get_ports()
         )

--- a/agents_runner/ui/pages/environments_env_vars.py
+++ b/agents_runner/ui/pages/environments_env_vars.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from PySide6.QtCore import Qt
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import QHBoxLayout
+from PySide6.QtWidgets import QHeaderView
+from PySide6.QtWidgets import QLabel
+from PySide6.QtWidgets import QLineEdit
+from PySide6.QtWidgets import QMessageBox
+from PySide6.QtWidgets import QPlainTextEdit
+from PySide6.QtWidgets import QSizePolicy
+from PySide6.QtWidgets import QStackedWidget
+from PySide6.QtWidgets import QTableWidget
+from PySide6.QtWidgets import QToolButton
+from PySide6.QtWidgets import QVBoxLayout
+from PySide6.QtWidgets import QWidget
+
+from agents_runner.environments import parse_env_vars_text
+from agents_runner.ui.constants import (
+    BUTTON_ROW_SPACING,
+    TAB_CONTENT_MARGINS,
+    TAB_CONTENT_SPACING,
+    TABLE_ROW_HEIGHT,
+)
+
+
+@dataclass
+class _EnvVarRow:
+    key: str = ""
+    value: str = ""
+
+
+class EnvVarsTabWidget(QWidget):
+    env_vars_changed = Signal()
+
+    _COL_KEY = 0
+    _COL_VALUE = 1
+    _COL_REMOVE = 2
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._rows: list[_EnvVarRow] = []
+        self._advanced_mode = False
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(*TAB_CONTENT_MARGINS)
+        layout.setSpacing(TAB_CONTENT_SPACING)
+
+        self._stack = QStackedWidget()
+        layout.addWidget(self._stack, 1)
+
+        self._simple_view = QWidget()
+        simple_layout = QVBoxLayout(self._simple_view)
+        simple_layout.setContentsMargins(0, 0, 0, 0)
+        simple_layout.setSpacing(TAB_CONTENT_SPACING)
+
+        self._table = QTableWidget()
+        self._table.setColumnCount(3)
+        self._table.setHorizontalHeaderLabels(["Key", "Value", ""])
+        self._table.horizontalHeader().setSectionResizeMode(
+            self._COL_KEY, QHeaderView.Stretch
+        )
+        self._table.horizontalHeader().setSectionResizeMode(
+            self._COL_VALUE, QHeaderView.Stretch
+        )
+        self._table.horizontalHeader().setSectionResizeMode(
+            self._COL_REMOVE, QHeaderView.ResizeToContents
+        )
+        self._table.verticalHeader().setVisible(False)
+        self._table.verticalHeader().setMinimumSectionSize(TABLE_ROW_HEIGHT)
+        self._table.verticalHeader().setDefaultSectionSize(TABLE_ROW_HEIGHT)
+        self._table.setSelectionMode(QTableWidget.NoSelection)
+        self._table.setFocusPolicy(Qt.NoFocus)
+        self._table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        simple_layout.addWidget(self._table, 1)
+
+        self._advanced_view = QWidget()
+        advanced_layout = QVBoxLayout(self._advanced_view)
+        advanced_layout.setContentsMargins(0, 0, 0, 0)
+        advanced_layout.setSpacing(TAB_CONTENT_SPACING)
+
+        self._advanced_text = QPlainTextEdit()
+        self._advanced_text.setPlaceholderText(
+            "\n".join(
+                [
+                    "# KEY=VALUE (one per line)",
+                    "# EXAMPLE_KEY=example value",
+                    "",
+                ]
+            )
+        )
+        self._advanced_text.setTabChangesFocus(True)
+        self._advanced_text.textChanged.connect(self.env_vars_changed.emit)
+        advanced_layout.addWidget(QLabel("Environment variables"))
+        advanced_layout.addWidget(self._advanced_text, 1)
+
+        self._stack.addWidget(self._simple_view)
+        self._stack.addWidget(self._advanced_view)
+        self._stack.setCurrentIndex(0)
+
+        footer_row = QHBoxLayout()
+        footer_row.setSpacing(BUTTON_ROW_SPACING)
+        self._add_label = QLabel("Add variable")
+        footer_row.addWidget(self._add_label)
+        self._add_btn = QToolButton()
+        self._add_btn.setText("Add")
+        self._add_btn.setToolButtonStyle(Qt.ToolButtonTextOnly)
+        self._add_btn.clicked.connect(self._on_add_row)
+        footer_row.addWidget(self._add_btn)
+        footer_row.addStretch(1)
+        self._mode_btn = QToolButton()
+        self._mode_btn.setToolButtonStyle(Qt.ToolButtonTextOnly)
+        self._mode_btn.clicked.connect(self._on_mode_clicked)
+        footer_row.addWidget(self._mode_btn)
+        layout.addLayout(footer_row)
+
+        self._render_table()
+        self._sync_mode_state()
+
+    def set_env_vars(self, env_vars: dict[str, str]) -> None:
+        self._rows = [
+            _EnvVarRow(key=str(key or "").strip(), value=str(value or ""))
+            for key, value in sorted((env_vars or {}).items(), key=lambda item: item[0])
+            if str(key or "").strip()
+        ]
+        self._advanced_mode = False
+
+        self._advanced_text.blockSignals(True)
+        try:
+            lines = [f"{row.key}={row.value}" for row in self._rows]
+            self._advanced_text.setPlainText("\n".join(lines))
+        finally:
+            self._advanced_text.blockSignals(False)
+
+        self._render_table()
+        self._sync_mode_state()
+
+    def get_env_vars(self) -> tuple[dict[str, str], list[str]]:
+        if self._advanced_mode:
+            return parse_env_vars_text(self._advanced_text.toPlainText() or "")
+
+        parsed: dict[str, str] = {}
+        errors: list[str] = []
+        for row_index, row in enumerate(self._rows, start=1):
+            key = str(row.key or "").strip()
+            value = str(row.value or "")
+            if not key and not value:
+                continue
+            if not key:
+                errors.append(f"row {row_index}: empty key")
+                continue
+            parsed[key] = value
+        return parsed, errors
+
+    def _on_mode_clicked(self) -> None:
+        if self._advanced_mode:
+            self._switch_to_simple_mode()
+            return
+        self._switch_to_advanced_mode()
+
+    def _on_add_row(self) -> None:
+        self._rows.append(_EnvVarRow(key="", value=""))
+        self._render_table()
+        self.env_vars_changed.emit()
+
+    def _sync_mode_state(self) -> None:
+        if self._advanced_mode:
+            self._stack.setCurrentIndex(1)
+            self._mode_btn.setText("Simple Mode")
+            self._add_label.setVisible(False)
+            self._add_btn.setVisible(False)
+            return
+        self._stack.setCurrentIndex(0)
+        self._mode_btn.setText("Advanced Mode")
+        self._add_label.setVisible(True)
+        self._add_btn.setVisible(True)
+
+    def _switch_to_advanced_mode(self) -> None:
+        lines: list[str] = []
+        for row in self._rows:
+            key = str(row.key or "").strip()
+            value = str(row.value or "")
+            if not key and not value:
+                continue
+            lines.append(f"{key}={value}")
+        self._advanced_text.blockSignals(True)
+        try:
+            self._advanced_text.setPlainText("\n".join(lines))
+        finally:
+            self._advanced_text.blockSignals(False)
+        self._advanced_mode = True
+        self._sync_mode_state()
+        self.env_vars_changed.emit()
+
+    def _switch_to_simple_mode(self) -> None:
+        parsed, errors = parse_env_vars_text(self._advanced_text.toPlainText() or "")
+        if errors:
+            QMessageBox.warning(
+                self,
+                "Invalid environment variables",
+                "Fix entries before leaving Advanced mode:\n" + "\n".join(errors[:12]),
+            )
+            return
+        self._rows = [
+            _EnvVarRow(key=str(key or "").strip(), value=str(value or ""))
+            for key, value in parsed.items()
+            if str(key or "").strip()
+        ]
+        self._advanced_mode = False
+        self._render_table()
+        self._sync_mode_state()
+        self.env_vars_changed.emit()
+
+    def _render_table(self) -> None:
+        self._table.blockSignals(True)
+        try:
+            self._table.setRowCount(0)
+            for row_index, row in enumerate(self._rows):
+                self._table.insertRow(row_index)
+
+                key_edit = QLineEdit(str(row.key or ""))
+                key_edit.setPlaceholderText("KEY")
+                key_edit.textChanged.connect(
+                    lambda text, i=row_index: self._on_key_changed(i, text)
+                )
+                self._table.setCellWidget(row_index, self._COL_KEY, key_edit)
+
+                value_edit = QLineEdit(str(row.value or ""))
+                value_edit.setPlaceholderText("Value")
+                value_edit.textChanged.connect(
+                    lambda text, i=row_index: self._on_value_changed(i, text)
+                )
+                self._table.setCellWidget(row_index, self._COL_VALUE, value_edit)
+
+                remove_btn = QToolButton()
+                remove_btn.setObjectName("RowTrash")
+                remove_btn.setText("Remove")
+                remove_btn.setToolButtonStyle(Qt.ToolButtonTextOnly)
+                remove_btn.clicked.connect(
+                    lambda _=False, i=row_index: self._on_remove_row(i)
+                )
+                self._table.setCellWidget(row_index, self._COL_REMOVE, remove_btn)
+        finally:
+            self._table.blockSignals(False)
+
+    def _on_key_changed(self, row_index: int, text: str) -> None:
+        if row_index >= len(self._rows):
+            return
+        self._rows[row_index].key = str(text or "")
+        self.env_vars_changed.emit()
+
+    def _on_value_changed(self, row_index: int, text: str) -> None:
+        if row_index >= len(self._rows):
+            return
+        self._rows[row_index].value = str(text or "")
+        self.env_vars_changed.emit()
+
+    def _on_remove_row(self, row_index: int) -> None:
+        if row_index < 0 or row_index >= len(self._rows):
+            return
+        self._rows.pop(row_index)
+        self._render_table()
+        self.env_vars_changed.emit()

--- a/agents_runner/ui/pages/environments_mounts.py
+++ b/agents_runner/ui/pages/environments_mounts.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from PySide6.QtCore import Qt
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import QComboBox
+from PySide6.QtWidgets import QHBoxLayout
+from PySide6.QtWidgets import QHeaderView
+from PySide6.QtWidgets import QLabel
+from PySide6.QtWidgets import QLineEdit
+from PySide6.QtWidgets import QMessageBox
+from PySide6.QtWidgets import QPlainTextEdit
+from PySide6.QtWidgets import QSizePolicy
+from PySide6.QtWidgets import QStackedWidget
+from PySide6.QtWidgets import QTableWidget
+from PySide6.QtWidgets import QToolButton
+from PySide6.QtWidgets import QVBoxLayout
+from PySide6.QtWidgets import QWidget
+
+from agents_runner.environments import parse_mounts_text
+from agents_runner.ui.constants import (
+    BUTTON_ROW_SPACING,
+    TAB_CONTENT_MARGINS,
+    TAB_CONTENT_SPACING,
+    TABLE_ROW_HEIGHT,
+)
+
+
+_MOUNT_MODES = ("rw", "ro", "cached", "delegated")
+
+
+@dataclass
+class _MountRow:
+    host_path: str = ""
+    container_path: str = ""
+    mode: str = "rw"
+
+
+def _simple_mount_row_from_spec(spec: str) -> _MountRow | None:
+    text = str(spec or "").strip()
+    if not text:
+        return None
+    parts = text.split(":")
+    if len(parts) < 2:
+        return None
+    host_path = str(parts[0] or "").strip()
+    container_path = str(parts[1] or "").strip()
+    if not host_path or not container_path:
+        return None
+    mode = "rw"
+    if len(parts) >= 3:
+        mode = str(parts[2] or "").strip().lower() or "rw"
+    if mode not in _MOUNT_MODES:
+        return None
+    return _MountRow(host_path=host_path, container_path=container_path, mode=mode)
+
+
+class MountsTabWidget(QWidget):
+    mounts_changed = Signal()
+
+    _COL_HOST_PATH = 0
+    _COL_CONTAINER_PATH = 1
+    _COL_MODE = 2
+    _COL_REMOVE = 3
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._rows: list[_MountRow] = []
+        self._advanced_mode = False
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(*TAB_CONTENT_MARGINS)
+        layout.setSpacing(TAB_CONTENT_SPACING)
+
+        self._stack = QStackedWidget()
+        layout.addWidget(self._stack, 1)
+
+        self._simple_view = QWidget()
+        simple_layout = QVBoxLayout(self._simple_view)
+        simple_layout.setContentsMargins(0, 0, 0, 0)
+        simple_layout.setSpacing(TAB_CONTENT_SPACING)
+
+        self._table = QTableWidget()
+        self._table.setColumnCount(4)
+        self._table.setHorizontalHeaderLabels(
+            ["Host path", "Container path", "Mode", ""]
+        )
+        self._table.horizontalHeader().setSectionResizeMode(
+            self._COL_HOST_PATH, QHeaderView.Stretch
+        )
+        self._table.horizontalHeader().setSectionResizeMode(
+            self._COL_CONTAINER_PATH, QHeaderView.Stretch
+        )
+        self._table.horizontalHeader().setSectionResizeMode(
+            self._COL_MODE, QHeaderView.ResizeToContents
+        )
+        self._table.horizontalHeader().setSectionResizeMode(
+            self._COL_REMOVE, QHeaderView.ResizeToContents
+        )
+        self._table.verticalHeader().setVisible(False)
+        self._table.verticalHeader().setMinimumSectionSize(TABLE_ROW_HEIGHT)
+        self._table.verticalHeader().setDefaultSectionSize(TABLE_ROW_HEIGHT)
+        self._table.setSelectionMode(QTableWidget.NoSelection)
+        self._table.setFocusPolicy(Qt.NoFocus)
+        self._table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        simple_layout.addWidget(self._table, 1)
+
+        self._advanced_view = QWidget()
+        advanced_layout = QVBoxLayout(self._advanced_view)
+        advanced_layout.setContentsMargins(0, 0, 0, 0)
+        advanced_layout.setSpacing(TAB_CONTENT_SPACING)
+
+        self._advanced_text = QPlainTextEdit()
+        self._advanced_text.setPlaceholderText(
+            "\n".join(
+                [
+                    "# host_path:container_path[:mode]",
+                    "# /home/user/.ssh:/home/midori-ai/.ssh:ro",
+                    "",
+                ]
+            )
+        )
+        self._advanced_text.setTabChangesFocus(True)
+        self._advanced_text.textChanged.connect(self.mounts_changed.emit)
+        advanced_layout.addWidget(QLabel("Mount definitions"))
+        advanced_layout.addWidget(self._advanced_text, 1)
+
+        self._stack.addWidget(self._simple_view)
+        self._stack.addWidget(self._advanced_view)
+        self._stack.setCurrentIndex(0)
+
+        footer_row = QHBoxLayout()
+        footer_row.setSpacing(BUTTON_ROW_SPACING)
+        self._add_label = QLabel("Add mount")
+        footer_row.addWidget(self._add_label)
+        self._add_btn = QToolButton()
+        self._add_btn.setText("Add")
+        self._add_btn.setToolButtonStyle(Qt.ToolButtonTextOnly)
+        self._add_btn.clicked.connect(self._on_add_row)
+        footer_row.addWidget(self._add_btn)
+        footer_row.addStretch(1)
+        self._mode_btn = QToolButton()
+        self._mode_btn.setToolButtonStyle(Qt.ToolButtonTextOnly)
+        self._mode_btn.clicked.connect(self._on_mode_clicked)
+        footer_row.addWidget(self._mode_btn)
+        layout.addLayout(footer_row)
+
+        self._render_table()
+        self._sync_mode_state()
+
+    def set_mounts(self, mounts: list[str]) -> None:
+        parsed_rows: list[_MountRow] = []
+        use_advanced_mode = False
+        for spec in mounts or []:
+            row = _simple_mount_row_from_spec(str(spec or "").strip())
+            if row is None:
+                use_advanced_mode = True
+                continue
+            parsed_rows.append(row)
+
+        self._rows = parsed_rows
+        self._advanced_mode = use_advanced_mode
+
+        self._advanced_text.blockSignals(True)
+        try:
+            self._advanced_text.setPlainText(
+                "\n".join(
+                    str(spec or "").strip()
+                    for spec in mounts or []
+                    if str(spec or "").strip()
+                )
+            )
+        finally:
+            self._advanced_text.blockSignals(False)
+
+        self._render_table()
+        self._sync_mode_state()
+
+    def get_mounts(self) -> tuple[list[str], list[str]]:
+        if self._advanced_mode:
+            mounts = parse_mounts_text(self._advanced_text.toPlainText() or "")
+            return mounts, []
+
+        mounts: list[str] = []
+        errors: list[str] = []
+        for row_index, row in enumerate(self._rows, start=1):
+            host_path = str(row.host_path or "").strip()
+            container_path = str(row.container_path or "").strip()
+            mode = str(row.mode or "rw").strip().lower() or "rw"
+
+            if not host_path and not container_path:
+                continue
+            if not host_path:
+                errors.append(f"row {row_index}: missing host path")
+                continue
+            if not container_path:
+                errors.append(f"row {row_index}: missing container path")
+                continue
+            if mode not in _MOUNT_MODES:
+                errors.append(f"row {row_index}: unsupported mode '{mode}'")
+                continue
+            mounts.append(f"{host_path}:{container_path}:{mode}")
+        return mounts, errors
+
+    def _on_mode_clicked(self) -> None:
+        if self._advanced_mode:
+            self._switch_to_simple_mode()
+            return
+        self._switch_to_advanced_mode()
+
+    def _on_add_row(self) -> None:
+        self._rows.append(_MountRow())
+        self._render_table()
+        self.mounts_changed.emit()
+
+    def _sync_mode_state(self) -> None:
+        if self._advanced_mode:
+            self._stack.setCurrentIndex(1)
+            self._mode_btn.setText("Simple Mode")
+            self._add_label.setVisible(False)
+            self._add_btn.setVisible(False)
+            return
+        self._stack.setCurrentIndex(0)
+        self._mode_btn.setText("Advanced Mode")
+        self._add_label.setVisible(True)
+        self._add_btn.setVisible(True)
+
+    def _switch_to_advanced_mode(self) -> None:
+        lines: list[str] = []
+        for row in self._rows:
+            host_path = str(row.host_path or "").strip()
+            container_path = str(row.container_path or "").strip()
+            mode = str(row.mode or "rw").strip().lower() or "rw"
+            if not host_path and not container_path:
+                continue
+            lines.append(f"{host_path}:{container_path}:{mode}")
+        self._advanced_text.blockSignals(True)
+        try:
+            self._advanced_text.setPlainText("\n".join(lines))
+        finally:
+            self._advanced_text.blockSignals(False)
+        self._advanced_mode = True
+        self._sync_mode_state()
+        self.mounts_changed.emit()
+
+    def _switch_to_simple_mode(self) -> None:
+        mounts = parse_mounts_text(self._advanced_text.toPlainText() or "")
+        rows: list[_MountRow] = []
+        errors: list[str] = []
+        for index, spec in enumerate(mounts, start=1):
+            row = _simple_mount_row_from_spec(spec)
+            if row is None:
+                errors.append(
+                    f"line {index}: expected host_path:container_path[:rw|ro|cached|delegated]"
+                )
+                continue
+            rows.append(row)
+
+        if errors:
+            QMessageBox.warning(
+                self,
+                "Cannot switch to Simple mode",
+                "Fix entries before leaving Advanced mode:\n" + "\n".join(errors[:12]),
+            )
+            return
+
+        self._rows = rows
+        self._advanced_mode = False
+        self._render_table()
+        self._sync_mode_state()
+        self.mounts_changed.emit()
+
+    def _render_table(self) -> None:
+        self._table.blockSignals(True)
+        try:
+            self._table.setRowCount(0)
+            for row_index, row in enumerate(self._rows):
+                self._table.insertRow(row_index)
+
+                host_edit = QLineEdit(str(row.host_path or ""))
+                host_edit.setPlaceholderText("/host/path")
+                host_edit.textChanged.connect(
+                    lambda text, i=row_index: self._on_host_path_changed(i, text)
+                )
+                self._table.setCellWidget(row_index, self._COL_HOST_PATH, host_edit)
+
+                container_edit = QLineEdit(str(row.container_path or ""))
+                container_edit.setPlaceholderText("/container/path")
+                container_edit.textChanged.connect(
+                    lambda text, i=row_index: self._on_container_path_changed(i, text)
+                )
+                self._table.setCellWidget(
+                    row_index, self._COL_CONTAINER_PATH, container_edit
+                )
+
+                mode_combo = QComboBox()
+                for mode in _MOUNT_MODES:
+                    mode_combo.addItem(mode, mode)
+                mode_index = mode_combo.findData(str(row.mode or "rw").strip().lower())
+                if mode_index < 0:
+                    mode_index = mode_combo.findData("rw")
+                mode_combo.setCurrentIndex(mode_index)
+                mode_combo.currentIndexChanged.connect(
+                    lambda _idx, i=row_index, combo=mode_combo: self._on_mode_changed(
+                        i, combo
+                    )
+                )
+                self._table.setCellWidget(row_index, self._COL_MODE, mode_combo)
+
+                remove_btn = QToolButton()
+                remove_btn.setObjectName("RowTrash")
+                remove_btn.setText("Remove")
+                remove_btn.setToolButtonStyle(Qt.ToolButtonTextOnly)
+                remove_btn.clicked.connect(
+                    lambda _=False, i=row_index: self._on_remove_row(i)
+                )
+                self._table.setCellWidget(row_index, self._COL_REMOVE, remove_btn)
+        finally:
+            self._table.blockSignals(False)
+
+    def _on_host_path_changed(self, row_index: int, text: str) -> None:
+        if row_index >= len(self._rows):
+            return
+        self._rows[row_index].host_path = str(text or "")
+        self.mounts_changed.emit()
+
+    def _on_container_path_changed(self, row_index: int, text: str) -> None:
+        if row_index >= len(self._rows):
+            return
+        self._rows[row_index].container_path = str(text or "")
+        self.mounts_changed.emit()
+
+    def _on_mode_changed(self, row_index: int, combo: QComboBox) -> None:
+        if row_index >= len(self._rows):
+            return
+        mode = str(combo.currentData() or "rw").strip().lower() or "rw"
+        self._rows[row_index].mode = mode
+        self.mounts_changed.emit()
+
+    def _on_remove_row(self, row_index: int) -> None:
+        if row_index < 0 or row_index >= len(self._rows):
+            return
+        self._rows.pop(row_index)
+        self._render_table()
+        self.mounts_changed.emit()

--- a/agents_runner/ui/pages/environments_navigation.py
+++ b/agents_runner/ui/pages/environments_navigation.py
@@ -46,12 +46,7 @@ class _EnvironmentsNavigationMixin:
         ):
             line_edit.textChanged.connect(self._queue_debounced_autosave)
 
-        for editor in (
-            self._preflight_script,
-            self._env_vars,
-            self._mounts,
-        ):
-            editor.textChanged.connect(self._queue_debounced_autosave)
+        self._preflight_script.textChanged.connect(self._queue_debounced_autosave)
 
     def _on_nav_button_clicked(self, key: str) -> None:
         self._navigate_to_pane(key, user_initiated=True)

--- a/agents_runner/ui/pages/settings.py
+++ b/agents_runner/ui/pages/settings.py
@@ -135,6 +135,7 @@ class SettingsPage(QWidget, _SettingsFormMixin):
         for combo in (
             self._use,
             self._shell,
+            self._interactive_terminal,
             self._ui_theme,
             self._radio_channel,
             self._radio_quality,

--- a/agents_runner/ui/pages/settings_form.py
+++ b/agents_runner/ui/pages/settings_form.py
@@ -25,6 +25,7 @@ from agents_runner.agent_cli import normalize_agent
 from agents_runner.agent_systems import available_agent_system_names
 from agents_runner.agent_systems import get_agent_system
 from agents_runner.agent_systems import get_default_agent_system_name
+from agents_runner.terminal_apps import detect_terminal_options
 from agents_runner.ui.radio import RadioController
 from agents_runner.ui.dialogs.theme_preview_dialog import ThemePreviewDialog
 from agents_runner.ui.graphics import available_ui_theme_names
@@ -110,6 +111,19 @@ class _SettingsFormMixin:
             ("tmux", "tmux"),
         ]:
             self._shell.addItem(label, value)
+
+        self._interactive_terminal = QComboBox()
+        self._interactive_terminal.setToolTip(
+            "Default terminal used by Run Interactive and Get Agent Help."
+        )
+        self._refresh_terminal_options(selected_terminal_id="")
+
+        self._refresh_interactive_terminal = QToolButton()
+        self._refresh_interactive_terminal.setText("Refresh")
+        self._refresh_interactive_terminal.setToolButtonStyle(Qt.ToolButtonTextOnly)
+        self._refresh_interactive_terminal.clicked.connect(
+            self._on_refresh_terminal_options_clicked
+        )
 
         self._ui_theme = QComboBox()
         self._ui_theme.setToolTip(
@@ -305,6 +319,15 @@ class _SettingsFormMixin:
         general_body.addWidget(self._github_workroom_prefer_browser)
         general_body.addWidget(self._agentsnova_auto_review_enabled)
 
+        terminal_layout = QGridLayout()
+        terminal_layout.setHorizontalSpacing(GRID_HORIZONTAL_SPACING)
+        terminal_layout.setVerticalSpacing(GRID_VERTICAL_SPACING)
+        terminal_layout.setColumnStretch(1, 1)
+        terminal_layout.addWidget(QLabel("Interactive terminal"), 0, 0)
+        terminal_layout.addWidget(self._interactive_terminal, 0, 1)
+        terminal_layout.addWidget(self._refresh_interactive_terminal, 0, 2)
+        general_body.addLayout(terminal_layout)
+
         github_write_layout = QGridLayout()
         github_write_layout.setHorizontalSpacing(GRID_HORIZONTAL_SPACING)
         github_write_layout.setVerticalSpacing(GRID_VERTICAL_SPACING)
@@ -345,7 +368,7 @@ class _SettingsFormMixin:
         agent_grid.setColumnStretch(1, 1)
         agent_grid.addWidget(QLabel("Agent CLI"), 0, 0)
         agent_grid.addWidget(self._use, 0, 1)
-        agent_grid.addWidget(QLabel("Shell"), 1, 0)
+        agent_grid.addWidget(QLabel("Agent Shell"), 1, 0)
         agent_grid.addWidget(self._shell, 1, 1)
         agent_body.addLayout(agent_grid)
         agent_body.addStretch(1)
@@ -458,7 +481,7 @@ class _SettingsFormMixin:
                 )
                 nav_layout.addWidget(button)
                 self._nav_buttons[spec.key] = button
-                self._compact_nav.addItem(spec.title, spec.key)
+                self._compact_nav.addItem(button_label, spec.key)
 
         nav_layout.addStretch(1)
 
@@ -693,6 +716,11 @@ class _SettingsFormMixin:
 
             shell_value = str(settings.get("shell") or "bash").strip().lower()
             self._set_combo_value(self._shell, shell_value, fallback="bash")
+            self._refresh_terminal_options(
+                selected_terminal_id=str(
+                    settings.get("interactive_terminal_id") or ""
+                ).strip()
+            )
 
             self._host_codex_dir.setText(
                 os.path.expanduser(
@@ -807,6 +835,9 @@ class _SettingsFormMixin:
         return {
             "use": str(self._use.currentData() or get_default_agent_system_name()),
             "shell": str(self._shell.currentData() or "bash"),
+            "interactive_terminal_id": str(
+                self._interactive_terminal.currentData() or ""
+            ),
             "ui_theme": normalize_ui_theme_name(
                 str(self._ui_theme.currentData() or "auto"), allow_auto=True
             ),
@@ -896,6 +927,38 @@ class _SettingsFormMixin:
         )
         if path:
             self._host_gemini_dir.setText(path)
+
+    def _refresh_terminal_options(self, *, selected_terminal_id: str) -> None:
+        selected_id = str(selected_terminal_id or "").strip()
+        current_id = str(self._interactive_terminal.currentData() or "").strip()
+        options = detect_terminal_options()
+
+        with QSignalBlocker(self._interactive_terminal):
+            self._interactive_terminal.clear()
+            if not options:
+                self._interactive_terminal.addItem("No terminals detected", "")
+                self._interactive_terminal.setCurrentIndex(0)
+                return
+
+            for option in options:
+                self._interactive_terminal.addItem(option.label, option.terminal_id)
+
+            desired = selected_id or current_id
+            if not desired:
+                desired = str(options[0].terminal_id or "").strip()
+            self._set_combo_value(
+                self._interactive_terminal,
+                desired,
+                fallback=str(options[0].terminal_id or "").strip(),
+            )
+
+    def _on_refresh_terminal_options_clicked(self) -> None:
+        self._refresh_terminal_options(
+            selected_terminal_id=str(
+                self._interactive_terminal.currentData() or ""
+            ).strip()
+        )
+        self._trigger_immediate_autosave()
 
     @staticmethod
     def _set_combo_value(combo: QComboBox, value: str, fallback: str) -> None:

--- a/agents_runner/ui/pages/tasks.py
+++ b/agents_runner/ui/pages/tasks.py
@@ -91,7 +91,7 @@ class TasksPage(QWidget):
         self._title.setStyleSheet("font-size: 18px; font-weight: 750;")
         self._subtitle = QLabel("Workflow")
         self._subtitle.setObjectName("SettingsPaneSubtitle")
-        self._env_label = QLabel("Env")
+        self._env_label = QLabel("Environments")
         self._env_select = QComboBox()
         self._env_select.setFixedWidth(240)
         self._env_select.currentIndexChanged.connect(


### PR DESCRIPTION
## Summary
- Closes #220 by implementing the requested UI polish across Tasks, Settings, and Environments.

## What Changed
- Removed redundant in-pane headers and renamed top labels from `Env` to `Environments` where applicable.
- Improved Tasks interactions, including stable hover actions, loading skeleton rows, and base-branch visibility transitions.
- Moved interactive terminal selection to Settings > General > Preferences and wired New Task to use that setting.
- Reworked Environments panes/navigation, including separate Preflight/Caching sections.
- Replaced env var and mount text editors with row-based editors plus advanced-mode text editing.
- Wired autosave/load/save flows to the new environment editor widgets.

## Validation
- `uv run --with ruff ruff format .`
- `uv run --with ruff ruff check .`

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
