### PR TITLE
Fix prompt section order and divider placement

### DIFF
--- a/agents_runner/docker/agent_worker_prompt.py
+++ b/agents_runner/docker/agent_worker_prompt.py
@@ -10,6 +10,7 @@ from agents_runner.prompt_sanitizer import sanitize_prompt
 from agents_runner.agent_cli import normalize_agent
 from agents_runner.environments import load_environments
 from agents_runner.prompts import load_prompt
+from agents_runner.prompts.sections import insert_prompt_sections_before_user_prompt
 from agents_runner.log_format import format_log
 from agents_runner.midoriai_template import MidoriAITemplateDetection
 
@@ -37,9 +38,22 @@ class PromptAssembler:
         """Assemble final prompt with desktop context and templates."""
         prompt_for_agent = self._base_prompt
 
+        if template_detection.midoriai_template_detected:
+            template_parts = self._load_template_parts(agent_cli)
+            if template_parts:
+                combined_template = "\n\n".join(template_parts)
+                prompt_for_agent = insert_prompt_sections_before_user_prompt(
+                    prompt_for_agent,
+                    [combined_template],
+                )
+                self._on_log(
+                    format_log("env", "template", "INFO", "injected template prompts")
+                )
+
         if desktop_enabled:
-            prompt_for_agent = sanitize_prompt(
-                f"{prompt_for_agent.rstrip()}{self._headless_desktop_prompt_instructions(display=desktop_display)}"
+            prompt_for_agent = insert_prompt_sections_before_user_prompt(
+                prompt_for_agent,
+                [self._headless_desktop_prompt_instructions(display=desktop_display)],
             )
             self._on_log(
                 format_log(
@@ -50,18 +64,7 @@ class PromptAssembler:
                 )
             )
 
-        if template_detection.midoriai_template_detected:
-            template_parts = self._load_template_parts(agent_cli)
-            if template_parts:
-                combined_template = "\n\n".join(template_parts)
-                prompt_for_agent = sanitize_prompt(
-                    f"{prompt_for_agent.rstrip()}\n\n{combined_template}"
-                )
-                self._on_log(
-                    format_log("env", "template", "INFO", "injected template prompts")
-                )
-
-        return prompt_for_agent
+        return sanitize_prompt(prompt_for_agent)
 
     def _load_template_parts(self, agent_cli: str) -> list[str]:
         """Load all template parts."""

--- a/agents_runner/prompts/sections.py
+++ b/agents_runner/prompts/sections.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+
+PROMPT_SECTION_DIVIDER = "-----"
+_PROMPT_SECTION_JOINER = f"\n\n{PROMPT_SECTION_DIVIDER}\n\n"
+
+
+def _clean_section(value: str | None) -> str:
+    return str(value or "").strip()
+
+
+def split_prompt_sections(prompt: str) -> list[str]:
+    text = str(prompt or "").strip()
+    if not text:
+        return []
+    if _PROMPT_SECTION_JOINER not in text:
+        return [text]
+    return [part.strip() for part in text.split(_PROMPT_SECTION_JOINER) if part.strip()]
+
+
+def compose_prompt_sections(sections: Sequence[str]) -> str:
+    cleaned = [_clean_section(section) for section in sections]
+    non_empty = [section for section in cleaned if section]
+    return _PROMPT_SECTION_JOINER.join(non_empty)
+
+
+def append_prompt_sections(prompt: str, sections: Sequence[str]) -> str:
+    existing = split_prompt_sections(prompt)
+    additions = [_clean_section(section) for section in sections]
+    additions = [section for section in additions if section]
+    return compose_prompt_sections([*existing, *additions])
+
+
+def insert_prompt_sections_before_user_prompt(
+    prompt: str, sections: Sequence[str]
+) -> str:
+    existing = split_prompt_sections(prompt)
+    additions = [_clean_section(section) for section in sections]
+    additions = [section for section in additions if section]
+
+    if not additions:
+        return compose_prompt_sections(existing)
+    if not existing:
+        return compose_prompt_sections(additions)
+
+    return compose_prompt_sections([*existing[:-1], *additions, existing[-1]])

--- a/agents_runner/prompts/task_builder.py
+++ b/agents_runner/prompts/task_builder.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from agents_runner.prompts.sections import insert_prompt_sections_before_user_prompt
+
 
 @dataclass(frozen=True, slots=True)
 class RetryContext:
@@ -29,7 +31,7 @@ def build_task_prompt(base_prompt: str, *, retry_context: RetryContext | None) -
         else f"attempt {retry_context.attempt_number}"
     )
 
-    preamble = "\n".join(
+    retry_section = "\n".join(
         [
             "RETRY CONTEXT",
             f"This is a retry attempt ({attempt_line}).",
@@ -46,8 +48,8 @@ def build_task_prompt(base_prompt: str, *, retry_context: RetryContext | None) -
             "4) Avoid deleting work or resetting the workspace unless the task explicitly asks for it.",
             "",
         ]
-    )
+    ).rstrip()
 
     if not prompt:
-        return preamble.rstrip()
-    return f"{preamble}{prompt}"
+        return retry_section
+    return insert_prompt_sections_before_user_prompt(prompt, [retry_section])


### PR DESCRIPTION
## Summary
- reorder prompt assembly to: 2, 3, 4, 5, 7, 6, 1 (and 8 for interactive typed runs)
- add a shared section composer with `-----` separators between included sections
- insert retry context immediately before the user prompt section on retry attempts

## Key changes
- add `agents_runner/prompts/sections.py` for section composition helpers
- update agent and interactive prompt builders to use section composition
- update GitHub/template/desktop insertion to preserve the new section order
- keep help-launch / non-full-prompt behavior unchanged

## Validation
- `uvx ruff check .`
- `python -m compileall` on changed files
- sanity check confirming retry context appears right before user prompt

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
