### PR TITLE
Add run-type env var for interactive vs normal container runs

### DIFF
--- a/agents_runner/docker/agent_worker_container.py
+++ b/agents_runner/docker/agent_worker_container.py
@@ -398,6 +398,7 @@ class ContainerExecutor:
             k = str(key).strip()
             if k:
                 env_args.extend(["-e", f"{k}={value}"])
+        env_args.extend(["-e", "MIDORI_AI_AGENTS_RUNNER_INTERACTIVE=false"])
 
         # Forward GitHub tokens if needed
         needs_token = (

--- a/agents_runner/ui/main_window_tasks_interactive_docker.py
+++ b/agents_runner/ui/main_window_tasks_interactive_docker.py
@@ -290,6 +290,7 @@ def launch_docker_terminal_task(
             if not k:
                 continue
             env_args.extend(["-e", f"{k}={value}"])
+        env_args.extend(["-e", "MIDORI_AI_AGENTS_RUNNER_INTERACTIVE=true"])
 
         # Check if we need to forward GH_TOKEN
         forward_gh_token = bool(


### PR DESCRIPTION
## Summary
- Add `MIDORI_AI_AGENTS_RUNNER_INTERACTIVE=true` to interactive Docker launches.
- Add `MIDORI_AI_AGENTS_RUNNER_INTERACTIVE=false` to non-interactive worker launches.
- Keep values as lowercase string booleans for script compatibility.

## Files
- `agents_runner/ui/main_window_tasks_interactive_docker.py`
- `agents_runner/docker/agent_worker_container.py`

## Validation
- `uvx ruff format agents_runner/ui/main_window_tasks_interactive_docker.py agents_runner/docker/agent_worker_container.py`
- `uvx ruff check agents_runner/ui/main_window_tasks_interactive_docker.py agents_runner/docker/agent_worker_container.py`
- Pre-commit hooks passed (`compileall`, import smoke)

## Commit
- `45ea1ec`

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
