### PR TITLE
[FIX] Refresh and smooth env branch dropdown behavior

### DIFF
--- a/agents_runner/ui/main_window.py
+++ b/agents_runner/ui/main_window.py
@@ -140,6 +140,8 @@ class MainWindow(
         self._dashboard_log_refresh_s: dict[str, float] = {}
         self._interactive_watch: dict[str, tuple[str, threading.Event]] = {}
         self._repo_branches_request_id: int = 0
+        self._repo_branches_request_meta: dict[int, dict[str, object]] = {}
+        self._repo_branches_cache: dict[str, list[str]] = {}
         self._state_path = default_state_path()
         self._save_timer = QTimer(self)
         self._save_timer.setSingleShot(True)

--- a/agents_runner/ui/main_window_environment.py
+++ b/agents_runner/ui/main_window_environment.py
@@ -90,9 +90,32 @@ class MainWindowEnvironmentMixin:
             "Set Workspace to a local folder or GitHub repo in Environments.",
         )
 
-    def _sync_new_task_repo_controls(self, env: Environment | None) -> None:
+    def _refresh_active_environment_repo_branches(
+        self,
+        *,
+        trigger_reason: str,
+        show_loading_ui: bool,
+        preserve_current_selection: bool,
+    ) -> None:
+        env = self._environments.get(self._active_environment_id())
+        self._sync_new_task_repo_controls(
+            env,
+            trigger_reason=trigger_reason,
+            show_loading_ui=show_loading_ui,
+            preserve_current_selection=preserve_current_selection,
+        )
+
+    def _sync_new_task_repo_controls(
+        self,
+        env: Environment | None,
+        *,
+        trigger_reason: str = "environment_apply",
+        show_loading_ui: bool = False,
+        preserve_current_selection: bool = False,
+    ) -> None:
         _workdir, ready, _ = self._new_task_workspace(env)
         if not ready:
+            self._new_task.set_repo_branches_loading(False)
             self._new_task.set_repo_controls_visible(False)
             self._new_task.set_repo_branches([])
             return
@@ -100,24 +123,61 @@ class MainWindowEnvironmentMixin:
         workspace_type = env.workspace_type or WORKSPACE_NONE if env else WORKSPACE_NONE
         has_repo = bool(workspace_type == WORKSPACE_CLONED)
         if workspace_type == WORKSPACE_NONE or not has_repo:
+            self._new_task.set_repo_branches_loading(False)
             self._new_task.set_repo_controls_visible(False)
             self._new_task.set_repo_branches([])
             return
 
         self._new_task.set_repo_controls_visible(True)
-        self._new_task.set_repo_branches([])
 
         if workspace_type == WORKSPACE_CLONED and env:
             target = str(env.workspace_target or "").strip()
             if not target:
+                self._new_task.set_repo_branches_loading(False)
+                self._new_task.set_repo_branches([])
                 return
+            env_id = str(env.env_id or "").strip()
+            fallback_branches = list(
+                getattr(self, "_repo_branches_cache", {}).get(env_id, [])
+            )
+            fallback_selected = ""
+            last_branch = str(getattr(env, "gh_last_base_branch", "") or "").strip()
+            if last_branch and last_branch in fallback_branches:
+                fallback_selected = last_branch
+
+            normalized_reason = str(trigger_reason or "").strip().lower()
+            if show_loading_ui:
+                if normalized_reason == "env_switch":
+                    if fallback_branches:
+                        self._new_task.set_repo_branches(
+                            fallback_branches,
+                            selected=fallback_selected or None,
+                            preserve_current_selection=False,
+                        )
+                    else:
+                        self._new_task.set_repo_branches([])
+                self._new_task.set_repo_branches_loading(True)
+            else:
+                self._new_task.set_repo_branches_loading(False)
+
             self._repo_branches_request_id += 1
             request_id = int(self._repo_branches_request_id)
+            self._repo_branches_request_meta[request_id] = {
+                "env_id": env_id,
+                "trigger_reason": str(trigger_reason or "").strip(),
+                "preserve_current_selection": bool(preserve_current_selection),
+                "fallback_branches": fallback_branches,
+                "fallback_selected": fallback_selected,
+            }
 
             def _worker() -> None:
-                branches = git_list_remote_heads(target)
+                result: object
                 try:
