### PR TITLE
[FEATURE] Improve auto-review base branch selection

### DIFF
--- a/agents_runner/ui/dialogs/auto_review_branch_dialog.py
+++ b/agents_runner/ui/dialogs/auto_review_branch_dialog.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from PySide6.QtCore import QTimer
+from PySide6.QtWidgets import QComboBox
+from PySide6.QtWidgets import QDialogButtonBox
+from PySide6.QtWidgets import QLabel
+from PySide6.QtWidgets import QVBoxLayout
+from PySide6.QtWidgets import QWidget
+
+from agents_runner.ui.dialogs.themed_dialog import ThemedDialog
+from agents_runner.ui.widgets import GlassCard
+
+
+class AutoReviewBranchDialog(ThemedDialog):
+    def __init__(
+        self,
+        *,
+        environment_name: str,
+        previous_branch: str,
+        branches: list[str],
+        timeout_seconds: int = 15,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._seconds_left = max(1, int(timeout_seconds))
+        self._timeout_timer = QTimer(self)
+        self._timeout_timer.timeout.connect(self._on_timeout_tick)
+
+        self.setModal(True)
+        self.setWindowTitle("Auto-Review Base Branch")
+        self.setMinimumWidth(620)
+
+        layout = self.content_layout()
+        layout.setContentsMargins(14, 14, 14, 14)
+        layout.setSpacing(10)
+
+        title = QLabel("Saved base branch is no longer available.")
+        title.setStyleSheet("font-size: 15px; font-weight: 700;")
+        title.setWordWrap(True)
+        layout.addWidget(title)
+
+        details = QLabel(
+            "\n".join(
+                [
+                    f"Environment: {environment_name or '(unknown)'}",
+                    f"Saved branch: {previous_branch or '(none)'}",
+                    "Pick a branch for this auto-review task. If no action is taken,",
+                    "the current selection will be used automatically.",
+                ]
+            )
+        )
+        details.setStyleSheet("color: rgba(237, 239, 245, 175);")
+        details.setWordWrap(True)
+        layout.addWidget(details)
+
+        branch_card = GlassCard()
+        branch_layout = QVBoxLayout(branch_card)
+        branch_layout.setContentsMargins(14, 12, 14, 12)
+        branch_layout.setSpacing(6)
+
+        branch_label = QLabel("Base branch")
+        branch_label.setStyleSheet("font-weight: 650;")
+        self._branch_combo = QComboBox()
+        self.set_branches(branches=branches, selected=previous_branch)
+        branch_layout.addWidget(branch_label)
+        branch_layout.addWidget(self._branch_combo)
+        layout.addWidget(branch_card)
+
+        self._countdown = QLabel("")
+        self._countdown.setStyleSheet("color: rgba(237, 239, 245, 160);")
+        self._countdown.setWordWrap(True)
+        layout.addWidget(self._countdown)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        self._ok_button = buttons.button(QDialogButtonBox.Ok)
+        layout.addWidget(buttons)
+
+        self._update_countdown_text()
+        self._timeout_timer.start(1000)
+
+    def done(self, result: int) -> None:
+        if self._timeout_timer.isActive():
+            self._timeout_timer.stop()
+        super().done(result)
+
+    def selected_branch(self) -> str:
+        return str(self._branch_combo.currentData() or "").strip()
+
+    def set_branches(self, *, branches: list[str], selected: str | None = None) -> None:
+        wanted = str(selected or "").strip()
+        self._branch_combo.blockSignals(True)
+        try:
+            self._branch_combo.clear()
+            self._branch_combo.addItem("Auto", "")
+            for name in branches or []:
+                branch = str(name or "").strip()
+                if not branch:
+                    continue
+                self._branch_combo.addItem(branch, branch)
+            if wanted:
+                idx = self._branch_combo.findData(wanted)
+                if idx >= 0:
+                    self._branch_combo.setCurrentIndex(idx)
+                    return
+            self._branch_combo.setCurrentIndex(0)
+        finally:
+            self._branch_combo.blockSignals(False)
+
+    def _update_countdown_text(self) -> None:
+        self._countdown.setText(
+            (
+                "Auto-review will continue in "
+                f"{self._seconds_left}s using the currently selected branch."
+            )
+        )
+        if self._ok_button is not None:
+            self._ok_button.setText(f"OK ({self._seconds_left}s)")
+
+    def _on_timeout_tick(self) -> None:
+        self._seconds_left -= 1
+        if self._seconds_left <= 0:
+            self.accept()
+            return
+        self._update_countdown_text()

--- a/agents_runner/ui/main_window.py
+++ b/agents_runner/ui/main_window.py
@@ -33,6 +33,7 @@ from agents_runner.ui.widgets.radio_control import RadioControlWidget
 
 from agents_runner.ui.main_window_capacity import _MainWindowCapacityMixin
 from agents_runner.ui.main_window_dashboard import _MainWindowDashboardMixin
+from agents_runner.ui.main_window_auto_review import _MainWindowAutoReviewMixin
 from agents_runner.ui.main_window_environment import _MainWindowEnvironmentMixin
 from agents_runner.ui.main_window_navigation import _MainWindowNavigationMixin
 from agents_runner.ui.main_window_persistence import _MainWindowPersistenceMixin
@@ -57,6 +58,7 @@ class MainWindow(
     _MainWindowSettingsMixin,
     _MainWindowEnvironmentMixin,
     _MainWindowDashboardMixin,
+    _MainWindowAutoReviewMixin,
     _MainWindowTasksAgentMixin,
     _MainWindowTasksInteractiveMixin,
     _MainWindowTasksInteractiveFinalizeMixin,
@@ -286,10 +288,6 @@ class MainWindow(
         self._refresh_radio_channel_options(disable_on_failure=True)
         self._on_radio_state_changed(self._radio_controller.state_snapshot())
         self._try_start_queued_tasks()
-
-    def _on_auto_review_requested(self, env_id: str, prompt: str) -> None:
-        host_codex = str(self._settings_data.get("host_codex_dir") or "").strip()
-        self._start_task_from_ui(prompt, host_codex, env_id, "")
 
     def resizeEvent(self, event) -> None:
         super().resizeEvent(event)

--- a/agents_runner/ui/main_window_auto_review.py
+++ b/agents_runner/ui/main_window_auto_review.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from PySide6.QtWidgets import QDialog
+
+from agents_runner.environments import WORKSPACE_CLONED
+from agents_runner.gh.git_ops import git_list_remote_heads
+from agents_runner.ui.dialogs.auto_review_branch_dialog import AutoReviewBranchDialog
+from midori_ai_logger import MidoriAiLogger
+
+logger = MidoriAiLogger(channel=None, name=__name__)
+
+
+class _MainWindowAutoReviewMixin:
+    def _on_auto_review_requested(self, env_id: str, prompt: str) -> None:
+        selected_env_id = str(env_id or "").strip() or self._active_environment_id()
+        if not selected_env_id:
+            return
+
+        resolved_base_branch = self._resolve_auto_review_base_branch(
+            env_id=selected_env_id
+        )
+        if resolved_base_branch is None:
+            return
+
+        host_codex = str(self._settings_data.get("host_codex_dir") or "").strip()
+        self._start_task_from_ui(
+            prompt, host_codex, selected_env_id, resolved_base_branch
+        )
+
+    def _resolve_auto_review_base_branch(self, *, env_id: str) -> str | None:
+        env = self._environments.get(str(env_id or "").strip())
+        if env is None:
+            return ""
+
+        workspace_type = str(getattr(env, "workspace_type", "") or "").strip().lower()
+        if workspace_type != WORKSPACE_CLONED:
+            return ""
+
+        repo_target = str(getattr(env, "workspace_target", "") or "").strip()
+        if not repo_target:
+            return ""
+
+        branches = git_list_remote_heads(repo_target)
+        if not branches:
+            logger.warning(
+                (
+                    "[github-auto-review] skipped: failed to refresh remote branches "
+                    f"for environment '{env_id}' ({repo_target})."
+                )
+            )
+            return None
+
+        branch_lookup = {name.casefold(): name for name in branches}
+        saved_branch = str(getattr(env, "gh_last_base_branch", "") or "").strip()
+        if saved_branch:
+            matched = branch_lookup.get(saved_branch.casefold())
+            if matched:
+                return matched
+
+            dialog = AutoReviewBranchDialog(
+                environment_name=str(getattr(env, "name", "") or env_id),
+                previous_branch=saved_branch,
+                branches=branches,
+                timeout_seconds=15,
+                parent=self,
+            )
+            if dialog.exec() != QDialog.DialogCode.Accepted:
+                logger.info(
+                    (
+                        "[github-auto-review] skipped: branch selector cancelled for "
+                        f"environment '{env_id}'."
+                    )
+                )
+                return None
+
+            selected = str(dialog.selected_branch() or "").strip()
+            if not selected:
+                return ""
+            return branch_lookup.get(selected.casefold(), "")
+
+        return ""


### PR DESCRIPTION
## Summary
- Add auto-review base branch resolution for GitHub issue/PR mention-triggered runs.
- Use `gh_last_base_branch` when it still exists remotely.
- If the saved branch is no longer valid, show a themed timed branch selector (15s) with `Auto` plus refreshed remote branches.
- On timeout, continue with whatever is currently selected in the dropdown.
- If remote branch refresh fails, skip that auto-review run.

## Implementation
- Add `_MainWindowAutoReviewMixin` to resolve auto-review base branch decisions before task start.
- Add `AutoReviewBranchDialog` for invalid saved-branch fallback and timeout behavior.
- Wire `MainWindow` to the new auto-review mixin path.

## Validation
- `uvx ruff format .`
- `uvx ruff check .`
- `uv run python -m py_compile agents_runner/ui/main_window.py agents_runner/ui/main_window_auto_review.py agents_runner/ui/dialogs/auto_review_branch_dialog.py`

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
