### PR TITLE
[FIX] Guard environments pane animation rest position

### DIFF
--- a/agents_runner/ui/pages/environments.py
+++ b/agents_runner/ui/pages/environments.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 
 from PySide6.QtCore import Qt
+from PySide6.QtCore import QPoint
 from PySide6.QtCore import QTimer
 from PySide6.QtCore import Signal
 from PySide6.QtGui import QResizeEvent
@@ -70,7 +71,7 @@ class EnvironmentsPage(
         self._advanced_autosave_timer.timeout.connect(self._emit_autosave)
 
         self._pane_animation = None
-        self._pane_rest_pos = None
+        self._pane_rest_pos: QPoint | None = None
         self._compact_mode = False
         self._active_pane_key = ""
 

--- a/agents_runner/ui/pages/environments_navigation.py
+++ b/agents_runner/ui/pages/environments_navigation.py
@@ -102,7 +102,8 @@ class EnvironmentsNavigationMixin:
             self._pane_animation.stop()
             self._pane_animation = None
 
-        self._page_stack.move(self._pane_rest_pos)
+        if self._pane_rest_pos is not None:
+            self._page_stack.move(self._pane_rest_pos)
         self._page_stack.setGraphicsEffect(None)
 
         base_pos = self._page_stack.pos()


### PR DESCRIPTION
## Summary
- fix a crash when switching panes in Environments/Settings navigation caused by `QWidget.move(None)`
- add a null guard before resetting the page-stack position in `EnvironmentsNavigationMixin._animate_stack`
- annotate `EnvironmentsPage._pane_rest_pos` as `QPoint | None` for parity with sibling pages and clearer typing

## Verification
- `uv run ruff format agents_runner/ui/pages/environments.py agents_runner/ui/pages/environments_navigation.py`
- `uv run ruff check agents_runner/ui/pages/environments.py agents_runner/ui/pages/environments_navigation.py`
- `uv run basedpyright` (known repo-wide baseline failures)
- `uv run basedpyright agents_runner/ui/pages/environments.py agents_runner/ui/pages/environments_navigation.py` (baseline mixin/Qt typing issues)

## Notes
- settings/tasks pane animation implementations were audited and already had the guard pattern; no changes required there.

---
{marker}
Created by [Midori AI Agents Runner]({agents_runner_url})
Agent Used: {agent_used}
Related: [Midori AI Monorepo]({midori_ai_url})