-                    self.repo_branches_ready.emit(request_id, branches)
+                    result = git_list_remote_heads(target)
+                except Exception:
+                    result = None
+                try:
+                    self.repo_branches_ready.emit(request_id, result)
                 except Exception:
                     pass
 
@@ -129,15 +189,49 @@ class MainWindowEnvironmentMixin:
         except Exception:
             return
         if request_id != int(getattr(self, "_repo_branches_request_id", 0)):
+            self._repo_branches_request_meta.pop(request_id, None)
             return
+        request_meta = self._repo_branches_request_meta.pop(request_id, {})
+
+        preserve_current_selection = bool(
+            request_meta.get("preserve_current_selection")
+        )
+        fallback_branch_values = request_meta.get("fallback_branches", [])
+        fallback_branches = [
+            str(branch or "").strip()
+            for branch in fallback_branch_values
+            if str(branch or "").strip()
+        ]
+        fallback_selected_raw = str(request_meta.get("fallback_selected") or "").strip()
+        fallback_selected = fallback_selected_raw if fallback_selected_raw else None
+
         env = self._environments.get(self._active_environment_id())
         workspace_type = env.workspace_type or WORKSPACE_NONE if env else WORKSPACE_NONE
         if workspace_type != WORKSPACE_CLONED:
+            self._new_task.set_repo_branches_loading(False)
             return
         if not isinstance(branches, list):
+            if fallback_branches:
+                self._new_task.set_repo_branches(
+                    fallback_branches,
+                    selected=fallback_selected,
+                    preserve_current_selection=preserve_current_selection,
+                )
+            else:
+                self._new_task.set_repo_branches_loading(False)
             return
         cleaned = [str(b or "").strip() for b in branches]
         cleaned = [b for b in cleaned if b]
+        if not cleaned:
+            if fallback_branches:
+                self._new_task.set_repo_branches(
+                    fallback_branches,
+                    selected=fallback_selected,
+                    preserve_current_selection=preserve_current_selection,
+                )
+            else:
+                self._new_task.set_repo_branches_loading(False)
+            return
         self._new_task.set_repo_controls_visible(True)
 
         # Restore last selected branch for cloned environments
@@ -147,7 +241,14 @@ class MainWindowEnvironmentMixin:
             if last_branch and last_branch in cleaned:
                 selected_branch = last_branch
 
-        self._new_task.set_repo_branches(cleaned, selected=selected_branch)
+        env_id = str(env.env_id or "").strip() if env else ""
+        if env_id:
+            self._repo_branches_cache[env_id] = list(cleaned)
+        self._new_task.set_repo_branches(
+            cleaned,
+            selected=selected_branch,
+            preserve_current_selection=preserve_current_selection,
+        )
 
     def _populate_environment_pickers(self) -> None:
         active_id = self._active_environment_id()
@@ -190,7 +291,13 @@ class MainWindowEnvironmentMixin:
         finally:
             self._syncing_environment = False
 
-    def _apply_active_environment_to_new_task(self) -> None:
+    def _apply_active_environment_to_new_task(
+        self,
+        *,
+        branch_refresh_reason: str = "environment_apply",
+        show_branch_loading: bool = False,
+        preserve_branch_selection: bool = False,
+    ) -> None:
         env = self._environments.get(self._active_environment_id())
         # Get effective agent and config dir (environment agent_selection overrides settings)
         agent_cli, host_codex = self._effective_agent_and_config(env=env)
@@ -231,7 +338,12 @@ class MainWindowEnvironmentMixin:
         self._new_task.set_defaults(host_codex=host_codex)
         self._new_task.set_workspace_status(path=workdir, ready=ready, message=message)
         self._new_task.set_agent_info(agent=current_agent, next_agent=next_agent)
