### PR TITLE
Fix GitHub polling startup latch and add start-path tests

### DIFF
--- a/agents_runner/tests/test_github_polling_runtime_probe.py
+++ b/agents_runner/tests/test_github_polling_runtime_probe.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import os
+import time
+
+from PySide6.QtCore import QCoreApplication
+from PySide6.QtCore import QEventLoop
+from PySide6.QtCore import QTimer
+
+import pytest
+
+from agents_runner.environments import Environment
+from agents_runner.environments import WORKSPACE_CLONED
+from agents_runner.ui.pages.github_work_coordinator import GitHubWorkCoordinator
+
+
+_ENABLE_RUNTIME_TEST_ENV = "RUN_GITHUB_POLL_RUNTIME_TEST"
+_DURATION_ENV = "GITHUB_POLL_RUNTIME_DURATION_S"
+_INTERVAL_ENV = "GITHUB_POLL_RUNTIME_INTERVAL_S"
+
+
+def _env_int(name: str, default: int, *, minimum: int) -> int:
+    raw = str(os.environ.get(name, default)).strip()
+    try:
+        parsed = int(raw)
+    except Exception:
+        parsed = default
+    return max(minimum, parsed)
+
+
+def test_github_polling_runtime_refresh_counts() -> None:
+    """Long-running runtime probe for GitHub background polling.
+
+    This test is intentionally opt-in because it runs for a few minutes and uses
+    live GitHub queries for Midori-AI-OSS/Agents-Runner.
+    """
+
+    if str(os.environ.get(_ENABLE_RUNTIME_TEST_ENV, "")).strip() != "1":
+        pytest.skip(
+            "Set RUN_GITHUB_POLL_RUNTIME_TEST=1 to run this multi-minute runtime probe."
+        )
+
+    duration_s = _env_int(_DURATION_ENV, 180, minimum=60)
+    interval_s = _env_int(_INTERVAL_ENV, 15, minimum=5)
+
+    app = QCoreApplication.instance()
+    if app is None:
+        app = QCoreApplication([])
+
+    coordinator = GitHubWorkCoordinator()
+    counts: dict[str, int] = {"pr": 0, "issue": 0}
+    started_at = time.monotonic()
+    first_refresh_delay_s: float | None = None
+
+    def _on_cache_updated(item_type: str, env_id: str) -> None:
+        nonlocal first_refresh_delay_s
+
+        key = str(item_type or "").strip().lower()
+        if key not in counts:
+            counts[key] = 0
+        counts[key] += 1
+
+        elapsed_s = time.monotonic() - started_at
+        if first_refresh_delay_s is None:
+            first_refresh_delay_s = elapsed_s
+
+        print(
+            f"[github-poll-runtime] +{elapsed_s:6.1f}s refreshed {key} for {env_id} "
+            f"(count={counts[key]})",
+            flush=True,
+        )
+
+    coordinator.cache_updated.connect(_on_cache_updated)
+
+    env_id = "runtime-probe"
+    coordinator.set_environments(
+        {
+            env_id: Environment(
+                env_id=env_id,
+                name="Runtime Probe",
+                workspace_type=WORKSPACE_CLONED,
+                workspace_target="Midori-AI-OSS/Agents-Runner",
+                github_polling_enabled=True,
+            )
+        }
+    )
+    coordinator.set_settings_data(
+        {
+            "github_polling_enabled": True,
+            "github_poll_interval_s": interval_s,
+            "github_poll_startup_delay_s": 0,
+            "agentsnova_auto_review_enabled": False,
+        }
+    )
+
+    loop = QEventLoop()
+    QTimer.singleShot(duration_s * 1000, loop.quit)
+    loop.exec()
+
+    coordinator.set_settings_data({"github_polling_enabled": False})
+
+    elapsed_total_s = time.monotonic() - started_at
+    total_refreshes = sum(counts.values())
+    first_delay_text = (
+        f"{first_refresh_delay_s:.1f}s" if first_refresh_delay_s is not None else "none"
+    )
+
+    print(
+        "[github-poll-runtime] summary "
+        f"duration={elapsed_total_s:.1f}s interval={interval_s}s "
+        f"first_refresh={first_delay_text} "
+        f"pr={counts.get('pr', 0)} issue={counts.get('issue', 0)} "
+        f"total={total_refreshes}",
+        flush=True,
+    )
+
+    assert total_refreshes > 0, (
+        "Background GitHub polling produced zero refresh events. "
+        f"duration={elapsed_total_s:.1f}s interval={interval_s}s "
+        f"counts={counts}"
+    )

