### PR TITLE
[FIX] Improve @agentsnova auto-review prompting and GitHub safety mar...

### DIFF
--- a/agents_runner/prompts/issue_fix_template.md
+++ b/agents_runner/prompts/issue_fix_template.md
@@ -8,10 +8,12 @@ Fix GitHub issue #{ISSUE_NUMBER} for repository {REPO_OWNER}/{REPO_NAME}.
 Issue URL: {ISSUE_URL}
 Issue title: {ISSUE_TITLE}
 
-Required workflow:
+Suggested workflow:
 1. Read the full issue details (description, linked context, and comments) and restate the problem in your own words.
-2. Reproduce the issue or, if reproduction is not possible, explain exactly why and identify the most probable failure path from code inspection.
-3. Identify root cause with file-level evidence before making changes.
-4. Implement a minimal, focused fix that addresses root cause without unrelated refactors.
-5. Verify behavior with the most relevant checks for the changed area and report concrete results.
-6. Summarize what changed, why it solves the issue, and any remaining risks or follow-up checks.
+2. Prefer using `gh` to review and manage issue context (details, discussion, and relevant updates), unless this repository explicitly asks for a different method.
+3. Reproduce the issue or, if reproduction is not possible, explain exactly why and identify the most likely failure path from code inspection.
+4. Identify root cause with file-level evidence before making changes.
+5. Implement a minimal, focused fix that addresses root cause without unrelated refactors.
+6. Verify behavior with the most relevant checks for the changed area and report concrete results.
+7. Follow this repository's instructions (especially AGENTS.md and related docs) for workflow, formatting, and communication.
+8. At the end, update GitHub so the user is informed: post the appropriate issue / PR / comment update with status, what changed, and current outcome.

--- a/agents_runner/prompts/pr_review_template.md
+++ b/agents_runner/prompts/pr_review_template.md
@@ -8,10 +8,11 @@ Review GitHub pull request #{PR_NUMBER} for repository {REPO_OWNER}/{REPO_NAME}.
 PR title: {PR_TITLE}
 PR URL: {PR_URL}
 
-Required workflow:
+Suggested workflow:
 1. Read and follow this repository's standards first, especially AGENTS.md and any repo-specific contribution/review instructions.
-2. Review the pull request against those repository standards.
-3. Run full local verification/tests.
-4. You are running in a PixelArch container with passwordless sudo available.
-5. Produce your review using the target repository's required format.
-6. If repository standards are missing or unclear, choose a clear review format and proceed.
+2. Prefer using `gh` to review and manage PR context (PR details, changed files, commits, and discussion), unless this repository explicitly asks for a different method.
+3. Review the pull request against repository standards and expected behavior.
+4. Run relevant local verification/tests as required by repository rules.
+5. Produce your review in the repository's expected format.
+6. If standards are missing or unclear, choose a clear review format and proceed.
+7. At the end, update GitHub so the user is informed: post the appropriate issue / PR / comment update with review outcome, key findings, and current status.

--- a/agents_runner/ui/main_window.py
+++ b/agents_runner/ui/main_window.py
@@ -122,6 +122,8 @@ class MainWindow(
             "github_polling_enabled": False,
             "github_poll_startup_delay_s": 35,
             "agentsnova_auto_review_enabled": True,
+            "agentsnova_auto_marker_comments_enabled": True,
+            "agentsnova_auto_reactions_enabled": True,
             "agentsnova_trusted_users_global": [],
             "agentsnova_review_guard_mode": "reaction",
         }

--- a/agents_runner/ui/main_window_persistence.py
+++ b/agents_runner/ui/main_window_persistence.py
@@ -193,6 +193,8 @@ class MainWindowPersistenceMixin:
         self._settings_data.setdefault("github_polling_enabled", False)
         self._settings_data.setdefault("github_poll_startup_delay_s", 35)
         self._settings_data.setdefault("agentsnova_auto_review_enabled", True)