-        self._sync_new_task_repo_controls(env)
+        self._sync_new_task_repo_controls(
+            env,
+            trigger_reason=branch_refresh_reason,
+            show_loading_ui=show_branch_loading,
+            preserve_current_selection=preserve_branch_selection,
+        )
         self._new_task.set_interactive_defaults(
             terminal_id=str(self._settings_data.get("interactive_terminal_id") or ""),
             command=self._default_interactive_command(agent_cli),
@@ -244,7 +356,11 @@ class MainWindowEnvironmentMixin:
         env_id = str(env_id or "")
         if env_id and env_id in self._environments:
             self._settings_data["active_environment_id"] = env_id
-            self._apply_active_environment_to_new_task()
+            self._apply_active_environment_to_new_task(
+                branch_refresh_reason="env_switch",
+                show_branch_loading=True,
+                preserve_branch_selection=False,
+            )
             self._schedule_save()
 
     def _reload_environments(self, preferred_env_id: str = "") -> None:

--- a/agents_runner/ui/main_window_navigation.py
+++ b/agents_runner/ui/main_window_navigation.py
@@ -121,7 +121,16 @@ class MainWindowNavigationMixin:
     def _show_tasks(self) -> None:
         if not self._try_autosave_before_navigation():
             return
+        was_visible = self._tasks_page.isVisible()
         self._tasks_page.show_new_task_tab(focus_prompt=True)
+        if not was_visible and hasattr(
+            self, "_refresh_active_environment_repo_branches"
+        ):
+            self._refresh_active_environment_repo_branches(
+                trigger_reason="tasks_entry",
+                show_loading_ui=True,
+                preserve_current_selection=True,
+            )
         self._transition_to_page(self._tasks_page)
 
     def _show_task_details(self) -> None:

--- a/agents_runner/ui/pages/new_task.py
+++ b/agents_runner/ui/pages/new_task.py
@@ -51,6 +51,7 @@ logger = MidoriAiLogger(channel=None, name=__name__)
 
 class NewTaskPage(QWidget):
     _BASE_BRANCH_LOADING_SENTINEL = "__loading__"
+    _BASE_BRANCH_LOADING_DELAY_MS = 250
 
     requested_run = Signal(str, str, str, str)
     requested_launch = Signal(str, str, str, str, str, str, str)
@@ -83,9 +84,18 @@ class NewTaskPage(QWidget):
         self._current_interactive_slot: Callable[..., Any] | None = None
         self._base_branch_visibility_animation: QParallelAnimationGroup | None = None
         self._base_branch_loading = False
+        self._base_branch_loading_requested = False
         self._base_branch_loading_snapshot: list[tuple[str, str]] = []
         self._base_branch_loading_selected = ""
         self._base_branch_loading_animation: QPropertyAnimation | None = None
+        self._base_branch_loading_delay_timer = QTimer(self)
+        self._base_branch_loading_delay_timer.setSingleShot(True)
+        self._base_branch_loading_delay_timer.setInterval(
+            self._BASE_BRANCH_LOADING_DELAY_MS
+        )
+        self._base_branch_loading_delay_timer.timeout.connect(
+            self._activate_base_branch_loading_visual
+        )
         self._pending_repo_branches_update: (
             tuple[list[str], str | None, bool] | None
         ) = None
@@ -989,7 +999,7 @@ class NewTaskPage(QWidget):
             animation = QPropertyAnimation(effect, b"opacity", self)
             animation.setDuration(880)
             animation.setKeyValueAt(0.0, 1.0)
-            animation.setKeyValueAt(0.5, 0.44)
+            animation.setKeyValueAt(0.5, 0.78)
             animation.setKeyValueAt(1.0, 1.0)
             animation.setEasingCurve(QEasingCurve.Type.InOutCubic)
             animation.setLoopCount(-1)
@@ -1051,30 +1061,39 @@ class NewTaskPage(QWidget):
         loading_selected = str(self._base_branch_loading_selected or "").strip()
         return loading_selected
 
+    def _activate_base_branch_loading_visual(self) -> None:
+        if not self._base_branch_loading_requested or self._base_branch_loading:
+            return
+        if self._base_branch.view().isVisible():
+            self._base_branch_loading_delay_timer.start()
+            return
+        self._pending_repo_branches_update = None
+        self._pending_repo_branches_timer.stop()
+        self._base_branch_loading = True
+        self._base_branch_loading_snapshot = self._capture_base_branch_items()
+        self._base_branch_loading_selected = self._selected_base_branch_for_preserve()
+        self._base_branch.blockSignals(True)
+        try:
+            self._base_branch.clear()
+            self._base_branch.addItem("Loading...", self._BASE_BRANCH_LOADING_SENTINEL)
+            self._base_branch.setCurrentIndex(0)
+        finally:
+            self._base_branch.blockSignals(False)
+        self._base_branch.setEnabled(False)
+        self._start_base_branch_loading_animation()
+
     def set_repo_branches_loading(self, loading: bool) -> None:
         should_load = bool(loading)
-        if should_load == self._base_branch_loading:
+        if should_load:
+            self._base_branch_loading_requested = True
+            if self._base_branch_loading:
+                return
+            self._base_branch_loading_delay_timer.start()
             return
 
-        if should_load:
-            self._pending_repo_branches_update = None
-            self._pending_repo_branches_timer.stop()
-            self._base_branch_loading = True
-            self._base_branch_loading_snapshot = self._capture_base_branch_items()
-            self._base_branch_loading_selected = (
-                self._selected_base_branch_for_preserve()
-            )
-            self._base_branch.blockSignals(True)
-            try:
-                self._base_branch.clear()
-                self._base_branch.addItem(
-                    "Loading...", self._BASE_BRANCH_LOADING_SENTINEL
-                )
-                self._base_branch.setCurrentIndex(0)
-            finally:
-                self._base_branch.blockSignals(False)
-            self._base_branch.setEnabled(False)
-            self._start_base_branch_loading_animation()
+        self._base_branch_loading_requested = False
+        self._base_branch_loading_delay_timer.stop()
+        if not self._base_branch_loading:
             return
 
         self._base_branch_loading = False
@@ -1160,6 +1179,7 @@ class NewTaskPage(QWidget):
         normalized = [str(name or "").strip() for name in branches or []]
         normalized = [name for name in normalized if name]
         if preserve_current_selection and self._base_branch.view().isVisible():
+            self.set_repo_branches_loading(False)
             self._pending_repo_branches_update = (
                 list(normalized),
                 str(selected or "").strip() or None,

--- a/agents_runner/ui/pages/new_task.py
+++ b/agents_runner/ui/pages/new_task.py
@@ -10,6 +10,7 @@ from PySide6.QtCore import QPropertyAnimation
 from PySide6.QtCore import Qt
 from PySide6.QtCore import QSize
 from PySide6.QtCore import Signal
+from PySide6.QtCore import QTimer
 from PySide6.QtCore import QThread
 from PySide6.QtGui import QTextCursor
 from PySide6.QtWidgets import QComboBox
@@ -49,6 +50,8 @@ logger = MidoriAiLogger(channel=None, name=__name__)
 
 
 class NewTaskPage(QWidget):
+    _BASE_BRANCH_LOADING_SENTINEL = "__loading__"
+
     requested_run = Signal(str, str, str, str)
     requested_launch = Signal(str, str, str, str, str, str, str)
     back_requested = Signal()
@@ -79,6 +82,19 @@ class NewTaskPage(QWidget):
         self._stt_worker: SttWorker | None = None
         self._current_interactive_slot: Callable[..., Any] | None = None
         self._base_branch_visibility_animation: QParallelAnimationGroup | None = None
+        self._base_branch_loading = False
+        self._base_branch_loading_snapshot: list[tuple[str, str]] = []
+        self._base_branch_loading_selected = ""
+        self._base_branch_loading_animation: QPropertyAnimation | None = None
+        self._pending_repo_branches_update: (
+            tuple[list[str], str | None, bool] | None
+        ) = None
+        self._pending_repo_branches_timer = QTimer(self)
+        self._pending_repo_branches_timer.setSingleShot(True)
+        self._pending_repo_branches_timer.setInterval(120)
+        self._pending_repo_branches_timer.timeout.connect(
+            self._apply_pending_repo_branches_update
+        )
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
@@ -854,6 +870,9 @@ class NewTaskPage(QWidget):
     def base_branch_controls_widget(self) -> QWidget:
         return self._base_branch_controls
 
+    def is_base_branch_controls_visible(self) -> bool:
+        return bool(self._base_branch_controls.isVisible())
+
     def _base_branch_opacity_effect(self) -> QGraphicsOpacityEffect:
         effect = self._base_branch_controls.graphicsEffect()
         if isinstance(effect, QGraphicsOpacityEffect):
@@ -955,27 +974,207 @@ class NewTaskPage(QWidget):
             return
         self._set_base_branch_visibility_immediate(visible=should_show)
 
-    def set_repo_branches(
-        self, branches: list[str], selected: str | None = None
+    def _base_branch_loading_effect(self) -> QGraphicsOpacityEffect:
+        effect = self._base_branch.graphicsEffect()
+        if isinstance(effect, QGraphicsOpacityEffect):
+            return effect
+        effect = QGraphicsOpacityEffect(self._base_branch)
+        effect.setOpacity(1.0)
+        self._base_branch.setGraphicsEffect(effect)
+        return effect
+
+    def _start_base_branch_loading_animation(self) -> None:
+        effect = self._base_branch_loading_effect()
+        if self._base_branch_loading_animation is None:
+            animation = QPropertyAnimation(effect, b"opacity", self)
+            animation.setDuration(880)
+            animation.setKeyValueAt(0.0, 1.0)
+            animation.setKeyValueAt(0.5, 0.44)
+            animation.setKeyValueAt(1.0, 1.0)
+            animation.setEasingCurve(QEasingCurve.Type.InOutCubic)
+            animation.setLoopCount(-1)
+            self._base_branch_loading_animation = animation
+        else:
+            self._base_branch_loading_animation.stop()
+        effect.setOpacity(1.0)
+        self._base_branch_loading_animation.start()
+
+    def _stop_base_branch_loading_animation(self) -> None:
+        if self._base_branch_loading_animation is not None:
+            self._base_branch_loading_animation.stop()
+        effect = self._base_branch.graphicsEffect()
+        if isinstance(effect, QGraphicsOpacityEffect):
+            effect.setOpacity(1.0)
+
+    def _capture_base_branch_items(self) -> list[tuple[str, str]]:
+        entries: list[tuple[str, str]] = []
+        for index in range(int(self._base_branch.count())):
+            text = str(self._base_branch.itemText(index) or "")
+            data = str(self._base_branch.itemData(index) or "")
+            entries.append((text, data))
+        return entries
+
+    def _restore_base_branch_loading_snapshot(self) -> None:
+        snapshot = list(self._base_branch_loading_snapshot)
+        selected = str(self._base_branch_loading_selected or "").strip()
+        self._base_branch.blockSignals(True)
+        try:
+            self._base_branch.clear()
+            if snapshot:
+                for text, data in snapshot:
+                    label = str(text or "").strip()
+                    value = str(data or "").strip()
+                    if not label and not value:
+                        label = "Auto"
+                    elif not label:
+                        label = value
+                    self._base_branch.addItem(label, value)
+            else:
+                self._base_branch.addItem("Auto", "")
+
+            idx = -1
+            if selected:
+                idx = self._base_branch.findData(selected)
+            if idx < 0:
+                idx = self._base_branch.findData("")
+            if idx < 0 and self._base_branch.count() > 0:
+                idx = 0
+            if idx >= 0:
+                self._base_branch.setCurrentIndex(idx)
+        finally:
+            self._base_branch.blockSignals(False)
+
+    def _selected_base_branch_for_preserve(self) -> str:
+        current = str(self._base_branch.currentData() or "").strip()
+        if current and current != self._BASE_BRANCH_LOADING_SENTINEL:
+            return current
+        loading_selected = str(self._base_branch_loading_selected or "").strip()
+        return loading_selected
+
+    def set_repo_branches_loading(self, loading: bool) -> None:
+        should_load = bool(loading)
+        if should_load == self._base_branch_loading:
+            return
+
+        if should_load:
+            self._pending_repo_branches_update = None
+            self._pending_repo_branches_timer.stop()
+            self._base_branch_loading = True
+            self._base_branch_loading_snapshot = self._capture_base_branch_items()
+            self._base_branch_loading_selected = (
+                self._selected_base_branch_for_preserve()
+            )
+            self._base_branch.blockSignals(True)
+            try:
+                self._base_branch.clear()
+                self._base_branch.addItem(
+                    "Loading...", self._BASE_BRANCH_LOADING_SENTINEL
+                )
+                self._base_branch.setCurrentIndex(0)
+            finally:
+                self._base_branch.blockSignals(False)
+            self._base_branch.setEnabled(False)
+            self._start_base_branch_loading_animation()
+            return
+
+        self._base_branch_loading = False
+        self._stop_base_branch_loading_animation()
+        self._base_branch.setEnabled(True)
+
+        is_loading_placeholder = (
+            self._base_branch.count() == 1
+            and str(self._base_branch.itemData(0) or "")
+            == self._BASE_BRANCH_LOADING_SENTINEL
+        )
+        if is_loading_placeholder:
+            self._restore_base_branch_loading_snapshot()
+
+        self._base_branch_loading_snapshot = []
+        self._base_branch_loading_selected = ""
+
+    def _apply_repo_branches_now(
+        self,
+        *,
+        branches: list[str],
+        selected: str | None,
+        preserve_current_selection: bool,
     ) -> None:
         wanted = str(selected or "").strip()
+        preserved = (
+            self._selected_base_branch_for_preserve()
+            if preserve_current_selection
+            else ""
+        )
+        self.set_repo_branches_loading(False)
+
         self._base_branch.blockSignals(True)
         try:
             self._base_branch.clear()
             self._base_branch.addItem("Auto", "")
+            seen: set[str] = set()
             for name in branches or []:
-                b = str(name or "").strip()
-                if not b:
+                branch = str(name or "").strip()
+                if not branch or branch in seen:
                     continue
-                self._base_branch.addItem(b, b)
-            if wanted:
-                idx = self._base_branch.findData(wanted)
-                if idx >= 0:
-                    self._base_branch.setCurrentIndex(idx)
-                    return
-            self._base_branch.setCurrentIndex(0)
+                seen.add(branch)
+                self._base_branch.addItem(branch, branch)
+
+            target = ""
+            if wanted and wanted in seen:
+                target = wanted
+            elif preserve_current_selection and preserved and preserved in seen:
+                target = preserved
+
+            idx = self._base_branch.findData(target)
+            if idx < 0:
+                idx = self._base_branch.findData("")
+            if idx < 0 and self._base_branch.count() > 0:
+                idx = 0
+            if idx >= 0:
+                self._base_branch.setCurrentIndex(idx)
         finally:
             self._base_branch.blockSignals(False)
+
+    def _apply_pending_repo_branches_update(self) -> None:
+        pending = self._pending_repo_branches_update
+        if pending is None:
+            return
+        if self._base_branch.view().isVisible():
+            self._pending_repo_branches_timer.start()
+            return
+
+        self._pending_repo_branches_update = None
+        branches, selected, preserve = pending
+        self._apply_repo_branches_now(
+            branches=list(branches),
+            selected=selected,
+            preserve_current_selection=bool(preserve),
+        )
+
+    def set_repo_branches(
+        self,
+        branches: list[str],
+        selected: str | None = None,
+        preserve_current_selection: bool = False,
+    ) -> None:
+        normalized = [str(name or "").strip() for name in branches or []]
+        normalized = [name for name in normalized if name]
+        if preserve_current_selection and self._base_branch.view().isVisible():
+            self._pending_repo_branches_update = (
+                list(normalized),
+                str(selected or "").strip() or None,
+                bool(preserve_current_selection),
+            )
+            self._pending_repo_branches_timer.start()
+            return
+
+        self._pending_repo_branches_update = None
+        self._pending_repo_branches_timer.stop()
+        self._apply_repo_branches_now(
+            branches=normalized,
+            selected=selected,
+            preserve_current_selection=preserve_current_selection,
+        )
 
     def set_interactive_defaults(self, terminal_id: str, command: str) -> None:
         if command:


### PR DESCRIPTION
## Summary
- refresh cloned-environment base branch info when entering Tasks
- refresh base branch info on environment switch with request-id stale-response protection
- preserve selected base branch when refreshed data still contains it
- keep previous branch list on fetch failure for safer UX
- smooth loading UX with delayed activation (250ms) to avoid flash/disappear effects
- defer loading visual while dropdown popup is open to avoid interrupting selection
- soften shimmer opacity range for a stable control appearance

## Validation
- uv sync --group ci
- uv run ruff format agents_runner/ui/main_window.py agents_runner/ui/main_window_environment.py agents_runner/ui/main_window_navigation.py agents_runner/ui/pages/new_task.py
- uv run ruff check agents_runner/ui/main_window.py agents_runner/ui/main_window_environment.py agents_runner/ui/main_window_navigation.py agents_runner/ui/pages/new_task.py
- uv run python -m py_compile agents_runner/ui/main_window.py agents_runner/ui/main_window_environment.py agents_runner/ui/main_window_navigation.py agents_runner/ui/pages/new_task.py
- uv run basedpyright agents_runner/ui/main_window.py agents_runner/ui/main_window_environment.py agents_runner/ui/main_window_navigation.py agents_runner/ui/pages/new_task.py (existing strict Qt/type-stub baseline issues remain)

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
