### PR TITLE
[FIX] Remove incorrect headless CLI startup path

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,55 +45,22 @@ def _configure_qt_logging_env() -> None:
     )
 
 
-def _parse_headless_mode(argv: list[str]) -> tuple[list[str], bool]:
-    """Return cleaned argv and whether headless startup mode is enabled."""
-    headless_requested = _is_truthy_env("AGENTS_RUNNER_HEADLESS")
-    cleaned = [argv[0]]
-    for arg in argv[1:]:
-        if arg == "--headless":
-            headless_requested = True
-            continue
-        cleaned.append(arg)
-    return cleaned, headless_requested
-
-
-def _configure_headless_runtime_env() -> None:
-    """Apply explicit headless-safe Qt defaults for SSH/X11 and no-display runs."""
-    has_display = bool(str(os.environ.get("DISPLAY", "")).strip())
-    platform = str(os.environ.get("QT_QPA_PLATFORM", "")).strip().lower()
-
-    if has_display:
-        if not platform:
-            os.environ["QT_QPA_PLATFORM"] = "xcb"
-    else:
-        if platform in {"", "xcb"}:
-            os.environ["QT_QPA_PLATFORM"] = "offscreen"
-
-    os.environ.setdefault("LIBGL_ALWAYS_SOFTWARE", "1")
-    os.environ.setdefault("QT_XCB_FORCE_SOFTWARE_OPENGL", "1")
-    os.environ.setdefault("QT_OPENGL", "software")
-
-
 def main() -> None:
     try:
-        argv, headless_mode = _parse_headless_mode(list(sys.argv))
-        if headless_mode:
-            _configure_headless_runtime_env()
-
         _configure_qt_logging_env()
 
         # Check if running in desktop viewer mode
-        if len(argv) > 1 and argv[1] == "--desktop-viewer":
+        if len(sys.argv) > 1 and sys.argv[1] == "--desktop-viewer":
             # Route to desktop viewer instead of main UI
             from agents_runner.ui.desktop_viewer import run_desktop_viewer
 
             # Remove --desktop-viewer from argv so argparse works correctly
-            viewer_args = [argv[0]] + argv[2:]
+            viewer_args = [sys.argv[0]] + sys.argv[2:]
             sys.exit(run_desktop_viewer(viewer_args))
 
         from agents_runner.ui.runtime.app import run_app
 
-        run_app(argv)
+        run_app(sys.argv)
     except SystemExit:
         raise
     except BaseException as error:


### PR DESCRIPTION
## Summary
- remove the `--headless` / `AGENTS_RUNNER_HEADLESS` startup path from `main.py`
- restore `main.py` argument flow to use `sys.argv` directly
- keep `--desktop-viewer` routing intact

## Validation
- `uv run python -m py_compile main.py`
- startup smoke checks:
  - `uv run main.py` (fails in this container because `DISPLAY=:1` is unreachable)
  - `env QT_QPA_PLATFORM=xcb LIBGL_ALWAYS_SOFTWARE=1 uv run main.py` (same unreachable display failure)
  - `xvfb-run -a uv run main.py` (starts successfully; process remained running until timeout)

## Issue
- posted working headless startup command to issue #249 and closed it

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