+        self._settings_data.setdefault("agentsnova_auto_marker_comments_enabled", True)
+        self._settings_data.setdefault("agentsnova_auto_reactions_enabled", True)
         self._settings_data.setdefault("agentsnova_trusted_users_global", [])
         self._settings_data.setdefault("agentsnova_review_guard_mode", "reaction")
         host_codex_dir = os.path.normpath(
@@ -258,6 +260,12 @@ class MainWindowPersistenceMixin:
             RadioController.normalize_loudness_boost_factor(
                 self._settings_data.get("radio_loudness_boost_factor")
             )
+        )
+        self._settings_data["agentsnova_auto_marker_comments_enabled"] = bool(
+            self._settings_data.get("agentsnova_auto_marker_comments_enabled", True)
+        )
+        self._settings_data["agentsnova_auto_reactions_enabled"] = bool(
+            self._settings_data.get("agentsnova_auto_reactions_enabled", True)
         )
         self._settings_data["github_polling_enabled"] = bool(
             self._settings_data.get("github_polling_enabled") or False

--- a/agents_runner/ui/main_window_settings.py
+++ b/agents_runner/ui/main_window_settings.py
@@ -116,6 +116,12 @@ class MainWindowSettingsMixin:
         merged["agentsnova_auto_review_enabled"] = bool(
             merged.get("agentsnova_auto_review_enabled", True)
         )
+        merged["agentsnova_auto_marker_comments_enabled"] = bool(
+            merged.get("agentsnova_auto_marker_comments_enabled", True)
+        )
+        merged["agentsnova_auto_reactions_enabled"] = bool(
+            merged.get("agentsnova_auto_reactions_enabled", True)
+        )
         try:
             merged["github_poll_interval_s"] = max(
                 5, int(merged.get("github_poll_interval_s", 30))

--- a/agents_runner/ui/pages/settings.py
+++ b/agents_runner/ui/pages/settings.py
@@ -155,6 +155,8 @@ class SettingsPage(QWidget, SettingsFormMixin):
             self._append_pixelarch_context,
             self._github_workroom_prefer_browser,
             self._agentsnova_auto_review_enabled,
+            self._agentsnova_auto_marker_comments_enabled,
+            self._agentsnova_auto_reactions_enabled,
             self._github_polling_enabled,
             self._headless_desktop_enabled,
             self._popup_theme_animation_enabled,

--- a/agents_runner/ui/pages/settings_form.py
+++ b/agents_runner/ui/pages/settings_form.py
@@ -255,6 +255,19 @@ class SettingsFormMixin:
         self._agentsnova_auto_review_enabled.setToolTip(
             "When enabled, PR/Issue mentions of @agentsnova can auto-queue tasks."
         )
+        self._agentsnova_auto_marker_comments_enabled = QCheckBox(
+            "Enable @agentsnova auto marker comments"
+        )
+        self._agentsnova_auto_marker_comments_enabled.setToolTip(
+            "When enabled, queued @agentsnova tasks post a GitHub marker comment "
+            "with the task id for visibility and dedupe safety."
+        )
+        self._agentsnova_auto_reactions_enabled = QCheckBox(
+            "Enable @agentsnova auto reactions"
+        )
+        self._agentsnova_auto_reactions_enabled.setToolTip(
+            "When enabled, @agentsnova queue triggers apply GitHub `eyes` reactions."
+        )
         self._github_polling_enabled = QCheckBox("Enable app-wide GitHub polling")
         self._github_polling_enabled.setToolTip(
             "When enabled, GitHub Issues/PRs poll in the background across enabled environments."
@@ -450,6 +463,8 @@ class SettingsFormMixin:
         github_page, github_body = self._create_page(specs_by_key["github"])
         github_body.addWidget(self._github_workroom_prefer_browser)
         github_body.addWidget(self._agentsnova_auto_review_enabled)
+        github_body.addWidget(self._agentsnova_auto_marker_comments_enabled)
+        github_body.addWidget(self._agentsnova_auto_reactions_enabled)
         github_body.addWidget(self._github_polling_enabled)
 
         github_grid = QGridLayout()
@@ -863,6 +878,12 @@ class SettingsFormMixin:
             self._agentsnova_auto_review_enabled.setChecked(
                 bool(settings.get("agentsnova_auto_review_enabled", True))
             )
+            self._agentsnova_auto_marker_comments_enabled.setChecked(
+                bool(settings.get("agentsnova_auto_marker_comments_enabled", True))
+            )
+            self._agentsnova_auto_reactions_enabled.setChecked(
+                bool(settings.get("agentsnova_auto_reactions_enabled", True))
+            )
             self._github_polling_enabled.setChecked(
                 bool(settings.get("github_polling_enabled") or False)
             )
@@ -994,6 +1015,12 @@ class SettingsFormMixin:
             ),
             "agentsnova_auto_review_enabled": bool(
                 self._agentsnova_auto_review_enabled.isChecked()
+            ),
+            "agentsnova_auto_marker_comments_enabled": bool(
+                self._agentsnova_auto_marker_comments_enabled.isChecked()
+            ),
+            "agentsnova_auto_reactions_enabled": bool(
+                self._agentsnova_auto_reactions_enabled.isChecked()
             ),
             "github_polling_enabled": bool(self._github_polling_enabled.isChecked()),
             "github_poll_startup_delay_s": poll_startup_delay_s,

--- a/agents_runner/ui/pages/tasks.py
+++ b/agents_runner/ui/pages/tasks.py
@@ -50,7 +50,7 @@ class _TasksPaneSpec:
 
 
 class TasksPage(QWidget):
-    auto_review_requested = Signal(str, str)
+    auto_review_requested = Signal(str, object)
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary
- Improve issue/PR auto-review prompts with `gh` guidance and explicit final GitHub update instructions.
- Post an auto marker comment with task id and runtime agent link when @agentsnova queueing starts.
- Keep auto reactions and expand to body mentions using `eyes`.
- Add marker-based dedupe behavior to avoid rerunning stale mentions.
- Add separate settings toggles for auto marker comments and auto reactions.

## Validation
- `uv run ruff check .`
- `uv run pytest agents_runner/tests/test_github_work_coordinator_polling_start.py agents_runner/tests/test_prompt_loader_substitution.py -q`

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
