### PR TITLE
Standardize panel scrolling and environment-aware nav tinting

### DIFF
--- a/agents_runner/ui/constants.py
+++ b/agents_runner/ui/constants.py
@@ -20,6 +20,7 @@ MAIN_LAYOUT_SPACING = 14
 # Left navigation panel constants
 LEFT_NAV_PANEL_WIDTH = 280
 LEFT_NAV_COMPACT_THRESHOLD = 1080
+LEFT_NAV_BUTTON_SPACING = 10
 
 # Header constants (GlassCard with title/subtitle/back)
 HEADER_MARGINS = (18, 16, 18, 16)

--- a/agents_runner/ui/pages/environments.py
+++ b/agents_runner/ui/pages/environments.py
@@ -28,6 +28,7 @@ from agents_runner.ui.constants import (
     CARD_SPACING,
     HEADER_MARGINS,
     HEADER_SPACING,
+    LEFT_NAV_BUTTON_SPACING,
     LEFT_NAV_PANEL_WIDTH,
     MAIN_LAYOUT_MARGINS,
     MAIN_LAYOUT_SPACING,
@@ -39,7 +40,7 @@ from agents_runner.ui.pages.environments_navigation import EnvironmentsNavigatio
 from agents_runner.ui.pages.github_trust import normalize_trusted_mode
 from agents_runner.ui.utils import apply_environment_combo_tint
 from agents_runner.ui.utils import stain_color
-from agents_runner.ui.widgets import GlassCard
+from agents_runner.ui.widgets import EdgeFadeScrollArea, GlassCard
 
 
 class EnvironmentsPage(
@@ -139,12 +140,16 @@ class EnvironmentsPage(
         panes_layout.setContentsMargins(0, 0, 0, 0)
         panes_layout.setSpacing(14)
 
+        self._nav_scroll = EdgeFadeScrollArea()
+        self._nav_scroll.setObjectName("SettingsNavScrollArea")
+        self._nav_scroll.setFixedWidth(LEFT_NAV_PANEL_WIDTH)
+
         self._nav_panel = QWidget()
         self._nav_panel.setObjectName("SettingsNavPanel")
-        self._nav_panel.setFixedWidth(LEFT_NAV_PANEL_WIDTH)
         nav_layout = QVBoxLayout(self._nav_panel)
         nav_layout.setContentsMargins(10, 10, 10, 10)
-        nav_layout.setSpacing(6)
+        nav_layout.setSpacing(LEFT_NAV_BUTTON_SPACING)
+        self._nav_scroll.setWidget(self._nav_panel)
 
         self._right_panel = QWidget()
         self._right_panel.setObjectName("SettingsPaneHost")
@@ -156,7 +161,7 @@ class EnvironmentsPage(
         self._page_stack.setObjectName("SettingsPageStack")
         right_layout.addWidget(self._page_stack, 1)
 
-        panes_layout.addWidget(self._nav_panel)
+        panes_layout.addWidget(self._nav_scroll)
         panes_layout.addWidget(self._right_panel, 1)
         card_layout.addLayout(panes_layout, 1)
 

--- a/agents_runner/ui/pages/environments.py
+++ b/agents_runner/ui/pages/environments.py
@@ -196,15 +196,28 @@ class EnvironmentsPage(
             stain = (env.normalized_color() if env else "").strip().lower()
 
         if not stain:
+            self._apply_nav_button_stain("")
             self._env_select.setStyleSheet("")
             self._tint_overlay.set_tint_color(None)
             self._color.setStyleSheet("")
             return
 
+        self._apply_nav_button_stain(stain)
         apply_environment_combo_tint(self._env_select, stain)
         tint = stain_color(stain)
         self._tint_overlay.set_tint_color(tint)
         apply_environment_combo_tint(self._color, stain)
+
+    def _apply_nav_button_stain(self, stain: str) -> None:
+        normalized = str(stain or "").strip().lower()
+        for button in self._nav_buttons.values():
+            if str(button.property("env_stain") or "") == normalized:
+                continue
+            button.setProperty("env_stain", normalized)
+            style = button.style()
+            style.unpolish(button)
+            style.polish(button)
+            button.update()
 
     def set_environments(self, envs: dict[str, Environment], active_id: str) -> None:
         self._environments = dict(envs)

--- a/agents_runner/ui/pages/environments_form.py
+++ b/agents_runner/ui/pages/environments_form.py
@@ -37,6 +37,7 @@ from agents_runner.ui.pages.environments_env_vars import EnvVarsTabWidget
 from agents_runner.ui.pages.environments_mounts import MountsTabWidget
 from agents_runner.ui.pages.environments_ports import PortsTabWidget
 from agents_runner.ui.pages.environments_prompts import PromptsTabWidget
+from agents_runner.ui.widgets import EdgeFadeScrollArea
 
 
 @dataclass(frozen=True)
@@ -404,7 +405,15 @@ class EnvironmentsFormMixin:
         page = QWidget()
         page_layout = QVBoxLayout(page)
         page_layout.setContentsMargins(0, 0, 0, 0)
-        page_layout.setSpacing(10)
+        page_layout.setSpacing(0)
+
+        scroll = EdgeFadeScrollArea(page)
+        scroll.setObjectName("SettingsPaneScrollArea")
+
+        content = QWidget(scroll)
+        content_layout = QVBoxLayout(content)
+        content_layout.setContentsMargins(0, 0, 0, 0)
+        content_layout.setSpacing(10)
 
         title = QLabel(spec.title)
         title.setObjectName("SettingsPaneTitle")
@@ -413,14 +422,17 @@ class EnvironmentsFormMixin:
         subtitle.setObjectName("SettingsPaneSubtitle")
         subtitle.setWordWrap(True)
 
-        body = QWidget(page)
+        body = QWidget(content)
         body_layout = QVBoxLayout(body)
         body_layout.setContentsMargins(0, 0, 0, 0)
         body_layout.setSpacing(GRID_VERTICAL_SPACING)
 
-        page_layout.addWidget(title)
-        page_layout.addWidget(subtitle)
-        page_layout.addWidget(body, 1)
+        content_layout.addWidget(title)
+        content_layout.addWidget(subtitle)
+        content_layout.addWidget(body)
+
+        scroll.setWidget(content)
+        page_layout.addWidget(scroll, 1)
         return page, body_layout
 
     def _register_page(self, key: str, widget: QWidget) -> None:

--- a/agents_runner/ui/pages/environments_navigation.py
+++ b/agents_runner/ui/pages/environments_navigation.py
@@ -158,4 +158,4 @@ class EnvironmentsNavigationMixin:
             return
         self._compact_mode = compact
         self._compact_nav.setVisible(compact)
-        self._nav_panel.setVisible(not compact)
+        self._nav_scroll.setVisible(not compact)

--- a/agents_runner/ui/pages/settings.py
+++ b/agents_runner/ui/pages/settings.py
@@ -19,6 +19,7 @@ from PySide6.QtWidgets import QVBoxLayout
 from PySide6.QtWidgets import QWidget
 
 from agents_runner.ui.widgets import GlassCard
+from agents_runner.ui.widgets import EdgeFadeScrollArea
 from agents_runner.ui.constants import (
     AUTOSAVE_DISCRETE_MS,
     MAIN_LAYOUT_MARGINS,
@@ -27,6 +28,7 @@ from agents_runner.ui.constants import (
     HEADER_SPACING,
     CARD_MARGINS,
     CARD_SPACING,
+    LEFT_NAV_BUTTON_SPACING,
     LEFT_NAV_COMPACT_THRESHOLD,
     LEFT_NAV_PANEL_WIDTH,
 )
@@ -97,12 +99,16 @@ class SettingsPage(QWidget, SettingsFormMixin):
         panes_layout.setContentsMargins(0, 0, 0, 0)
         panes_layout.setSpacing(14)
 
+        self._nav_scroll = EdgeFadeScrollArea()
+        self._nav_scroll.setObjectName("SettingsNavScrollArea")
+        self._nav_scroll.setFixedWidth(LEFT_NAV_PANEL_WIDTH)
+
         self._nav_panel = QWidget()
         self._nav_panel.setObjectName("SettingsNavPanel")
-        self._nav_panel.setFixedWidth(LEFT_NAV_PANEL_WIDTH)
         nav_layout = QVBoxLayout(self._nav_panel)
         nav_layout.setContentsMargins(10, 10, 10, 10)
-        nav_layout.setSpacing(6)
+        nav_layout.setSpacing(LEFT_NAV_BUTTON_SPACING)
+        self._nav_scroll.setWidget(self._nav_panel)
 
         self._right_panel = QWidget()
         self._right_panel.setObjectName("SettingsPaneHost")
@@ -114,7 +120,7 @@ class SettingsPage(QWidget, SettingsFormMixin):
         self._page_stack.setObjectName("SettingsPageStack")
         right_layout.addWidget(self._page_stack, 1)
 
-        panes_layout.addWidget(self._nav_panel)
+        panes_layout.addWidget(self._nav_scroll)
         panes_layout.addWidget(self._right_panel, 1)
 
         card_layout.addLayout(panes_layout, 1)
@@ -307,4 +313,4 @@ class SettingsPage(QWidget, SettingsFormMixin):
             return
         self._compact_mode = compact
         self._compact_nav.setVisible(compact)
-        self._nav_panel.setVisible(not compact)
+        self._nav_scroll.setVisible(not compact)

--- a/agents_runner/ui/pages/settings_form.py
+++ b/agents_runner/ui/pages/settings_form.py
@@ -37,6 +37,7 @@ from agents_runner.ui.radio import RadioController
 from agents_runner.ui.dialogs.theme_preview_dialog import ThemePreviewDialog
 from agents_runner.ui.graphics import available_ui_theme_names
 from agents_runner.ui.graphics import normalize_ui_theme_name
+from agents_runner.ui.widgets import EdgeFadeScrollArea
 from agents_runner.ui.widgets.theme_preview import ThemePreviewTile
 from agents_runner.ui.constants import (
     GRID_HORIZONTAL_SPACING,
@@ -570,7 +571,15 @@ class SettingsFormMixin:
         page = QWidget()
         page_layout = QVBoxLayout(page)
         page_layout.setContentsMargins(0, 0, 0, 0)
-        page_layout.setSpacing(10)
+        page_layout.setSpacing(0)
+
+        scroll = EdgeFadeScrollArea(page)
+        scroll.setObjectName("SettingsPaneScrollArea")
+
+        content = QWidget(scroll)
+        content_layout = QVBoxLayout(content)
+        content_layout.setContentsMargins(0, 0, 0, 0)
+        content_layout.setSpacing(10)
 
         title = QLabel(spec.title)
         title.setObjectName("SettingsPaneTitle")
@@ -579,14 +588,17 @@ class SettingsFormMixin:
         subtitle.setObjectName("SettingsPaneSubtitle")
         subtitle.setWordWrap(True)
 
-        body = QWidget(page)
+        body = QWidget(content)
         body_layout = QVBoxLayout(body)
         body_layout.setContentsMargins(0, 0, 0, 0)
         body_layout.setSpacing(GRID_VERTICAL_SPACING)
 
-        page_layout.addWidget(title)
-        page_layout.addWidget(subtitle)
-        page_layout.addWidget(body, 1)
+        content_layout.addWidget(title)
+        content_layout.addWidget(subtitle)
+        content_layout.addWidget(body)
+
+        scroll.setWidget(content)
+        page_layout.addWidget(scroll, 1)
         return page, body_layout
 
     def _register_page(self, key: str, widget: QWidget) -> None:

--- a/agents_runner/ui/pages/tasks.py
+++ b/agents_runner/ui/pages/tasks.py
@@ -25,6 +25,7 @@ from agents_runner.ui.constants import CARD_MARGINS
 from agents_runner.ui.constants import CARD_SPACING
 from agents_runner.ui.constants import HEADER_MARGINS
 from agents_runner.ui.constants import HEADER_SPACING
+from agents_runner.ui.constants import LEFT_NAV_BUTTON_SPACING
 from agents_runner.ui.constants import LEFT_NAV_COMPACT_THRESHOLD
 from agents_runner.ui.constants import LEFT_NAV_PANEL_WIDTH
 from agents_runner.ui.constants import MAIN_LAYOUT_MARGINS
@@ -35,7 +36,7 @@ from agents_runner.ui.pages.github_work_list import GitHubWorkListPage
 from agents_runner.ui.pages.new_task import NewTaskPage
 from agents_runner.ui.utils import apply_environment_combo_tint
 from agents_runner.ui.utils import stain_color
-from agents_runner.ui.widgets import GlassCard
+from agents_runner.ui.widgets import EdgeFadeScrollArea, GlassCard
 
 
 _GITHUB_NAV_KEYS = ("pull_requests", "issues")
@@ -124,12 +125,16 @@ class TasksPage(QWidget):
         panes_layout.setContentsMargins(0, 0, 0, 0)
         panes_layout.setSpacing(14)
 
+        self._nav_scroll = EdgeFadeScrollArea()
+        self._nav_scroll.setObjectName("SettingsNavScrollArea")
+        self._nav_scroll.setFixedWidth(LEFT_NAV_PANEL_WIDTH)
+
         self._nav_panel = QWidget()
         self._nav_panel.setObjectName("SettingsNavPanel")
-        self._nav_panel.setFixedWidth(LEFT_NAV_PANEL_WIDTH)
         nav_layout = QVBoxLayout(self._nav_panel)
         nav_layout.setContentsMargins(10, 10, 10, 10)
-        nav_layout.setSpacing(6)
+        nav_layout.setSpacing(LEFT_NAV_BUTTON_SPACING)
+        self._nav_scroll.setWidget(self._nav_panel)
 
         self._right_panel = QWidget()
         self._right_panel.setObjectName("SettingsPaneHost")
@@ -141,7 +146,7 @@ class TasksPage(QWidget):
         self._page_stack.setObjectName("SettingsPageStack")
         right_layout.addWidget(self._page_stack, 1)
 
-        panes_layout.addWidget(self._nav_panel)
+        panes_layout.addWidget(self._nav_scroll)
         panes_layout.addWidget(self._right_panel, 1)
 
         card_layout.addLayout(panes_layout, 1)
@@ -522,7 +527,7 @@ class TasksPage(QWidget):
             and state_changed
             and self.isVisible()
             and not self._compact_mode
-            and self._nav_panel.isVisible()
+            and self._nav_scroll.isVisible()
         )
 
         if should_animate:
@@ -625,4 +630,4 @@ class TasksPage(QWidget):
             return
         self._compact_mode = compact
         self._compact_nav.setVisible(compact)
-        self._nav_panel.setVisible(not compact)
+        self._nav_scroll.setVisible(not compact)

--- a/agents_runner/ui/style/template_base.py
+++ b/agents_runner/ui/style/template_base.py
@@ -383,6 +383,150 @@ TEMPLATE_BASE = """
         background-color: rgba(56, 189, 248, 76);
     }
 
+    /* Environments page: tint nav hover + selected states by active environment stain. */
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="cyan"]:hover {
+        border: 1px solid rgba(56, 189, 248, 70);
+        background-color: rgba(56, 189, 248, 20);
+    }
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="cyan"]:checked {
+        border: 1px solid rgba(56, 189, 248, 110);
+        background-color: rgba(56, 189, 248, 62);
+    }
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="cyan"]:checked:hover {
+        border: 1px solid rgba(56, 189, 248, 130);
+        background-color: rgba(56, 189, 248, 76);
+    }
+
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="emerald"]:hover {
+        border: 1px solid rgba(16, 185, 129, 70);
+        background-color: rgba(16, 185, 129, 20);
+    }
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="emerald"]:checked {
+        border: 1px solid rgba(16, 185, 129, 110);
+        background-color: rgba(16, 185, 129, 62);
+    }
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="emerald"]:checked:hover {
+        border: 1px solid rgba(16, 185, 129, 130);
+        background-color: rgba(16, 185, 129, 76);
+    }
+
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="violet"]:hover {
+        border: 1px solid rgba(139, 92, 246, 70);
+        background-color: rgba(139, 92, 246, 20);
+    }
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="violet"]:checked {
+        border: 1px solid rgba(139, 92, 246, 110);
+        background-color: rgba(139, 92, 246, 62);
+    }
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="violet"]:checked:hover {
+        border: 1px solid rgba(139, 92, 246, 130);
+        background-color: rgba(139, 92, 246, 76);
+    }
+
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="rose"]:hover {
+        border: 1px solid rgba(244, 63, 94, 70);
+        background-color: rgba(244, 63, 94, 20);
+    }
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="rose"]:checked {
+        border: 1px solid rgba(244, 63, 94, 110);
+        background-color: rgba(244, 63, 94, 62);
+    }
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="rose"]:checked:hover {
+        border: 1px solid rgba(244, 63, 94, 130);
+        background-color: rgba(244, 63, 94, 76);
+    }
+
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="amber"]:hover {
+        border: 1px solid rgba(245, 158, 11, 70);
+        background-color: rgba(245, 158, 11, 20);
+    }
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="amber"]:checked {
+        border: 1px solid rgba(245, 158, 11, 110);
+        background-color: rgba(245, 158, 11, 62);
+    }
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="amber"]:checked:hover {
+        border: 1px solid rgba(245, 158, 11, 130);
+        background-color: rgba(245, 158, 11, 76);
+    }
+
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="blue"]:hover {
+        border: 1px solid rgba(59, 130, 246, 70);
+        background-color: rgba(59, 130, 246, 20);
+    }
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="blue"]:checked {
+        border: 1px solid rgba(59, 130, 246, 110);
+        background-color: rgba(59, 130, 246, 62);
+    }
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="blue"]:checked:hover {
+        border: 1px solid rgba(59, 130, 246, 130);
+        background-color: rgba(59, 130, 246, 76);
+    }
+
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="teal"]:hover {
+        border: 1px solid rgba(20, 184, 166, 70);
+        background-color: rgba(20, 184, 166, 20);
+    }
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="teal"]:checked {
+        border: 1px solid rgba(20, 184, 166, 110);
+        background-color: rgba(20, 184, 166, 62);
+    }
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="teal"]:checked:hover {
+        border: 1px solid rgba(20, 184, 166, 130);
+        background-color: rgba(20, 184, 166, 76);
+    }
+
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="lime"]:hover {
+        border: 1px solid rgba(132, 204, 22, 70);
+        background-color: rgba(132, 204, 22, 20);
+    }
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="lime"]:checked {
+        border: 1px solid rgba(132, 204, 22, 110);
+        background-color: rgba(132, 204, 22, 62);
+    }
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="lime"]:checked:hover {
+        border: 1px solid rgba(132, 204, 22, 130);
+        background-color: rgba(132, 204, 22, 76);
+    }
+
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="fuchsia"]:hover {
+        border: 1px solid rgba(217, 70, 239, 70);
+        background-color: rgba(217, 70, 239, 20);
+    }
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="fuchsia"]:checked {
+        border: 1px solid rgba(217, 70, 239, 110);
+        background-color: rgba(217, 70, 239, 62);
+    }
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="fuchsia"]:checked:hover {
+        border: 1px solid rgba(217, 70, 239, 130);
+        background-color: rgba(217, 70, 239, 76);
+    }
+
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="indigo"]:hover {
+        border: 1px solid rgba(99, 102, 241, 70);
+        background-color: rgba(99, 102, 241, 20);
+    }
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="indigo"]:checked {
+        border: 1px solid rgba(99, 102, 241, 110);
+        background-color: rgba(99, 102, 241, 62);
+    }
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="indigo"]:checked:hover {
+        border: 1px solid rgba(99, 102, 241, 130);
+        background-color: rgba(99, 102, 241, 76);
+    }
+
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="orange"]:hover {
+        border: 1px solid rgba(249, 115, 22, 70);
+        background-color: rgba(249, 115, 22, 20);
+    }
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="orange"]:checked {
+        border: 1px solid rgba(249, 115, 22, 110);
+        background-color: rgba(249, 115, 22, 62);
+    }
+    QWidget#EnvironmentsPageRoot QToolButton#SettingsNavButton[env_stain="orange"]:checked:hover {
+        border: 1px solid rgba(249, 115, 22, 130);
+        background-color: rgba(249, 115, 22, 76);
+    }
+
     QLabel#SettingsPaneTitle {
         font-size: 16px;
         font-weight: 760;

--- a/agents_runner/ui/style/template_base.py
+++ b/agents_runner/ui/style/template_base.py
@@ -333,6 +333,21 @@ TEMPLATE_BASE = """
         border-radius: 0px;
     }
 
+    QScrollArea#SettingsNavScrollArea,
+    QScrollArea#SettingsPaneScrollArea {
+        background: transparent;
+        border: none;
+    }
+
+    QScrollArea#SettingsNavScrollArea > QWidget > QWidget,
+    QScrollArea#SettingsPaneScrollArea > QWidget > QWidget {
+        background: transparent;
+    }
+
+    QWidget#ScrollEdgeFadeOverlay {
+        background: transparent;
+    }
+
     QLabel#SettingsNavSection {
         color: rgba(237, 239, 245, 145);
         font-size: 11px;

--- a/agents_runner/ui/widgets/__init__.py
+++ b/agents_runner/ui/widgets/__init__.py
@@ -3,6 +3,7 @@ from .animated_button import AnimatedPushButton, AnimatedToolButton
 from .animated_checkbox import AnimatedCheckBox
 from .arc_spinner import ArcSpinner
 from .artifact_highlighter import ArtifactSyntaxHighlighter, detect_language
+from .edge_fade_scroll_area import EdgeFadeScrollArea
 from .glass_card import GlassCard
 from .loading_bar import BouncingLoadingBar
 from .log_highlighter import LogHighlighter
@@ -21,6 +22,7 @@ __all__ = [
     "ArcSpinner",
     "ArtifactSyntaxHighlighter",
     "BouncingLoadingBar",
+    "EdgeFadeScrollArea",
     "GlassCard",
     "LogHighlighter",
     "SmoothScrollArea",

--- a/agents_runner/ui/widgets/edge_fade_scroll_area.py
+++ b/agents_runner/ui/widgets/edge_fade_scroll_area.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from PySide6.QtCore import QEvent, Qt
+from PySide6.QtGui import QColor, QLinearGradient, QPaintEvent, QPainter
+from PySide6.QtWidgets import QScrollArea, QWidget
+
+
+class _ScrollEdgeFadeOverlay(QWidget):
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("ScrollEdgeFadeOverlay")
+        self._top_visible = False
+        self._bottom_visible = False
+        self._fade_px = 24
+        self._fade_alpha = 48
+        self.setAttribute(Qt.WA_TransparentForMouseEvents, True)
+        self.setAttribute(Qt.WA_NoSystemBackground, True)
+        self.setAutoFillBackground(False)
+
+    def set_state(
+        self, *, top_visible: bool, bottom_visible: bool, fade_px: int, fade_alpha: int
+    ) -> None:
+        top_visible = bool(top_visible)
+        bottom_visible = bool(bottom_visible)
+        fade_px = max(0, int(fade_px))
+        fade_alpha = max(0, min(255, int(fade_alpha)))
+        if (
+            self._top_visible == top_visible
+            and self._bottom_visible == bottom_visible
+            and self._fade_px == fade_px
+            and self._fade_alpha == fade_alpha
+        ):
+            return
+        self._top_visible = top_visible
+        self._bottom_visible = bottom_visible
+        self._fade_px = fade_px
+        self._fade_alpha = fade_alpha
+        self.setVisible(self._top_visible or self._bottom_visible)
+        self.update()
+
+    def paintEvent(self, event: QPaintEvent) -> None:
+        del event
+        if (
+            not self._top_visible and not self._bottom_visible
+        ) or self._fade_alpha <= 0:
+            return
+
+        width = int(self.width())
+        height = int(self.height())
+        if width <= 0 or height <= 0:
+            return
+
+        fade_px = int(min(max(self._fade_px, 0), max(0, height // 2)))
+        if fade_px <= 0:
+            return
+
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing, False)
+        color = QColor(0, 0, 0, self._fade_alpha)
+
+        if self._top_visible:
+            top_gradient = QLinearGradient(0, 0, 0, fade_px)
+            top_gradient.setColorAt(0.0, color)
+            top_gradient.setColorAt(1.0, QColor(0, 0, 0, 0))
+            painter.fillRect(0, 0, width, fade_px, top_gradient)
+
+        if self._bottom_visible:
+            bottom_gradient = QLinearGradient(0, height - fade_px, 0, height)
+            bottom_gradient.setColorAt(0.0, QColor(0, 0, 0, 0))
+            bottom_gradient.setColorAt(1.0, color)
+            painter.fillRect(0, height - fade_px, width, fade_px, bottom_gradient)
+
+
+class EdgeFadeScrollArea(QScrollArea):
+    """QScrollArea with conditional top/bottom edge fades."""
+
+    def __init__(
+        self,
+        parent: QWidget | None = None,
+        *,
+        fade_px: int = 24,
+        fade_alpha: int = 48,
+    ) -> None:
+        super().__init__(parent)
+        self._fade_px = max(0, int(fade_px))
+        self._fade_alpha = max(0, min(255, int(fade_alpha)))
+
+        self.setWidgetResizable(True)
+        self.setFrameShape(QScrollArea.NoFrame)
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+
+        self._overlay = _ScrollEdgeFadeOverlay(self.viewport())
+        self._overlay.hide()
+        self._overlay.raise_()
+
+        scrollbar = self.verticalScrollBar()
+        scrollbar.valueChanged.connect(self._sync_edge_fades)
+        scrollbar.rangeChanged.connect(self._on_scroll_range_changed)
+        self.viewport().installEventFilter(self)
+
+        self._sync_overlay_geometry()
+        self._sync_edge_fades()
+
+    def setWidget(self, widget: QWidget) -> None:
+        super().setWidget(widget)
+        self._sync_overlay_geometry()
+        self._sync_edge_fades()
+
+    def set_fade_parameters(
+        self, *, fade_px: int | None = None, fade_alpha: int | None = None
+    ) -> None:
+        if fade_px is not None:
+            self._fade_px = max(0, int(fade_px))
+        if fade_alpha is not None:
+            self._fade_alpha = max(0, min(255, int(fade_alpha)))
+        self._sync_edge_fades()
+
+    def refresh_edge_fades(self) -> None:
+        self._sync_edge_fades()
+
+    def eventFilter(self, obj: object, event: QEvent) -> bool:
+        if obj is self.viewport() and event.type() in (
+            QEvent.Type.Resize,
+            QEvent.Type.Show,
+            QEvent.Type.LayoutRequest,
+        ):
+            self._sync_overlay_geometry()
+            self._sync_edge_fades()
+        return super().eventFilter(obj, event)
+
+    def _sync_overlay_geometry(self) -> None:
+        self._overlay.setGeometry(self.viewport().rect())
+        self._overlay.raise_()
+
+    def _on_scroll_range_changed(self, _minimum: int, _maximum: int) -> None:
+        self._sync_edge_fades()
+
+    def _sync_edge_fades(self, _value: int | None = None) -> None:
+        scrollbar = self.verticalScrollBar()
+        minimum = int(scrollbar.minimum())
+        maximum = int(scrollbar.maximum())
+        value = int(scrollbar.value())
+        has_overflow = maximum > minimum
+        show_top = has_overflow and value > minimum
+        show_bottom = has_overflow and value < maximum
+        self._overlay.set_state(
+            top_visible=show_top,
+            bottom_visible=show_bottom,
+            fade_px=self._fade_px,
+            fade_alpha=self._fade_alpha,
+        )


### PR DESCRIPTION
## Summary
- add reusable `EdgeFadeScrollArea` with subtle conditional top/bottom edge fades
- standardize left panel nav spacing to `10px` in Tasks, Environments, and Settings
- make Settings and Environments right pane pages scrollable with conditional edge fades
- keep Tasks right pane behavior unchanged to avoid nested scroll regressions
- tint Environments left-nav button hover/selected states by active environment stain

## Validation
- `uv sync --group ci`
- `uv run ruff format <touched files>`
- `uv run ruff check <touched files>`
- `uv run python -m py_compile <touched files>`
- `QT_QPA_PLATFORM=offscreen uv run python` smoke instantiate Tasks/Settings/Environments pages

## Notes
- full-project `basedpyright` still reports existing baseline errors unrelated to this change set

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