--- a/agents_runner/tests/test_github_work_coordinator_polling_start.py
+++ b/agents_runner/tests/test_github_work_coordinator_polling_start.py
@@ -1,0 +1,129 @@
+# pyright: reportPrivateUsage=false
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+
+from PySide6.QtCore import QCoreApplication
+from PySide6.QtTest import QTest
+
+import pytest
+
+from agents_runner.ui.pages.github_work_coordinator import GitHubWorkCoordinator
+
+
+def _app() -> QCoreApplication:
+    app = QCoreApplication.instance()
+    if app is None:
+        app = QCoreApplication([])
+    return app
+
+
+def _wait_until(
+    predicate: Callable[[], bool],
+    *,
+    timeout_ms: int = 2000,
+) -> bool:
+    app = _app()
+    deadline = time.monotonic() + (timeout_ms / 1000.0)
+    while time.monotonic() < deadline:
+        app.processEvents()
+        if predicate():
+            return True
+        QTest.qWait(10)
+    app.processEvents()
+    return bool(predicate())
+
+
+def test_polling_starts_immediately_when_startup_delay_is_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _app()
+    coordinator = GitHubWorkCoordinator()
+
+    start_calls = 0
+
+    def _record_start() -> None:
+        nonlocal start_calls
+        start_calls += 1
+
+    monkeypatch.setattr(coordinator, "_start_poll_cycle", _record_start)
+
+    coordinator.set_settings_data(
+        {
+            "github_polling_enabled": True,
+            "github_poll_interval_s": 30,
+            "github_poll_startup_delay_s": 0,
+        }
+    )
+
+    assert start_calls == 1
+    assert coordinator._startup_poll_started is True
+    assert coordinator._poll_timer.isActive()
+
+    coordinator.set_settings_data({"github_polling_enabled": False})
+
+
+def test_polling_starts_after_startup_delay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _app()
+    coordinator = GitHubWorkCoordinator()
+
+    start_calls = 0
+
+    def _record_start() -> None:
+        nonlocal start_calls
+        start_calls += 1
+
+    monkeypatch.setattr(coordinator, "_start_poll_cycle", _record_start)
+
+    coordinator.set_settings_data(
+        {
+            "github_polling_enabled": True,
+            "github_poll_interval_s": 30,
+            "github_poll_startup_delay_s": 1,
+        }
+    )
+
+    assert start_calls == 0
+    assert coordinator._startup_poll_started is False
+    assert coordinator._startup_timer.isActive()
+    assert coordinator._poll_timer.isActive() is False
+
+    assert _wait_until(lambda: start_calls == 1, timeout_ms=1800)
+    assert coordinator._startup_poll_started is True
+    assert coordinator._poll_timer.isActive()
+
+    coordinator.set_settings_data({"github_polling_enabled": False})
+
+
+def test_start_poll_cycle_recovers_after_startup_probe_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _app()
+    coordinator = GitHubWorkCoordinator()
+    coordinator._settings = {"github_polling_enabled": True}
+
+    eligible_calls = 0
+
+    def _flaky_eligible_env_ids() -> list[str]:
+        nonlocal eligible_calls
+        eligible_calls += 1
+        if eligible_calls == 1:
+            raise RuntimeError("startup sequencing not ready")
+        return []
+
+    monkeypatch.setattr(
+        coordinator,
+        "_eligible_poll_environment_ids",
+        _flaky_eligible_env_ids,
+    )
+
+    coordinator._start_poll_cycle()
+    assert eligible_calls == 1
+    assert coordinator._poll_cycle_running is False
+
+    coordinator._start_poll_cycle()
+    assert eligible_calls == 2
+    assert coordinator._poll_cycle_running is False


### PR DESCRIPTION
## Summary
- fixed a startup edge case in `GitHubWorkCoordinator` where polling could appear permanently stopped if an exception occurred before the poll worker thread started
- updated startup logic to always clear `_poll_cycle_running` on pre-thread failures (eligibility resolution failure or thread start failure), allowing later timer ticks to retry
- added polling-start regression tests:
  - `agents_runner/tests/test_github_work_coordinator_polling_start.py`
    - immediate start when startup delay is 0
    - delayed start when startup delay is > 0
    - recovery behavior after startup probe error
- retained runtime probe test for multi-minute refresh counting:
  - `agents_runner/tests/test_github_polling_runtime_probe.py`

## Verification
- `uv run ruff check agents_runner/ui/pages/github_work_coordinator.py agents_runner/tests/test_github_work_coordinator_polling_start.py agents_runner/tests/test_github_polling_runtime_probe.py`
- `uv run pytest agents_runner/tests/test_github_work_coordinator_polling_start.py agents_runner/tests/test_github_polling_runtime_probe.py -q`
  - result: `3 passed, 1 skipped`
- Runtime probe (180s, previously executed):
  - `pr=12`, `issue=12`, `total=24`

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
