### PR TITLE
[CI] Split gates into format/lint/type/tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -23,8 +23,8 @@ If the agent switched modes during the work, briefly explain below.
 ## Quick checklist
 
 - [ ] PR title uses `[TYPE] Title`.
-- [ ] Lint/format ran (command + result):
-- [ ] Tests ran (command + PASS/FAIL summary):
+- [ ] Lint/format ran (for example `uv sync --group ci && uv run ruff format --check . && uv run ruff check .`) (command + result):
+- [ ] Tests ran (for example `uv sync --group ci && uv run pytest -q`) (command + PASS/FAIL summary):
 - [ ] Docs updated (files, if any):
 - [ ] Task file moved (if applicable):
 

--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -1,0 +1,24 @@
+name: CI Format
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  format:
+    name: CI Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6.6.0
+
+      - name: Sync
+        run: uv sync --group ci
+
+      - name: Format Check
+        run: uv run ruff format --check .

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -1,0 +1,24 @@
+name: CI Lint
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: CI Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6.6.0
+
+      - name: Sync
+        run: uv sync --group ci
+
+      - name: Lint
+        run: uv run ruff check .

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,18 +1,20 @@
-name: CI
+name: CI Tests
 
 permissions:
   contents: read
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
-  lint-and-test:
+  tests:
+    name: CI Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        
+
       - uses: astral-sh/setup-uv@v6.6.0
       - uses: oven-sh/setup-bun@v2.0.2
       - uses: docker/setup-docker-action@v4
@@ -28,8 +30,5 @@ jobs:
       - name: Sync
         run: uv sync --group ci
 
-      - name: Lint
-        run: uv run ruff check --select F .
-
       - name: Tests
-        run: uv run pytest -q
+        run: uv run pytest -q --maxfail=1

--- a/.github/workflows/ci-type.yml
+++ b/.github/workflows/ci-type.yml
@@ -1,0 +1,24 @@
+name: CI Type
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  type:
+    name: CI Type
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6.6.0
+
+      - name: Sync
+        run: uv sync --group ci
+
+      - name: Type Check
+        run: uv run basedpyright

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ This project uses the Codex contributor coordination system. Follow these guidel
 - **Code style:** Python 3.13+, type hints, minimal diffs (avoid drive-by refactors)
 - **Docs:** Do not update `README.md`; prefer code and docstrings as the source of truth and keep notes minimal and task-scoped
 - **Commits:** Commit early and often — prefer many small, focused commits with clear `[TYPE]` messages and concise descriptions.
-- **Test:** Do not add/build tests unless explicitly requested. When requested, run via `uv run pytest`.
+- **Test:** Do not add/build tests unless explicitly requested. When requested, run via `uv sync --group ci && uv run pytest`.
 
 ---
 
@@ -76,14 +76,16 @@ This project uses the Codex contributor coordination system. Follow these guidel
   - Keep reusable logic separate from wiring; compute data first, then apply it in UI/widgets/themes.
   - For new features, add or reuse at least one shared helper instead of duplicating logic.
 
+- Sync CI toolchain (before lint/test/type): `uv sync --group ci`
 - Format with Ruff (before every commit): `uv run ruff format .`
 - Lint with Ruff (treat failures as blockers): `uv run ruff check .`
+- Type-check with basedpyright (strict): `uv run basedpyright`
 - Tests:
   - Do not add/build tests unless explicitly requested.
   - If you believe a test is really needed to prevent regressions, ask first (keep it minimal).
   - When tests are requested/approved, prefer package-scoped tests in that package’s `tests/` folder (for example `agents_runner/<subsystem>/tests/`).
   - `agents_runner/tests/` is reserved for full package or full-program/integration tests, and should only be used when explicitly requested.
-  - Run via `uv run pytest`.
+  - Run via `uv sync --group ci && uv run pytest`.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,10 @@ dependencies = [
 ]
 
 [dependency-groups]
-lint = [
+ci = [
     "ruff>=0.12.0",
-]
-test = [
     "pytest>=8.4.0",
+    "basedpyright>=1.34.0",
 ]
 
 [build-system]
@@ -34,6 +33,10 @@ packages = ["agents_runner"]
 [tool.pytest.ini_options]
 testpaths = ["agents_runner/tests"]
 pythonpath = ["."]
+
+[tool.basedpyright]
+typeCheckingMode = "strict"
+pythonVersion = "3.13"
 
 [tool.uv.sources]
 midori_ai_logger = { git = "https://github.com/Midori-AI-OSS/agents-packages.git", subdirectory = "logger" }


### PR DESCRIPTION
## Summary
- Added four standalone CI workflows: CI Format, CI Lint, CI Type, and CI Tests
- Unified developer tooling under a single `ci` dependency group in `pyproject.toml`
- Updated existing CI workflow sync step to `uv sync --group ci`
- Updated contributor docs/checklists that referenced lint/test commands to the new `ci` flow

## Validation
- `uv run ruff format --check .` passed
- `uv run ruff check .` passed
- `uv run basedpyright` currently reports a large existing strict-type backlog
- `uv run pytest -q --maxfail=1` aborted in local headless run at `test_tasks_nav_button_fade_behavior`

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
