### PR TITLE
[FIX] Correct radio hover geometry and reveal direction

### DIFF
--- a/agents_runner/ui/main_window.py
+++ b/agents_runner/ui/main_window.py
@@ -388,12 +388,27 @@ class MainWindow(
         if not self._radio_controller.qt_available:
             return
 
+        snapshot = self._radio_controller.state_snapshot()
+        connection_state = str(snapshot.get("connection_state") or "").strip().lower()
+        is_active = bool(snapshot.get("is_playing")) or bool(
+            snapshot.get("desired_playing")
+        )
+        if connection_state == "reconnecting":
+            is_active = True
+
+        if is_active:
+            self._settings_data["radio_enabled"] = False
+            self._radio_controller.set_enabled(False, start_when_enabled=False)
+            self._settings.set_settings(self._settings_data)
+            self._schedule_save()
+            return
+
         if not bool(self._settings_data.get("radio_enabled") or False):
             self._settings_data["radio_enabled"] = True
             self._radio_controller.set_enabled(True, start_when_enabled=False)
             self._settings.set_settings(self._settings_data)
 
-        self._radio_controller.toggle_playback()
+        self._radio_controller.start_playback()
         self._schedule_save()
 
     def _on_radio_control_volume_changed(self, value: int) -> None:
@@ -435,6 +450,10 @@ class MainWindow(
             self.setWindowTitle(APP_TITLE)
             return
 
+        if (not bool(state.get("enabled"))) and (not bool(state.get("is_playing"))):
+            self.setWindowTitle(self._active_environment_window_title())
+            return
+
         channel_label = str(state.get("channel_label") or "all").strip() or "all"
         current_track = self._normalize_radio_window_track_title(
             state.get("current_track")
@@ -452,6 +471,19 @@ class MainWindow(
             return
 
         self.setWindowTitle(f"{APP_TITLE} [{channel_label}]")
+
+    def _active_environment_window_title(self) -> str:
+        active_env_id = str(
+            self._settings_data.get("active_environment_id") or ""
+        ).strip()
+        if not active_env_id:
+            active_env_id = "default"
+        env = self._environments.get(active_env_id)
+        if env is not None:
+            env_name = str(getattr(env, "name", "") or "").strip()
+            if env_name:
+                return env_name
+        return active_env_id
 
     def _refresh_radio_channel_options(self, *, disable_on_failure: bool) -> None:
         selected_channel = RadioController.normalize_channel(

--- a/agents_runner/ui/main_window_environment.py
+++ b/agents_runner/ui/main_window_environment.py
@@ -349,6 +349,15 @@ class MainWindowEnvironmentMixin:
             command=self._default_interactive_command(agent_cli),
         )
         self._populate_environment_pickers()
+        if hasattr(self, "_radio_controller") and hasattr(
+            self, "_update_window_title_from_radio_state"
+        ):
+            try:
+                self._update_window_title_from_radio_state(
+                    self._radio_controller.state_snapshot()
+                )
+            except Exception:
+                pass
 
     def _on_new_task_env_changed(self, env_id: str) -> None:
         if self._syncing_environment:

--- a/agents_runner/ui/pages/settings_form.py
+++ b/agents_runner/ui/pages/settings_form.py
@@ -324,7 +324,7 @@ class SettingsFormMixin:
 
         self._radio_enabled = QCheckBox("Enable Midori AI Radio")
         self._radio_enabled.setToolTip(
-            "Allows starting radio playback from the navbar control."
+            "Controls whether the navbar radio system is enabled."
         )
         self._radio_autostart = QCheckBox("Auto-start radio on app launch")
         self._radio_autostart.setToolTip(

--- a/agents_runner/ui/radio/controller.py
+++ b/agents_runner/ui/radio/controller.py
@@ -102,6 +102,7 @@ class RadioController(QObject):
         self._watchdog_timer: QTimer | None = None
         self._channel_fade_out: QVariantAnimation | None = None
         self._channel_fade_in: QVariantAnimation | None = None
+        self._runtime_timers_active = False
 
         if not self._qt_available:
             self._status_text = (
@@ -158,9 +159,7 @@ class RadioController(QObject):
             self._emit_state()
             return
 
-        self._health_timer.start()
-        self._current_timer.start()
-        self._watchdog_timer.start()
+        self._set_runtime_timers_active(True)
         QTimer.singleShot(0, self._poll_health)
         QTimer.singleShot(0, self._poll_current)
         self._emit_state()
@@ -302,18 +301,14 @@ class RadioController(QObject):
 
     def shutdown(self) -> None:
         self.cancel_start_when_service_ready()
-        if self._health_timer is not None:
-            self._health_timer.stop()
-        if self._current_timer is not None:
-            self._current_timer.stop()
-        if self._watchdog_timer is not None:
-            self._watchdog_timer.stop()
+        self._set_runtime_timers_active(False)
         self._stop_channel_fades()
         self._cancel_reconnect(reset_attempts=True)
         try:
             self.stop_playback()
         except Exception:
             pass
+        self._clear_player_source()
 
     def set_enabled(self, enabled: bool, *, start_when_enabled: bool = False) -> None:
         enabled = bool(enabled)
@@ -325,9 +320,16 @@ class RadioController(QObject):
             self.cancel_start_when_service_ready()
             self._cancel_reconnect(reset_attempts=True)
             self.stop_playback()
+            self._clear_player_source()
+            if changed:
+                self._set_runtime_timers_active(False)
             self._status_text = "Radio disabled."
             self._emit_state()
             return
+
+        if changed or not self._runtime_timers_active:
+            self._set_runtime_timers_active(True)
+            self._poll_runtime_state_soon()
 
         if changed and start_when_enabled:
             self.start_playback()
@@ -442,6 +444,9 @@ class RadioController(QObject):
         if not self._qt_available:
             return
         self._start_when_service_ready = True
+        if not self._runtime_timers_active:
+            self._set_runtime_timers_active(True)
+            self._poll_runtime_state_soon()
         if self._service_available and self._enabled and not self._is_playing:
             self._start_when_service_ready = False
             self.start_playback()
@@ -451,7 +456,7 @@ class RadioController(QObject):
 
     def toggle_playback(self) -> None:
         if not self._enabled:
-            self._enabled = True
+            self.set_enabled(True, start_when_enabled=False)
         if self._desired_playing or self._is_playing:
             self.stop_playback()
             return
@@ -817,6 +822,9 @@ class RadioController(QObject):
             else:
                 self._status_text = "Radio service unavailable."
             self._log_error_throttled("service", reason)
+
+        if available and (not self._enabled) and self._runtime_timers_active:
+            self._set_runtime_timers_active(False)
 
         self._emit_state()
 
@@ -1291,3 +1299,38 @@ class RadioController(QObject):
             immediate=True,
         )
         self._emit_state()
+
+    def _set_runtime_timers_active(self, active: bool) -> None:
+        active = bool(active)
+        if active == self._runtime_timers_active:
+            return
+        self._runtime_timers_active = active
+        for timer in (
+            self._health_timer,
+            self._current_timer,
+            self._watchdog_timer,
+        ):
+            if timer is None:
+                continue
+            if active:
+                if not timer.isActive():
+                    timer.start()
+                continue
+            if timer.isActive():
+                timer.stop()
+
+    def _poll_runtime_state_soon(self) -> None:
+        if not self._qt_available:
+            return
+        if self._network is None:
+            return
+        QTimer.singleShot(0, self._poll_health)
+        QTimer.singleShot(0, self._poll_current)
+
+    def _clear_player_source(self) -> None:
+        if self._player is None:
+            return
+        try:
+            self._player.setSource(QUrl())
+        except Exception:
+            pass

--- a/agents_runner/ui/widgets/radio_control.py
+++ b/agents_runner/ui/widgets/radio_control.py
@@ -82,6 +82,7 @@ class RadioControlWidget(QWidget):
         slider_layout.addWidget(self._volume_slider, 1)
         root.addWidget(self._slider_wrap, 1)
         root.addWidget(self._play_button)
+        root.setAlignment(self._play_button, Qt.AlignRight | Qt.AlignVCenter)
 
         self._slider_opacity_effect = QGraphicsOpacityEffect(self._slider_wrap)
         self._slider_wrap.setGraphicsEffect(self._slider_opacity_effect)

--- a/agents_runner/ui/widgets/radio_control.py
+++ b/agents_runner/ui/widgets/radio_control.py
@@ -11,6 +11,7 @@ from PySide6.QtCore import QVariantAnimation
 from PySide6.QtCore import Signal
 from PySide6.QtGui import QColor
 from PySide6.QtWidgets import QGraphicsOpacityEffect
+from PySide6.QtWidgets import QBoxLayout
 from PySide6.QtWidgets import QHBoxLayout
 from PySide6.QtWidgets import QSlider
 from PySide6.QtWidgets import QToolButton
@@ -62,6 +63,7 @@ class RadioControlWidget(QWidget):
         root = QHBoxLayout(self)
         root.setContentsMargins(0, 0, 0, 0)
         root.setSpacing(0)
+        root.setDirection(QBoxLayout.Direction.RightToLeft)
 
         self._volume_section = QWidget(self)
         self._volume_section.setFixedHeight(self.PLAY_BUTTON_HEIGHT)
@@ -104,9 +106,8 @@ class RadioControlWidget(QWidget):
         self._play_button.clicked.connect(self.play_requested.emit)
         play_section_layout.addWidget(self._play_button, 0, Qt.AlignCenter)
 
-        root.addWidget(self._volume_section, 0, Qt.AlignLeft | Qt.AlignVCenter)
-        root.addStretch(1)
-        root.addWidget(self._play_section, 0, Qt.AlignRight | Qt.AlignVCenter)
+        root.addWidget(self._play_section, 0, Qt.AlignVCenter)
+        root.addWidget(self._volume_section, 0, Qt.AlignVCenter)
 
         self._slider_opacity_effect = QGraphicsOpacityEffect(self._slider_wrap)
         self._slider_wrap.setGraphicsEffect(self._slider_opacity_effect)
@@ -125,6 +126,9 @@ class RadioControlWidget(QWidget):
         self._volume_width_anim.setDuration(self.ANIMATION_MS)
         self._volume_width_anim.setEasingCurve(QEasingCurve.Type.OutCubic)
         self._volume_width_anim.valueChanged.connect(self._sync_volume_min_width)
+        self._volume_width_anim.finished.connect(
+            self._on_volume_width_animation_finished
+        )
 
         self._opacity_anim = QPropertyAnimation(
             self._slider_opacity_effect, b"opacity", self
@@ -312,9 +316,7 @@ class RadioControlWidget(QWidget):
         self._expanded = expanded
         self._volume_width_anim.stop()
         self._opacity_anim.stop()
-        target_root_width = self.EXPANDED_WIDTH if expanded else self.COLLAPSED_WIDTH
-        self.setMinimumWidth(target_root_width)
-        self.setMaximumWidth(target_root_width)
+        self._set_root_width(self.EXPANDED_WIDTH)
 
         current_volume_width = int(self._volume_section.maximumWidth())
         target_volume_width = (
@@ -336,3 +338,12 @@ class RadioControlWidget(QWidget):
         except Exception:
             return
         self._volume_section.setMinimumWidth(width)
+
+    def _on_volume_width_animation_finished(self) -> None:
+        if self._expanded:
+            return
+        self._set_root_width(self.COLLAPSED_WIDTH)
+
+    def _set_root_width(self, width: int) -> None:
+        self.setMinimumWidth(width)
+        self.setMaximumWidth(width)

--- a/agents_runner/ui/widgets/radio_control.py
+++ b/agents_runner/ui/widgets/radio_control.py
@@ -28,7 +28,7 @@ class RadioControlWidget(QWidget):
     COLLAPSED_WIDTH = 44
     EXPANDED_WIDTH = 230
     ANIMATION_MS = 170
-    COLLAPSE_DELAY_MS = 350
+    COLLAPSE_DELAY_MS = 3000
     ICON_COLOR_PLAYING = (16, 185, 129)
     ICON_COLOR_IDLE = (239, 68, 68)
     ICON_COLOR_RECONNECT_START = (250, 204, 21)
@@ -178,7 +178,7 @@ class RadioControlWidget(QWidget):
         elif self._connection_state == "reconnecting":
             tooltip = "Reconnecting Midori AI Radio."
         elif self._is_playing:
-            tooltip = "Stop Midori AI Radio."
+            tooltip = "Turn off Midori AI Radio."
         elif self._radio_enabled:
             tooltip = "Start Midori AI Radio."
         else:
@@ -250,6 +250,9 @@ class RadioControlWidget(QWidget):
 
     def _schedule_collapse(self) -> None:
         if self._drag_active:
+            return
+        if self._is_interaction_active():
+            self._collapse_timer.stop()
             return
         self._collapse_timer.start()
 

--- a/agents_runner/ui/widgets/radio_control.py
+++ b/agents_runner/ui/widgets/radio_control.py
@@ -29,17 +29,24 @@ class RadioControlWidget(QWidget):
     EXPANDED_WIDTH = 230
     ANIMATION_MS = 170
     COLLAPSE_DELAY_MS = 3000
+    PLAY_BUTTON_WIDTH = 40
+    PLAY_BUTTON_HEIGHT = 40
+    VOLUME_RIGHT_GAP = 8
     ICON_COLOR_PLAYING = (16, 185, 129)
     ICON_COLOR_IDLE = (239, 68, 68)
     ICON_COLOR_RECONNECT_START = (250, 204, 21)
     ICON_COLOR_RECONNECT_END = (76, 29, 149)
     RECONNECT_ANIMATION_MS = 900
     CONNECTION_STATES = ("unavailable", "idle", "playing", "reconnecting")
+    COLLAPSED_VOLUME_WIDTH = max(0, COLLAPSED_WIDTH - PLAY_BUTTON_WIDTH)
+    EXPANDED_VOLUME_WIDTH = max(
+        COLLAPSED_VOLUME_WIDTH, EXPANDED_WIDTH - PLAY_BUTTON_WIDTH
+    )
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setObjectName("RadioControlRoot")
-        self.setFixedHeight(40)
+        self.setFixedHeight(self.PLAY_BUTTON_HEIGHT)
         self.setMinimumWidth(self.COLLAPSED_WIDTH)
         self.setMaximumWidth(self.COLLAPSED_WIDTH)
 
@@ -54,20 +61,19 @@ class RadioControlWidget(QWidget):
 
         root = QHBoxLayout(self)
         root.setContentsMargins(0, 0, 0, 0)
-        root.setSpacing(8)
+        root.setSpacing(0)
 
-        self._play_button = QToolButton(self)
-        self._play_button.setObjectName("RadioControlButton")
-        self._play_button.setIconSize(QSize(18, 18))
-        self._play_button.setToolButtonStyle(Qt.ToolButtonIconOnly)
-        self._play_button.setAutoRaise(False)
-        self._play_button.setCheckable(True)
-        self._play_button.setFixedSize(40, 40)
-        self._play_button.clicked.connect(self.play_requested.emit)
+        self._volume_section = QWidget(self)
+        self._volume_section.setFixedHeight(self.PLAY_BUTTON_HEIGHT)
+        self._volume_section.setMinimumWidth(self.COLLAPSED_VOLUME_WIDTH)
+        self._volume_section.setMaximumWidth(self.COLLAPSED_VOLUME_WIDTH)
+        volume_section_layout = QHBoxLayout(self._volume_section)
+        volume_section_layout.setContentsMargins(0, 0, self.VOLUME_RIGHT_GAP, 0)
+        volume_section_layout.setSpacing(0)
 
-        self._slider_wrap = QWidget(self)
+        self._slider_wrap = QWidget(self._volume_section)
         self._slider_wrap.setObjectName("RadioControlSliderWrap")
-        self._slider_wrap.setFixedHeight(40)
+        self._slider_wrap.setFixedHeight(self.PLAY_BUTTON_HEIGHT)
         slider_layout = QHBoxLayout(self._slider_wrap)
         slider_layout.setContentsMargins(0, 0, 0, 0)
         slider_layout.setSpacing(0)
@@ -80,31 +86,51 @@ class RadioControlWidget(QWidget):
         self._volume_slider.sliderPressed.connect(self._on_slider_pressed)
         self._volume_slider.sliderReleased.connect(self._on_slider_released)
         slider_layout.addWidget(self._volume_slider, 1)
-        root.addWidget(self._slider_wrap, 1)
-        root.addWidget(self._play_button)
-        root.setAlignment(self._play_button, Qt.AlignRight | Qt.AlignVCenter)
+        volume_section_layout.addWidget(self._slider_wrap, 1)
+
+        self._play_section = QWidget(self)
+        self._play_section.setFixedSize(self.PLAY_BUTTON_WIDTH, self.PLAY_BUTTON_HEIGHT)
+        play_section_layout = QHBoxLayout(self._play_section)
+        play_section_layout.setContentsMargins(0, 0, 0, 0)
+        play_section_layout.setSpacing(0)
+
+        self._play_button = QToolButton(self._play_section)
+        self._play_button.setObjectName("RadioControlButton")
+        self._play_button.setIconSize(QSize(18, 18))
+        self._play_button.setToolButtonStyle(Qt.ToolButtonIconOnly)
+        self._play_button.setAutoRaise(False)
+        self._play_button.setCheckable(True)
+        self._play_button.setFixedSize(self.PLAY_BUTTON_WIDTH, self.PLAY_BUTTON_HEIGHT)
+        self._play_button.clicked.connect(self.play_requested.emit)
+        play_section_layout.addWidget(self._play_button, 0, Qt.AlignCenter)
+
+        root.addWidget(self._volume_section, 0, Qt.AlignLeft | Qt.AlignVCenter)
+        root.addStretch(1)
+        root.addWidget(self._play_section, 0, Qt.AlignRight | Qt.AlignVCenter)
 
         self._slider_opacity_effect = QGraphicsOpacityEffect(self._slider_wrap)
         self._slider_wrap.setGraphicsEffect(self._slider_opacity_effect)
         self._slider_opacity_effect.setOpacity(0.0)
-        self._slider_wrap.setVisible(False)
 
         self._collapse_timer = QTimer(self)
         self._collapse_timer.setSingleShot(True)
         self._collapse_timer.setInterval(self.COLLAPSE_DELAY_MS)
         self._collapse_timer.timeout.connect(self._on_collapse_timeout)
 
-        self._width_anim = QPropertyAnimation(self, b"maximumWidth", self)
-        self._width_anim.setDuration(self.ANIMATION_MS)
-        self._width_anim.setEasingCurve(QEasingCurve.Type.OutCubic)
-        self._width_anim.valueChanged.connect(self._sync_min_width)
+        self._volume_width_anim = QPropertyAnimation(
+            self._volume_section,
+            b"maximumWidth",
+            self,
+        )
+        self._volume_width_anim.setDuration(self.ANIMATION_MS)
+        self._volume_width_anim.setEasingCurve(QEasingCurve.Type.OutCubic)
+        self._volume_width_anim.valueChanged.connect(self._sync_volume_min_width)
 
         self._opacity_anim = QPropertyAnimation(
             self._slider_opacity_effect, b"opacity", self
         )
         self._opacity_anim.setDuration(self.ANIMATION_MS)
         self._opacity_anim.setEasingCurve(QEasingCurve.Type.OutCubic)
-        self._opacity_anim.finished.connect(self._on_opacity_animation_finished)
         self._reconnect_anim = QVariantAnimation(self)
         self._reconnect_anim.setDuration(self.RECONNECT_ANIMATION_MS)
         self._reconnect_anim.setStartValue(0.0)
@@ -117,7 +143,9 @@ class RadioControlWidget(QWidget):
 
         for watched in (
             self,
+            self._play_section,
             self._play_button,
+            self._volume_section,
             self._slider_wrap,
             self._volume_slider,
         ):
@@ -267,7 +295,9 @@ class RadioControlWidget(QWidget):
     def _is_interaction_active(self) -> bool:
         if (
             self.underMouse()
+            or self._play_section.underMouse()
             or self._play_button.underMouse()
+            or self._volume_section.underMouse()
             or self._slider_wrap.underMouse()
         ):
             return True
@@ -280,18 +310,19 @@ class RadioControlWidget(QWidget):
             return
 
         self._expanded = expanded
-        self._width_anim.stop()
+        self._volume_width_anim.stop()
         self._opacity_anim.stop()
+        target_root_width = self.EXPANDED_WIDTH if expanded else self.COLLAPSED_WIDTH
+        self.setMinimumWidth(target_root_width)
+        self.setMaximumWidth(target_root_width)
 
-        if expanded:
-            self._slider_wrap.setVisible(True)
-
-        current_max_width = int(self.maximumWidth())
-        target_width = self.EXPANDED_WIDTH if expanded else self.COLLAPSED_WIDTH
-
-        self._width_anim.setStartValue(current_max_width)
-        self._width_anim.setEndValue(target_width)
-        self._width_anim.start()
+        current_volume_width = int(self._volume_section.maximumWidth())
+        target_volume_width = (
+            self.EXPANDED_VOLUME_WIDTH if expanded else self.COLLAPSED_VOLUME_WIDTH
+        )
+        self._volume_width_anim.setStartValue(current_volume_width)
+        self._volume_width_anim.setEndValue(target_volume_width)
+        self._volume_width_anim.start()
 
         start_opacity = float(self._slider_opacity_effect.opacity())
         target_opacity = 1.0 if expanded else 0.0
@@ -299,14 +330,9 @@ class RadioControlWidget(QWidget):
         self._opacity_anim.setEndValue(target_opacity)
         self._opacity_anim.start()
 
-    def _sync_min_width(self, value: object) -> None:
+    def _sync_volume_min_width(self, value: object) -> None:
         try:
             width = int(value)
         except Exception:
             return
-        self.setMinimumWidth(width)
-
-    def _on_opacity_animation_finished(self) -> None:
-        if self._expanded:
-            return
-        self._slider_wrap.setVisible(False)
+        self._volume_section.setMinimumWidth(width)

--- a/agents_runner/ui/widgets/radio_control.py
+++ b/agents_runner/ui/widgets/radio_control.py
@@ -64,7 +64,6 @@ class RadioControlWidget(QWidget):
         self._play_button.setCheckable(True)
         self._play_button.setFixedSize(40, 40)
         self._play_button.clicked.connect(self.play_requested.emit)
-        root.addWidget(self._play_button)
 
         self._slider_wrap = QWidget(self)
         self._slider_wrap.setObjectName("RadioControlSliderWrap")
@@ -82,6 +81,7 @@ class RadioControlWidget(QWidget):
         self._volume_slider.sliderReleased.connect(self._on_slider_released)
         slider_layout.addWidget(self._volume_slider, 1)
         root.addWidget(self._slider_wrap, 1)
+        root.addWidget(self._play_button)
 
         self._slider_opacity_effect = QGraphicsOpacityEffect(self._slider_wrap)
         self._slider_wrap.setGraphicsEffect(self._slider_opacity_effect)

--- a/agents_runner/ui/widgets/radio_control.py
+++ b/agents_runner/ui/widgets/radio_control.py
@@ -11,7 +11,6 @@ from PySide6.QtCore import QVariantAnimation
 from PySide6.QtCore import Signal
 from PySide6.QtGui import QColor
 from PySide6.QtWidgets import QGraphicsOpacityEffect
-from PySide6.QtWidgets import QBoxLayout
 from PySide6.QtWidgets import QHBoxLayout
 from PySide6.QtWidgets import QSlider
 from PySide6.QtWidgets import QToolButton
@@ -63,7 +62,6 @@ class RadioControlWidget(QWidget):
         root = QHBoxLayout(self)
         root.setContentsMargins(0, 0, 0, 0)
         root.setSpacing(0)
-        root.setDirection(QBoxLayout.Direction.RightToLeft)
 
         self._volume_section = QWidget(self)
         self._volume_section.setFixedHeight(self.PLAY_BUTTON_HEIGHT)
@@ -106,8 +104,9 @@ class RadioControlWidget(QWidget):
         self._play_button.clicked.connect(self.play_requested.emit)
         play_section_layout.addWidget(self._play_button, 0, Qt.AlignCenter)
 
-        root.addWidget(self._play_section, 0, Qt.AlignVCenter)
+        root.addStretch(1)
         root.addWidget(self._volume_section, 0, Qt.AlignVCenter)
+        root.addWidget(self._play_section, 0, Qt.AlignVCenter)
 
         self._slider_opacity_effect = QGraphicsOpacityEffect(self._slider_wrap)
         self._slider_wrap.setGraphicsEffect(self._slider_opacity_effect)


### PR DESCRIPTION
## Summary
- fix regression where radio button drifted toward the middle during hover/collapse
- keep button pinned by using a right-anchored root layout (`stretch + volume + button`)
- preserve collapse timing behavior while snapping root width only after collapse animation finishes
- make volume bar reveal from the button edge toward the left (right-to-left reveal)

## Validation
- `uv run python` offscreen geometry probe for play/volume x-position stability during expand/collapse
- `uv run ruff format agents_runner/ui/widgets/radio_control.py`
- `uv run ruff check agents_runner/ui/widgets/radio_control.py`
- `uv run python -m py_compile agents_runner/ui/widgets/radio_control.py`

## Notes
- external `RadioControlWidget` API and existing QSS object names remain unchanged.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
