### PR TITLE
[FIX] Always start interactive desktop runtime when cache is enabled

### DIFF
--- a/agents_runner/docker/cache_resolver.py
+++ b/agents_runner/docker/cache_resolver.py
@@ -21,7 +21,13 @@ _cache_build_lock = threading.Lock()
 
 @dataclass
 class CacheResolutionResult:
-    """Result of cache resolution containing runtime image and cache flags."""
+    """Result of cache resolution containing runtime image and cache flags.
+
+    Note:
+        desktop_preflight_cached indicates whether a desktop image layer was
+        reused/built. It must not be treated as "desktop services already
+        running" for the launched container.
+    """
 
     runtime_image: str
     system_preflight_cached: bool

--- a/agents_runner/ui/main_window_tasks_interactive_docker.py
+++ b/agents_runner/ui/main_window_tasks_interactive_docker.py
@@ -260,14 +260,16 @@ def launch_docker_terminal_task(
                 )
             )
 
-    # Prepare preflight scripts and get mounts
+    # Prepare preflight scripts and get mounts.
+    # Desktop caching only pre-installs desktop dependencies into an image layer;
+    # runtime desktop services still need to start for each container launch.
     preflight_clause, preflight_mounts, tmp_paths = _prepare_preflight_scripts(
         task_token=task_token,
         desktop_preflight_script=desktop_preflight_script,
         settings_preflight_script=settings_preflight_script,
         environment_preflight_script=environment_preflight_script,
         skip_system=system_preflight_cached,
-        skip_desktop=desktop_preflight_cached,
+        skip_desktop=False,
         skip_settings=settings_preflight_cached,
         skip_environment=environment_preflight_cached,
     )


### PR DESCRIPTION
## Summary
- Stop treating desktop cache state as a signal to skip interactive desktop runtime startup
- Keep desktop caching as an image-layer optimization only
- Clarify cache flag semantics in cache resolver docs

## Validation
- `uv run python -m py_compile agents_runner/ui/main_window_tasks_interactive_docker.py agents_runner/docker/cache_resolver.py`

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
