### PR TITLE
[UI] Refine GitHub workroom popup chat UX and controls

### DIFF
--- a/agents_runner/gh/work_items.py
+++ b/agents_runner/gh/work_items.py
@@ -469,6 +469,30 @@ def post_comment(
     raise GhManagementError(f"unsupported item type: {item_type}")
 
 
+def delete_issue_comment(
+    repo_owner: str,
+    repo_name: str,
+    *,
+    comment_id: int,
+) -> None:
+    repo = _repo_full_name(repo_owner, repo_name)
+    comment_id_value = int(comment_id)
+    if comment_id_value <= 0:
+        raise GhManagementError("invalid comment id")
+
+    run_gh_gh(
+        [
+            "api",
+            "--method",
+            "DELETE",
+            f"repos/{repo}/issues/comments/{comment_id_value}",
+            "-H",
+            "Accept: application/vnd.github+json",
+        ],
+        timeout_s=30.0,
+    )
+
+
 def set_item_open_state(
     repo_owner: str,
     repo_name: str,

--- a/agents_runner/ui/dialogs/github_workroom_dialog.py
+++ b/agents_runner/ui/dialogs/github_workroom_dialog.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from datetime import datetime
+from pathlib import Path
 
 from PySide6.QtCore import Qt
+from PySide6.QtCore import QThread
 from PySide6.QtCore import QTimer
 from PySide6.QtCore import QUrl
 from PySide6.QtCore import Signal
@@ -18,6 +20,7 @@ from PySide6.QtWidgets import QToolButton
 from PySide6.QtWidgets import QVBoxLayout
 from PySide6.QtWidgets import QWidget
 
+from agents_runner.gh.work_items import delete_issue_comment
 from agents_runner.gh.work_items import GitHubWorkroom
 from agents_runner.gh.work_items import get_authenticated_github_login
 from agents_runner.gh.work_items import get_issue_workroom
@@ -25,8 +28,13 @@ from agents_runner.gh.work_items import get_pull_request_workroom
 from agents_runner.gh.work_items import post_comment
 from agents_runner.gh.work_items import set_item_open_state
 from agents_runner.prompts import load_prompt
+from agents_runner.stt.mic_recorder import FfmpegPulseRecorder
+from agents_runner.stt.mic_recorder import MicRecorderError
+from agents_runner.stt.mic_recorder import MicRecording
 from agents_runner.ui.dialogs.themed_dialog import ThemedDialog
+from agents_runner.ui.icons import mic_icon
 from agents_runner.ui.lucide_icons import lucide_icon
+from agents_runner.ui.stt.qt_worker import SttWorker
 from agents_runner.ui.utils import resolve_chat_bubble_tone
 from agents_runner.ui.widgets import ChatBubbleAction
 from agents_runner.ui.widgets import ChatBubbleData
@@ -63,6 +71,11 @@ class GitHubWorkroomDialog(ThemedDialog):
             str(get_authenticated_github_login() or "").strip().lower()
         )
         self._room: GitHubWorkroom | None = None
+
+        self._stt_mode = "offline"
+        self._mic_recording: MicRecording | None = None
+        self._stt_thread: QThread | None = None
+        self._stt_worker: SttWorker | None = None
 
         self.setWindowTitle("GitHub Workroom")
         self.setMinimumSize(860, 620)
@@ -142,32 +155,77 @@ class GitHubWorkroomDialog(ThemedDialog):
         composer_title = QLabel("Comment")
         composer_title.setStyleSheet("font-size: 13px; font-weight: 700;")
 
-        row = QHBoxLayout()
-        row.setSpacing(8)
+        composer_input = QWidget()
+        composer_input.setObjectName("WorkroomComposerInput")
+        composer_input.setStyleSheet(
+            "\n".join(
+                [
+                    "QWidget#WorkroomComposerInput {",
+                    "  border: 1px solid rgba(115, 124, 143, 140);",
+                    "  background-color: rgba(26, 28, 37, 185);",
+                    "  border-radius: 0px;",
+                    "}",
+                    "QWidget#WorkroomComposerInput QLineEdit {",
+                    "  border: 0px;",
+                    "  background: transparent;",
+                    "  color: rgba(237, 239, 245, 235);",
+                    "  padding: 7px 4px;",
+                    "}",
+                    "QWidget#WorkroomComposerInput QToolButton {",
+                    "  border: 0px;",
+                    "  border-radius: 0px;",
+                    "  background: transparent;",
+                    "  color: rgba(237, 239, 245, 210);",
+                    "  padding: 6px;",
+                    "}",
+                    "QWidget#WorkroomComposerInput QToolButton:hover:!disabled {",
+                    "  background: rgba(112, 124, 156, 60);",
+                    "}",
+                    "QWidget#WorkroomComposerInput QToolButton:pressed:!disabled {",
+                    "  background: rgba(112, 124, 156, 90);",
+                    "}",
+                    "QWidget#WorkroomComposerInput QToolButton:disabled {",
+                    "  color: rgba(237, 239, 245, 95);",
+                    "}",
+                ]
+            )
+        )
+
+        row = QHBoxLayout(composer_input)
+        row.setContentsMargins(4, 2, 4, 2)
+        row.setSpacing(4)
+
+        self._voice_btn = QToolButton()
+        self._voice_btn.setCheckable(True)
+        self._voice_btn.setIcon(mic_icon(size=18))
+        self._voice_btn.setIconSize(self._voice_btn.iconSize())
+        self._voice_btn.setToolButtonStyle(Qt.ToolButtonIconOnly)
+        self._voice_btn.setToolTip("Speech-to-text into the comment input.")
+        self._voice_btn.toggled.connect(self._on_voice_toggled)
 
         self._comment = QLineEdit()
         self._comment.setPlaceholderText("Write a comment...")
+        self._comment.textChanged.connect(self._sync_send_button_state)
+        self._comment.returnPressed.connect(self._on_comment_return_pressed)
 
         self._btn_send = QToolButton()
-        self._btn_send.setText("Comment")
-        self._btn_send.setIcon(lucide_icon("file-pen-line"))
-        self._btn_send.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        self._btn_send.setIcon(lucide_icon("arrow-up"))
+        self._btn_send.setToolButtonStyle(Qt.ToolButtonIconOnly)
+        self._btn_send.setToolTip("Post comment")
         self._btn_send.clicked.connect(self._on_send_comment)
 
+        row.addWidget(self._voice_btn, 0)
         row.addWidget(self._comment, 1)
-        row.addWidget(self._btn_send)
-
-        self._status = QLabel("Loading...")
-        self._status.setStyleSheet("color: rgba(237, 239, 245, 160);")
+        row.addWidget(self._btn_send, 0)
 
         composer_layout.addWidget(composer_title)
-        composer_layout.addLayout(row)
-        composer_layout.addWidget(self._status)
+        composer_layout.addWidget(composer_input)
 
         layout.addWidget(composer)
 
         self._sync_primary_button()
         self._sync_open_state_button("open")
+        self._sync_send_button_state()
         self.refresh()
 
     def _normalize_user(self, username: str) -> str:
@@ -178,9 +236,14 @@ class GitHubWorkroomDialog(ThemedDialog):
             return False
         return self._normalize_user(username) == self._current_login
 
+    def _item_kind_label(self, item_type: str) -> str:
+        return "PR" if str(item_type or "").strip().lower() == "pr" else "Issue"
+
     def _clear_timeline(self) -> None:
         while self._timeline_layout.count() > 1:
             item = self._timeline_layout.takeAt(0)
+            if item is None:
+                continue
             widget = item.widget()
             if widget is not None:
                 widget.deleteLater()
@@ -212,15 +275,161 @@ class GitHubWorkroomDialog(ThemedDialog):
 
     def _sync_open_state_button(self, state: str) -> None:
         normalized = str(state or "").strip().lower()
+        item_label = self._item_kind_label(self._item_type)
         if normalized == "open":
-            self._btn_toggle_state.setText("Close")
+            self._btn_toggle_state.setText(f"Close ({item_label})")
             self._btn_toggle_state.setIcon(lucide_icon("square"))
             self._btn_toggle_state.setToolTip("Close this item")
             return
 
-        self._btn_toggle_state.setText("Reopen")
+        self._btn_toggle_state.setText(f"Reopen ({item_label})")
         self._btn_toggle_state.setIcon(lucide_icon("play"))
         self._btn_toggle_state.setToolTip("Reopen this item")
+
+    def _sync_send_button_state(self) -> None:
+        self._btn_send.setEnabled(bool(str(self._comment.text() or "").strip()))
+
+    def _on_comment_return_pressed(self) -> None:
+        if self._btn_send.isEnabled():
+            self._on_send_comment()
+
+    def _reset_voice_button(self) -> None:
+        self._voice_btn.setEnabled(True)
+        self._voice_btn.setIcon(mic_icon(size=18))
+        self._voice_btn.setToolTip("Speech-to-text into the comment input.")
+
+    def _on_voice_toggled(self, enabled: bool) -> None:
+        if self._stt_thread is not None:
+            self._voice_btn.blockSignals(True)
+            try:
+                self._voice_btn.setChecked(False)
+            finally:
+                self._voice_btn.blockSignals(False)
+            return
+
+        if enabled:
+            self._start_voice_recording()
+            return
+
+        self._stop_voice_recording_and_transcribe()
+
+    def _start_voice_recording(self) -> None:
+        if not FfmpegPulseRecorder.is_available():
+            QMessageBox.warning(
+                self,
+                "Voice input unavailable",
+                "Could not find `ffmpeg` in PATH (needed to record audio).",
+            )
+            self._voice_btn.blockSignals(True)
+            try:
+                self._voice_btn.setChecked(False)
+            finally:
+                self._voice_btn.blockSignals(False)
+            self._reset_voice_button()
+            return
+
+        try:
+            recorder = FfmpegPulseRecorder()
+            self._mic_recording = recorder.start()
+        except MicRecorderError as exc:
+            QMessageBox.warning(
+                self, "Microphone error", str(exc) or "Could not start recording."
+            )
+            self._voice_btn.blockSignals(True)
+            try:
+                self._voice_btn.setChecked(False)
+            finally:
+                self._voice_btn.blockSignals(False)
+            self._reset_voice_button()
+            return
+
+        self._voice_btn.setIcon(lucide_icon("square"))
+        self._voice_btn.setToolTip("Stop recording and transcribe into the comment.")
+
+    def _stop_voice_recording_and_transcribe(self) -> None:
+        recording = self._mic_recording
+        self._mic_recording = None
+        if recording is None:
+            self._reset_voice_button()
+            return
+
+        self._voice_btn.setEnabled(False)
+
+        recorder = FfmpegPulseRecorder(output_dir=recording.output_path.parent)
+        try:
+            audio_path = recorder.stop(recording)
+        except MicRecorderError as exc:
+            QMessageBox.warning(
+                self, "Microphone error", str(exc) or "Could not stop recording."
+            )
+            self._voice_btn.blockSignals(True)
+            try:
+                self._voice_btn.setChecked(False)
+            finally:
+                self._voice_btn.blockSignals(False)
+            self._reset_voice_button()
+            return
+
+        self._voice_btn.setIcon(lucide_icon("refresh-cw"))
+        self._voice_btn.setToolTip("Transcribing speech-to-text…")
+
+        worker = SttWorker(mode=self._stt_mode, audio_path=str(audio_path))
+        thread = QThread(self)
+        worker.moveToThread(thread)
+
+        thread.started.connect(worker.run)
+        worker.done.connect(self._on_stt_done)
+        worker.error.connect(self._on_stt_error)
+
+        worker.done.connect(thread.quit)
+        worker.error.connect(thread.quit)
+
+        worker.done.connect(worker.deleteLater)
+        worker.error.connect(worker.deleteLater)
+
+        thread.finished.connect(self._on_stt_finished)
+        thread.finished.connect(thread.deleteLater)
+
+        self._stt_worker = worker
+        self._stt_thread = thread
+        thread.start()
+
+    def _on_stt_done(self, text: str, audio_path: str) -> None:
+        value = str(text or "").strip()
+        if value:
+            current = str(self._comment.text() or "").strip()
+            next_value = f"{current} {value}".strip() if current else value
+            self._comment.setText(next_value)
+            self._comment.setCursorPosition(len(next_value))
+        else:
+            QMessageBox.information(
+                self,
+                "No speech detected",
+                "Speech-to-text did not return any text.",
+            )
+
+        try:
+            Path(str(audio_path or "")).unlink(missing_ok=True)
+        except Exception:
+            pass
+
+    def _on_stt_error(self, message: str, audio_path: str) -> None:
+        msg = str(message or "").strip() or "Speech-to-text failed."
+        QMessageBox.warning(self, "Speech-to-text error", msg)
+        try:
+            Path(str(audio_path or "")).unlink(missing_ok=True)
+        except Exception:
+            pass
+
+    def _on_stt_finished(self) -> None:
+        self._stt_thread = None
+        self._stt_worker = None
+        self._voice_btn.blockSignals(True)
+        try:
+            self._voice_btn.setChecked(False)
+        finally:
+            self._voice_btn.blockSignals(False)
+        self._reset_voice_button()
 
     def _format_time(self, value: str) -> str:
         text = str(value or "").strip()
@@ -237,7 +446,7 @@ class GitHubWorkroomDialog(ThemedDialog):
         if room is None:
             return
 
-        kind = "PR" if room.item_type == "pr" else "Issue"
+        kind = self._item_kind_label(room.item_type)
         draft_suffix = " (draft)" if room.is_draft else ""
         self._title.setText(f"{kind} #{room.number}: {room.title}{draft_suffix}")
         self._subtitle.setText(
@@ -291,80 +500,71 @@ class GitHubWorkroomDialog(ThemedDialog):
         issue_bubble.primary_requested.connect(self._on_primary)
         self._add_timeline_bubble(issue_bubble)
 
-        if not room.comments:
-            note = ChatBubbleWidget()
-            note.set_tone(
-                resolve_chat_bubble_tone(
-                    role="other",
-                    env_stain=self._environment_stain,
-                    username="system",
-                )
-            )
-            note.set_data(
-                ChatBubbleData(
-                    author="system",
-                    timestamp="",
-                    body="No comments yet.",
-                    role="other",
-                    actions=(),
-                )
-            )
-            self._add_timeline_bubble(note)
-        else:
-            for comment in room.comments:
-                reactions = comment.reactions
-                reaction_bits: list[str] = []
-                if reactions.thumbs_up > 0:
-                    reaction_bits.append(f"+1={reactions.thumbs_up}")
-                if reactions.thumbs_down > 0:
-                    reaction_bits.append(f"-1={reactions.thumbs_down}")
-                if reactions.eyes > 0:
-                    reaction_bits.append(f"eyes={reactions.eyes}")
-                if reactions.rocket > 0:
-                    reaction_bits.append(f"rocket={reactions.rocket}")
-                if reactions.hooray > 0:
-                    reaction_bits.append(f"hooray={reactions.hooray}")
-                reaction_text = (
-                    f" · {', '.join(reaction_bits)}" if reaction_bits else ""
-                )
-                role = "self" if self._is_self_author(comment.author) else "other"
+        for comment in room.comments:
+            reactions = comment.reactions
+            reaction_bits: list[str] = []
+            if reactions.thumbs_up > 0:
+                reaction_bits.append(f"+1={reactions.thumbs_up}")
+            if reactions.thumbs_down > 0:
+                reaction_bits.append(f"-1={reactions.thumbs_down}")
+            if reactions.eyes > 0:
+                reaction_bits.append(f"eyes={reactions.eyes}")
+            if reactions.rocket > 0:
+                reaction_bits.append(f"rocket={reactions.rocket}")
+            if reactions.hooray > 0:
+                reaction_bits.append(f"hooray={reactions.hooray}")
+            reaction_text = f" · {', '.join(reaction_bits)}" if reaction_bits else ""
+            role = "self" if self._is_self_author(comment.author) else "other"
 
-                bubble = ChatBubbleWidget()
-                bubble.set_tone(
-                    resolve_chat_bubble_tone(
-                        role=role,
-                        env_stain=self._environment_stain,
-                        username=comment.author or "unknown",
+            actions: list[ChatBubbleAction] = [
+                ChatBubbleAction(
+                    action_id="reply",
+                    label="Reply",
+                    icon_name="reply",
+                    tooltip="Focus comment composer",
+                ),
+                ChatBubbleAction(
+                    action_id="open",
+                    label="Open",
+                    icon_name="external-link",
+                    tooltip="Open in browser",
+                ),
+            ]
+            if self._is_self_author(comment.author):
+                actions.append(
+                    ChatBubbleAction(
+                        action_id="delete",
+                        label="Delete",
+                        icon_name="trash-2",
+                        tooltip="Delete this comment",
                     )
                 )
-                bubble.set_data(
-                    ChatBubbleData(
-                        author=comment.author or "unknown",
-                        timestamp=f"{self._format_time(comment.created_at)}{reaction_text}",
-                        body=comment.body or "(empty)",
-                        role=role,
-                        actions=(
-                            ChatBubbleAction(
-                                action_id="reply",
-                                label="Reply",
-                                icon_name="reply",
-                                tooltip="Focus comment composer",
-                            ),
-                            ChatBubbleAction(
-                                action_id="open",
-                                label="Open",
-                                icon_name="external-link",
-                                tooltip="Open in browser",
-                            ),
-                        ),
-                    )
+
+            bubble = ChatBubbleWidget()
+            bubble.set_tone(
+                resolve_chat_bubble_tone(
+                    role=role,
+                    env_stain=self._environment_stain,
+                    username=comment.author or "unknown",
                 )
-                bubble.reply_requested.connect(self._focus_comment_composer)
-                bubble.open_requested.connect(self._open_in_browser)
-                self._add_timeline_bubble(bubble)
+            )
+            bubble.set_data(
+                ChatBubbleData(
+                    author=comment.author or "unknown",
+                    timestamp=f"{self._format_time(comment.created_at)}{reaction_text}",
+                    body=comment.body or "(empty)",
+                    role=role,
+                    actions=tuple(actions),
+                )
+            )
+            bubble.reply_requested.connect(self._focus_comment_composer)
+            bubble.open_requested.connect(self._open_in_browser)
+            bubble.delete_requested.connect(
+                lambda cid=comment.comment_id: self._on_delete_comment(cid)
+            )
+            self._add_timeline_bubble(bubble)
 
         QTimer.singleShot(0, self._scroll_timeline_to_bottom)
-        self._status.setText(f"Loaded {len(room.comments)} comment(s).")
         if self._focus_comment_on_show:
             QTimer.singleShot(0, self._focus_comment_composer)
             self._focus_comment_on_show = False
@@ -393,8 +593,6 @@ class GitHubWorkroomDialog(ThemedDialog):
         return answer == QMessageBox.Yes
 
     def refresh(self) -> None:
-        self._status.setText("Refreshing...")
-
         def _load() -> None:
             if self._item_type == "pr":
                 self._room = get_pull_request_workroom(
@@ -412,7 +610,6 @@ class GitHubWorkroomDialog(ThemedDialog):
         try:
             self._with_wait_cursor(_load)
         except Exception as exc:
-            self._status.setText(f"Failed to load: {exc}")
             QMessageBox.warning(self, "GitHub load failed", str(exc))
             return
 
@@ -504,6 +701,35 @@ class GitHubWorkroomDialog(ThemedDialog):
 
         self.refresh()
 
+    def _on_delete_comment(self, comment_id: int) -> None:
+        room = self._room
+        if room is None:
+            return
+
+        if not self._confirm_write(
+            message=(
+                f"Delete comment #{int(comment_id)} on {room.item_type} "
+                f"#{room.number} in {room.repo_owner}/{room.repo_name}?"
+            ),
+            destructive=True,
+        ):
+            return
+
+        def _write() -> None:
+            delete_issue_comment(
+                room.repo_owner,
+                room.repo_name,
+                comment_id=int(comment_id),
+            )
+
+        try:
+            self._with_wait_cursor(_write)
+        except Exception as exc:
+            QMessageBox.warning(self, "Comment delete failed", str(exc))
+            return
+
+        self.refresh()
+
     def _on_send_comment(self) -> None:
         room = self._room
         if room is None:
@@ -539,4 +765,5 @@ class GitHubWorkroomDialog(ThemedDialog):
             return
 
         self._comment.clear()
+        self._sync_send_button_state()
         self.refresh()

--- a/agents_runner/ui/dialogs/github_workroom_dialog.py
+++ b/agents_runner/ui/dialogs/github_workroom_dialog.py
@@ -4,21 +4,22 @@ from collections.abc import Callable
 from datetime import datetime
 
 from PySide6.QtCore import Qt
+from PySide6.QtCore import QTimer
 from PySide6.QtCore import QUrl
 from PySide6.QtCore import Signal
 from PySide6.QtGui import QDesktopServices
-from PySide6.QtGui import QTextCursor
 from PySide6.QtWidgets import QApplication
 from PySide6.QtWidgets import QHBoxLayout
 from PySide6.QtWidgets import QLabel
 from PySide6.QtWidgets import QLineEdit
 from PySide6.QtWidgets import QMessageBox
-from PySide6.QtWidgets import QPlainTextEdit
+from PySide6.QtWidgets import QScrollArea
 from PySide6.QtWidgets import QToolButton
 from PySide6.QtWidgets import QVBoxLayout
 from PySide6.QtWidgets import QWidget
 
 from agents_runner.gh.work_items import GitHubWorkroom
+from agents_runner.gh.work_items import get_authenticated_github_login
 from agents_runner.gh.work_items import get_issue_workroom
 from agents_runner.gh.work_items import get_pull_request_workroom
 from agents_runner.gh.work_items import post_comment
@@ -26,6 +27,10 @@ from agents_runner.gh.work_items import set_item_open_state
 from agents_runner.prompts import load_prompt
 from agents_runner.ui.dialogs.themed_dialog import ThemedDialog
 from agents_runner.ui.lucide_icons import lucide_icon
+from agents_runner.ui.utils import resolve_chat_bubble_tone
+from agents_runner.ui.widgets import ChatBubbleAction
+from agents_runner.ui.widgets import ChatBubbleData
+from agents_runner.ui.widgets import ChatBubbleWidget
 from agents_runner.ui.widgets import GlassCard
 
 
@@ -41,6 +46,8 @@ class GitHubWorkroomDialog(ThemedDialog):
         number: int,
         item_url: str = "",
         confirmation_mode: str,
+        environment_stain: str = "",
+        focus_comment: bool = False,
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent)
@@ -50,6 +57,11 @@ class GitHubWorkroomDialog(ThemedDialog):
         self._number = max(1, int(number))
         self._item_url = str(item_url or "").strip()
         self._confirmation_mode = str(confirmation_mode or "always").strip().lower()
+        self._environment_stain = str(environment_stain or "").strip().lower()
+        self._focus_comment_on_show = bool(focus_comment)
+        self._current_login = (
+            str(get_authenticated_github_login() or "").strip().lower()
+        )
         self._room: GitHubWorkroom | None = None
 
         self.setWindowTitle("GitHub Workroom")
@@ -105,12 +117,21 @@ class GitHubWorkroomDialog(ThemedDialog):
         timeline_title = QLabel("Timeline")
         timeline_title.setStyleSheet("font-size: 13px; font-weight: 700;")
 
-        self._timeline = QPlainTextEdit()
-        self._timeline.setReadOnly(True)
-        self._timeline.setObjectName("LogsView")
+        self._timeline_scroll = QScrollArea()
+        self._timeline_scroll.setWidgetResizable(True)
+        self._timeline_scroll.setFrameShape(QScrollArea.NoFrame)
+        self._timeline_scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self._timeline_scroll.setObjectName("TaskScroll")
+
+        self._timeline_list = QWidget()
+        self._timeline_layout = QVBoxLayout(self._timeline_list)
+        self._timeline_layout.setContentsMargins(4, 4, 4, 4)
+        self._timeline_layout.setSpacing(8)
+        self._timeline_layout.addStretch(1)
+        self._timeline_scroll.setWidget(self._timeline_list)
 
         timeline_layout.addWidget(timeline_title)
-        timeline_layout.addWidget(self._timeline, 1)
+        timeline_layout.addWidget(self._timeline_scroll, 1)
         layout.addWidget(timeline_card, 1)
 
         composer = GlassCard()
@@ -148,6 +169,33 @@ class GitHubWorkroomDialog(ThemedDialog):
         self._sync_primary_button()
         self._sync_open_state_button("open")
         self.refresh()
+
+    def _normalize_user(self, username: str) -> str:
+        return str(username or "").strip().lower().lstrip("@")
+
+    def _is_self_author(self, username: str) -> bool:
+        if not self._current_login:
+            return False
+        return self._normalize_user(username) == self._current_login
+
+    def _clear_timeline(self) -> None:
+        while self._timeline_layout.count() > 1:
+            item = self._timeline_layout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
+
+    def _add_timeline_bubble(self, bubble: ChatBubbleWidget) -> None:
+        index = max(0, self._timeline_layout.count() - 1)
+        self._timeline_layout.insertWidget(index, bubble)
+
+    def _focus_comment_composer(self) -> None:
+        self._comment.setFocus(Qt.OtherFocusReason)
+        self._comment.setCursorPosition(len(str(self._comment.text() or "")))
+
+    def _scroll_timeline_to_bottom(self) -> None:
+        bar = self._timeline_scroll.verticalScrollBar()
+        bar.setValue(bar.maximum())
 
     def _sync_primary_button(self) -> None:
         if self._item_type == "pr":
@@ -197,17 +245,71 @@ class GitHubWorkroomDialog(ThemedDialog):
         )
         self._sync_open_state_button(room.state)
 
-        lines: list[str] = []
-        lines.append(f"{kind} #{room.number}")
-        lines.append(f"State: {room.state}")
-        lines.append(f"URL: {room.url}")
-        lines.append("")
-        lines.append("Description")
-        lines.append(room.body or "(empty)")
-        lines.append("")
-        lines.append("Comments")
+        self._clear_timeline()
+
+        issue_role = "self" if self._is_self_author(room.author) else "other"
+        issue_actions = (
+            ChatBubbleAction(
+                action_id="reply",
+                label="Reply",
+                icon_name="reply",
+                tooltip="Focus comment composer",
+            ),
+            ChatBubbleAction(
+                action_id="open",
+                label="Open",
+                icon_name="external-link",
+                tooltip="Open in browser",
+            ),
+            ChatBubbleAction(
+                action_id="primary",
+                label="Review PR" if room.item_type == "pr" else "Fix Issue",
+                icon_name="git-pull-request" if room.item_type == "pr" else "bug",
+                tooltip="Create task prompt",
+            ),
+        )
+        issue_body = room.body or "(empty description)"
+        issue_bubble = ChatBubbleWidget()
+        issue_bubble.set_tone(
+            resolve_chat_bubble_tone(
+                role=issue_role,
+                env_stain=self._environment_stain,
+                username=room.author or "unknown",
+            )
+        )
+        issue_bubble.set_data(
+            ChatBubbleData(
+                author=f"{kind} #{room.number} · {room.author or 'unknown'}",
+                timestamp=f"{self._format_time(room.created_at)} · {room.state}",
+                body=issue_body,
+                role=issue_role,
+                actions=issue_actions,
+            )
+        )
+        issue_bubble.reply_requested.connect(self._focus_comment_composer)
+        issue_bubble.open_requested.connect(self._open_in_browser)
+        issue_bubble.primary_requested.connect(self._on_primary)
+        self._add_timeline_bubble(issue_bubble)
+
         if not room.comments:
-            lines.append("(no comments)")
+            note = ChatBubbleWidget()
+            note.set_tone(
+                resolve_chat_bubble_tone(
+                    role="other",
+                    env_stain=self._environment_stain,
+                    username="system",
+                )
+            )
+            note.set_data(
+                ChatBubbleData(
+                    author="system",
+                    timestamp="",
+                    body="No comments yet.",
+                    role="other",
+                    actions=(),
+                )
+            )
+            self._add_timeline_bubble(note)
         else:
             for comment in room.comments:
                 reactions = comment.reactions
@@ -218,20 +320,54 @@ class GitHubWorkroomDialog(ThemedDialog):
                     reaction_bits.append(f"-1={reactions.thumbs_down}")
                 if reactions.eyes > 0:
                     reaction_bits.append(f"eyes={reactions.eyes}")
+                if reactions.rocket > 0:
+                    reaction_bits.append(f"rocket={reactions.rocket}")
+                if reactions.hooray > 0:
+                    reaction_bits.append(f"hooray={reactions.hooray}")
                 reaction_text = (
-                    f" | reactions: {', '.join(reaction_bits)}" if reaction_bits else ""
+                    f" · {', '.join(reaction_bits)}" if reaction_bits else ""
                 )
-                lines.append(
-                    f"- {comment.author or 'unknown'} @ {self._format_time(comment.created_at)}{reaction_text}"
-                )
-                lines.append(comment.body or "(empty)")
-                lines.append("")
+                role = "self" if self._is_self_author(comment.author) else "other"
 
-        self._timeline.setPlainText("\n".join(lines).rstrip())
-        cursor = self._timeline.textCursor()
-        cursor.movePosition(QTextCursor.End)
-        self._timeline.setTextCursor(cursor)
+                bubble = ChatBubbleWidget()
+                bubble.set_tone(
+                    resolve_chat_bubble_tone(
+                        role=role,
+                        env_stain=self._environment_stain,
+                        username=comment.author or "unknown",
+                    )
+                )
+                bubble.set_data(
+                    ChatBubbleData(
+                        author=comment.author or "unknown",
+                        timestamp=f"{self._format_time(comment.created_at)}{reaction_text}",
+                        body=comment.body or "(empty)",
+                        role=role,
+                        actions=(
+                            ChatBubbleAction(
+                                action_id="reply",
+                                label="Reply",
+                                icon_name="reply",
+                                tooltip="Focus comment composer",
+                            ),
+                            ChatBubbleAction(
+                                action_id="open",
+                                label="Open",
+                                icon_name="external-link",
+                                tooltip="Open in browser",
+                            ),
+                        ),
+                    )
+                )
+                bubble.reply_requested.connect(self._focus_comment_composer)
+                bubble.open_requested.connect(self._open_in_browser)
+                self._add_timeline_bubble(bubble)
+
+        QTimer.singleShot(0, self._scroll_timeline_to_bottom)
         self._status.setText(f"Loaded {len(room.comments)} comment(s).")
+        if self._focus_comment_on_show:
+            QTimer.singleShot(0, self._focus_comment_composer)
+            self._focus_comment_on_show = False
 
     def _with_wait_cursor(self, fn: Callable[[], None]) -> None:
         QApplication.setOverrideCursor(Qt.WaitCursor)

--- a/agents_runner/ui/dialogs/github_workroom_dialog.py
+++ b/agents_runner/ui/dialogs/github_workroom_dialog.py
@@ -461,7 +461,7 @@ class GitHubWorkroomDialog(ThemedDialog):
             ChatBubbleAction(
                 action_id="reply",
                 label="Reply",
-                icon_name="reply",
+                icon_name="corner-up-right",
                 tooltip="Focus comment composer",
             ),
             ChatBubbleAction(
@@ -520,7 +520,7 @@ class GitHubWorkroomDialog(ThemedDialog):
                 ChatBubbleAction(
                     action_id="reply",
                     label="Reply",
-                    icon_name="reply",
+                    icon_name="corner-up-right",
                     tooltip="Focus comment composer",
                 ),
                 ChatBubbleAction(

--- a/agents_runner/ui/pages/github_work_list.py
+++ b/agents_runner/ui/pages/github_work_list.py
@@ -2,16 +2,20 @@ from __future__ import annotations
 
 from datetime import datetime
 
+from PySide6.QtCore import QEasingCurve
+from PySide6.QtCore import QParallelAnimationGroup
+from PySide6.QtCore import QPoint
 from PySide6.QtCore import QPropertyAnimation
 from PySide6.QtCore import Qt
-from PySide6.QtCore import QTimer
 from PySide6.QtCore import QUrl
 from PySide6.QtCore import Signal
+from PySide6.QtCore import QEvent
 from PySide6.QtGui import QDesktopServices
+from PySide6.QtGui import QEnterEvent
 from PySide6.QtGui import QMouseEvent
 from PySide6.QtGui import QResizeEvent
-from PySide6.QtWidgets import QGraphicsOpacityEffect
 from PySide6.QtWidgets import QHBoxLayout
+from PySide6.QtWidgets import QGraphicsOpacityEffect
 from PySide6.QtWidgets import QLabel
 from PySide6.QtWidgets import QScrollArea
 from PySide6.QtWidgets import QSizePolicy
@@ -22,196 +26,191 @@ from PySide6.QtWidgets import QWidget
 from agents_runner.environments import Environment
 from agents_runner.environments import resolve_environment_github_repo
 from agents_runner.gh.work_items import GitHubWorkItem
-from agents_runner.gh.work_items import get_authenticated_github_login
 from agents_runner.prompts import load_prompt
 from agents_runner.ui.dialogs.github_workroom_dialog import GitHubWorkroomDialog
 from agents_runner.ui.lucide_icons import lucide_icon
-from agents_runner.ui.utils import resolve_chat_bubble_tone
 from agents_runner.ui.utils import stain_color
 from agents_runner.ui.widgets import BouncingLoadingBar
-from agents_runner.ui.widgets import ChatBubbleAction
-from agents_runner.ui.widgets import ChatBubbleData
-from agents_runner.ui.widgets import ChatBubbleWidget
 from midori_ai_logger import MidoriAiLogger
 
 logger = MidoriAiLogger(channel=None, name=__name__)
 
 
 class _GitHubWorkRow(QWidget):
+    _ACTION_PANEL_HIDDEN_OFFSET = 14
+    _ACTION_PANEL_WIDTH = 86
+
     clicked = Signal(object)
     primary_requested = Signal(object)
-    reply_requested = Signal(object)
     open_requested = Signal(object)
 
     def __init__(self, *, item_type: str, parent: QWidget | None = None) -> None:
         super().__init__(parent)
-        self._item: GitHubWorkItem | None = None
+        self._item = None
         self._item_type = str(item_type or "issue").strip().lower()
-        self._stain = "slate"
-        self._current_login = ""
-        self._row_animation: QPropertyAnimation | None = None
 
         self.setObjectName("TaskRow")
         self.setAttribute(Qt.WA_StyledBackground, True)
         self.setProperty("stain", "slate")
         self.setCursor(Qt.PointingHandCursor)
-        self.setMinimumHeight(108)
-        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.setFixedHeight(56)
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
 
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(8, 8, 8, 8)
-        layout.setSpacing(0)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(12, 8, 12, 8)
+        layout.setSpacing(10)
 
-        self._bubble = ChatBubbleWidget()
-        self._bubble.reply_requested.connect(
-            lambda: self.reply_requested.emit(self._item)
-        )
-        self._bubble.open_requested.connect(
-            lambda: self.open_requested.emit(self._item)
-        )
-        self._bubble.primary_requested.connect(
+        self._title = QLabel("—")
+        self._title.setStyleSheet("font-weight: 650; color: rgba(237, 239, 245, 235);")
+        self._title.setMinimumWidth(260)
+
+        self._meta = QLabel("—")
+        self._meta.setStyleSheet("color: rgba(237, 239, 245, 160);")
+
+        self._actions_host = QWidget(self)
+        self._actions_host.setFixedWidth(self._ACTION_PANEL_WIDTH)
+        self._actions_host.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
+        self._actions_panel = QWidget(self._actions_host)
+        actions_layout = QHBoxLayout(self._actions_panel)
+        actions_layout.setContentsMargins(0, 0, 0, 0)
+        actions_layout.setSpacing(8)
+
+        self._btn_primary = QToolButton()
+        self._btn_primary.setObjectName("RowTrash")
+        self._btn_primary.setToolButtonStyle(Qt.ToolButtonIconOnly)
+        self._btn_primary.clicked.connect(
             lambda: self.primary_requested.emit(self._item)
         )
-        layout.addWidget(self._bubble, 1)
 
-    def _normalize_user(self, username: str) -> str:
-        return str(username or "").strip().lower().lstrip("@")
+        self._btn_open = QToolButton()
+        self._btn_open.setObjectName("RowTrash")
+        self._btn_open.setToolButtonStyle(Qt.ToolButtonIconOnly)
+        self._btn_open.clicked.connect(lambda: self.open_requested.emit(self._item))
 
-    def _is_self_author(self, author: str) -> bool:
-        return bool(self._current_login) and self._normalize_user(author) == str(
-            self._current_login or ""
-        )
+        actions_layout.addWidget(self._btn_primary, 0, Qt.AlignRight)
+        actions_layout.addWidget(self._btn_open, 0, Qt.AlignRight)
 
-    def _format_time(self, value: str) -> str:
-        text = str(value or "").strip()
-        if not text:
-            return "—"
-        try:
-            parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
-            return parsed.strftime("%Y-%m-%d %H:%M")
-        except Exception:
-            return text
+        layout.addWidget(self._title, 6)
+        layout.addWidget(self._meta, 5)
+        layout.addWidget(self._actions_host, 0)
 
-    def _opacity_effect(self) -> QGraphicsOpacityEffect:
-        effect = self.graphicsEffect()
+        self._actions_animation: QParallelAnimationGroup | None = None
+        self._actions_visible = False
+        self._configure_actions()
+        self._set_actions_visible(False, animate=False)
+
+    def _configure_actions(self) -> None:
+        if self._item_type == "pr":
+            self._btn_primary.setIcon(lucide_icon("git-pull-request"))
+            self._btn_primary.setToolTip("Review PR")
+        else:
+            self._btn_primary.setIcon(lucide_icon("bug"))
+            self._btn_primary.setToolTip("Fix Issue")
+
+        self._btn_open.setIcon(lucide_icon("eye"))
+        self._btn_open.setToolTip("Open workroom")
+
+    def _actions_opacity_effect(self) -> QGraphicsOpacityEffect:
+        effect = self._actions_panel.graphicsEffect()
         if isinstance(effect, QGraphicsOpacityEffect):
             return effect
-        effect = QGraphicsOpacityEffect(self)
-        effect.setOpacity(1.0)
-        self.setGraphicsEffect(effect)
+        effect = QGraphicsOpacityEffect(self._actions_panel)
+        effect.setOpacity(1.0 if self._actions_visible else 0.0)
+        self._actions_panel.setGraphicsEffect(effect)
         return effect
 
-    def play_entrance(self, *, delay_ms: int = 0) -> None:
-        effect = self._opacity_effect()
-        effect.setOpacity(0.0)
-        if self._row_animation is not None:
-            self._row_animation.stop()
-            self._row_animation = None
+    def _layout_actions_panel(self) -> None:
+        panel_width = int(self._actions_host.width())
+        panel_height = int(self._actions_host.height())
+        self._actions_panel.resize(panel_width, panel_height)
+        x = 0 if self._actions_visible else self._ACTION_PANEL_HIDDEN_OFFSET
+        self._actions_panel.move(x, 0)
 
-        def _start() -> None:
-            anim = QPropertyAnimation(effect, b"opacity", self)
-            anim.setDuration(220)
-            anim.setStartValue(0.0)
-            anim.setEndValue(1.0)
-            anim.finished.connect(self._on_entrance_finished)
-            anim.start()
-            self._row_animation = anim
+    def _set_actions_visible(self, visible: bool, *, animate: bool = True) -> None:
+        target_visible = bool(visible)
+        self._actions_visible = target_visible
 
-        if delay_ms > 0:
-            QTimer.singleShot(delay_ms, _start)
-        else:
-            _start()
+        if self._actions_animation is not None:
+            self._actions_animation.stop()
+            self._actions_animation = None
 
-    def _on_entrance_finished(self) -> None:
-        self._row_animation = None
-        effect = self.graphicsEffect()
-        if isinstance(effect, QGraphicsOpacityEffect):
-            effect.setOpacity(1.0)
-            self.setGraphicsEffect(None)
+        effect = self._actions_opacity_effect()
+        target_x = 0 if target_visible else self._ACTION_PANEL_HIDDEN_OFFSET
+        target_opacity = 1.0 if target_visible else 0.0
+
+        self._actions_panel.setAttribute(
+            Qt.WA_TransparentForMouseEvents, not target_visible
+        )
+
+        if not animate:
+            current_y = int(self._actions_panel.pos().y())
+            self._actions_panel.move(target_x, current_y)
+            effect.setOpacity(target_opacity)
+            return
+
+        start_pos = QPoint(
+            int(self._actions_panel.pos().x()), int(self._actions_panel.pos().y())
+        )
+        end_pos = QPoint(target_x, int(self._actions_panel.pos().y()))
+        start_opacity = float(effect.opacity())
+
+        pos_anim = QPropertyAnimation(self._actions_panel, b"pos", self)
+        pos_anim.setDuration(180)
+        pos_anim.setStartValue(start_pos)
+        pos_anim.setEndValue(end_pos)
+        pos_anim.setEasingCurve(QEasingCurve.Type.InOutCubic)
+
+        opacity_anim = QPropertyAnimation(effect, b"opacity", self)
+        opacity_anim.setDuration(180)
+        opacity_anim.setStartValue(start_opacity)
+        opacity_anim.setEndValue(target_opacity)
+        opacity_anim.setEasingCurve(QEasingCurve.Type.InOutCubic)
+
+        group = QParallelAnimationGroup(self)
+        group.addAnimation(pos_anim)
+        group.addAnimation(opacity_anim)
+
+        def _on_finished() -> None:
+            self._actions_animation = None
+            if not self._actions_visible:
+                self._actions_panel.setAttribute(Qt.WA_TransparentForMouseEvents, True)
+
+        group.finished.connect(_on_finished)
+        group.start()
+        self._actions_animation = group
 
     def set_stain(self, stain: str) -> None:
         value = str(stain or "slate").strip().lower() or "slate"
-        self._stain = value
         if str(self.property("stain") or "") == value:
-            self._refresh_bubble()
             return
         self.setProperty("stain", value)
         self.style().unpolish(self)
         self.style().polish(self)
         self.update()
-        self._refresh_bubble()
 
-    def _refresh_bubble(self) -> None:
-        item = self._item
-        if item is None:
-            return
-        preview = str(item.body or "").strip().replace("\n", " ")
-        if not preview:
-            preview = "(no preview)"
-        if len(preview) > 200:
-            preview = f"{preview[:197].rstrip()}..."
-        role = "self" if self._is_self_author(item.author) else "other"
-        prefix = "PR" if item.item_type == "pr" else "Issue"
-        title = f"{prefix} #{item.number}: {item.title}"
-        timestamp = f"by {item.author or 'unknown'} · updated {self._format_time(item.updated_at)}"
-        if self._item_type == "pr":
-            primary_label = "Review"
-            primary_icon = "git-pull-request"
-        else:
-            primary_label = "Fix"
-            primary_icon = "bug"
-
-        self._bubble.set_tone(
-            resolve_chat_bubble_tone(
-                role=role,
-                env_stain=self._stain,
-                username=item.author or "unknown",
-            )
-        )
-        self._bubble.set_data(
-            ChatBubbleData(
-                author=title,
-                timestamp=timestamp,
-                body=preview,
-                role=role,
-                actions=(
-                    ChatBubbleAction(
-                        action_id="reply",
-                        label="Reply",
-                        icon_name="reply",
-                        tooltip="Open thread and focus composer",
-                    ),
-                    ChatBubbleAction(
-                        action_id="primary",
-                        label=primary_label,
-                        icon_name=primary_icon,
-                        tooltip="Generate task prompt",
-                    ),
-                    ChatBubbleAction(
-                        action_id="open",
-                        label="Open",
-                        icon_name="external-link",
-                        tooltip="Open full workroom",
-                    ),
-                ),
-            )
-        )
-
-    def set_item(
-        self,
-        item: GitHubWorkItem,
-        *,
-        current_login: str,
-    ) -> None:
+    def set_item(self, item: GitHubWorkItem, *, meta_text: str) -> None:
         self._item = item
-        self._current_login = str(current_login or "").strip().lower()
-        self._refresh_bubble()
+        prefix = "PR" if item.item_type == "pr" else "Issue"
+        self._title.setText(f"{prefix} #{item.number}: {item.title}")
+
+        self._meta.setText(meta_text)
 
     def mousePressEvent(self, event: QMouseEvent) -> None:
-        target = self.childAt(event.position().toPoint())
-        if event.button() == Qt.LeftButton and not isinstance(target, QToolButton):
+        if event.button() == Qt.LeftButton:
             self.clicked.emit(self._item)
         super().mousePressEvent(event)
+
+    def resizeEvent(self, event: QResizeEvent) -> None:
+        super().resizeEvent(event)
+        self._layout_actions_panel()
+
+    def enterEvent(self, event: QEnterEvent) -> None:
+        self._set_actions_visible(True, animate=True)
+        super().enterEvent(event)
+
+    def leaveEvent(self, event: QEvent) -> None:
+        self._set_actions_visible(False, animate=True)
+        super().leaveEvent(event)
 
 
 class _GitHubWorkSkeletonRow(QWidget):
@@ -220,13 +219,13 @@ class _GitHubWorkSkeletonRow(QWidget):
         self.setObjectName("TaskRow")
         self.setAttribute(Qt.WA_StyledBackground, True)
         self.setProperty("stain", "slate")
-        self.setFixedHeight(108)
+        self.setFixedHeight(56)
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
 
         layout = QHBoxLayout(self)
         layout.setContentsMargins(12, 8, 12, 8)
         layout.setSpacing(0)
-        self._pulse = BouncingLoadingBar(width=240, height=76, chunk_fraction=0.40)
+        self._pulse = BouncingLoadingBar(width=240, height=40, chunk_fraction=0.40)
         self._pulse.set_mode("shimmer_sweep")
         self._pulse.start()
         layout.addWidget(self._pulse, 1)
@@ -272,16 +271,10 @@ class GitHubWorkListPage(QWidget):
         self._confirmation_mode = "always"
         self._active_stain = ""
         self._last_fetch_issue = ""
-        self._current_login = (
-            str(get_authenticated_github_login() or "").strip().lower()
-        )
 
         self._rows: dict[int, _GitHubWorkRow] = {}
         self._skeleton_rows: list[_GitHubWorkSkeletonRow] = []
         self._initial_load_seen_keys: set[str] = set()
-        self._render_items: list[GitHubWorkItem] = []
-        self._render_index = 0
-        self._render_batch_size = 12
 
         root = QVBoxLayout(self)
         root.setContentsMargins(0, 0, 0, 0)
@@ -306,7 +299,7 @@ class GitHubWorkListPage(QWidget):
         c1 = QLabel("Item")
         c1.setStyleSheet("color: rgba(237, 239, 245, 150); font-weight: 650;")
         c1.setMinimumWidth(260)
-        c3 = QLabel("Thread")
+        c3 = QLabel("Info")
         c3.setStyleSheet("color: rgba(237, 239, 245, 150); font-weight: 650;")
         self._column_labels = (c1, c3)
 
@@ -327,9 +320,6 @@ class GitHubWorkListPage(QWidget):
         self._list_layout.setSpacing(6)
         self._list_layout.addStretch(1)
         self._scroll.setWidget(self._list)
-        self._scroll.verticalScrollBar().valueChanged.connect(
-            self._on_scroll_value_changed
-        )
 
         card_layout.addWidget(columns)
         card_layout.addWidget(self._scroll, 1)
@@ -507,8 +497,6 @@ class GitHubWorkListPage(QWidget):
                 widget.deleteLater()
         self._rows.clear()
         self._skeleton_rows.clear()
-        self._render_items = []
-        self._render_index = 0
 
     def _render_loading_rows(self, *, stain: str) -> None:
         self._clear_rows()
@@ -520,50 +508,26 @@ class GitHubWorkListPage(QWidget):
 
     def _render_rows(self, items: list[GitHubWorkItem], *, stain: str) -> None:
         self._clear_rows()
-        self._render_items = list(items)
-        self._render_index = 0
-        self._append_next_batch(stain=stain)
 
-    def _append_next_batch(self, *, stain: str) -> None:
-        total = len(self._render_items)
-        if self._render_index >= total:
-            return
-
-        start = self._render_index
-        end = min(total, start + self._render_batch_size)
-        delay = 0
-        for item in self._render_items[start:end]:
+        for item in items:
             row = _GitHubWorkRow(item_type=self._item_type)
             row.set_stain(stain)
-            row.set_item(item, current_login=self._current_login)
+            row.set_item(
+                item,
+                meta_text=(
+                    f"by {item.author or 'unknown'}  |  updated {self._format_time(item.updated_at)}"
+                ),
+            )
             row.clicked.connect(self._open_item)
             row.open_requested.connect(self._open_item)
-            row.reply_requested.connect(self._reply_to_item)
             row.primary_requested.connect(self._request_prompt_from_item)
             self._list_layout.insertWidget(self._list_layout.count() - 1, row)
-            row.play_entrance(delay_ms=delay)
-            delay += 30
             self._rows[item.number] = row
-
-        self._render_index = end
-
-    def _on_scroll_value_changed(self, value: int) -> None:
-        _ = value
-        if not self._render_items or self._render_index >= len(self._render_items):
-            return
-        bar = self._scroll.verticalScrollBar()
-        if bar.value() + bar.pageStep() >= bar.maximum() - 48:
-            self._append_next_batch(stain=self._current_stain())
 
     def _open_item(self, item: object) -> None:
         if not isinstance(item, GitHubWorkItem):
             return
         self._open_item_dialog(item, focus_comment=False)
-
-    def _reply_to_item(self, item: object) -> None:
-        if not isinstance(item, GitHubWorkItem):
-            return
-        self._open_item_dialog(item, focus_comment=True)
 
     def _open_item_dialog(self, item: GitHubWorkItem, *, focus_comment: bool) -> None:
         if self._prefer_browser and item.url:
@@ -584,7 +548,7 @@ class GitHubWorkListPage(QWidget):
             item_url=item.url,
             confirmation_mode=self._confirmation_mode,
             environment_stain=self._current_stain(),
-            focus_comment=focus_comment,
+            focus_comment=bool(focus_comment),
             parent=self,
         )
         dialog.prompt_requested.connect(

--- a/agents_runner/ui/pages/github_work_list.py
+++ b/agents_runner/ui/pages/github_work_list.py
@@ -198,7 +198,13 @@ class _GitHubWorkRow(QWidget):
     def mousePressEvent(self, event: QMouseEvent) -> None:
         if event.button() == Qt.LeftButton:
             self.clicked.emit(self._item)
-        super().mousePressEvent(event)
+            event.accept()
+            return
+        try:
+            super().mousePressEvent(event)
+        except RuntimeError:
+            # Row teardown can race with queued click delivery.
+            event.accept()
 
     def resizeEvent(self, event: QResizeEvent) -> None:
         super().resizeEvent(event)

--- a/agents_runner/ui/pages/github_work_list.py
+++ b/agents_runner/ui/pages/github_work_list.py
@@ -2,20 +2,16 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from PySide6.QtCore import QEasingCurve
-from PySide6.QtCore import QParallelAnimationGroup
-from PySide6.QtCore import QPoint
 from PySide6.QtCore import QPropertyAnimation
 from PySide6.QtCore import Qt
+from PySide6.QtCore import QTimer
 from PySide6.QtCore import QUrl
 from PySide6.QtCore import Signal
-from PySide6.QtCore import QEvent
 from PySide6.QtGui import QDesktopServices
-from PySide6.QtGui import QEnterEvent
 from PySide6.QtGui import QMouseEvent
 from PySide6.QtGui import QResizeEvent
-from PySide6.QtWidgets import QHBoxLayout
 from PySide6.QtWidgets import QGraphicsOpacityEffect
+from PySide6.QtWidgets import QHBoxLayout
 from PySide6.QtWidgets import QLabel
 from PySide6.QtWidgets import QScrollArea
 from PySide6.QtWidgets import QSizePolicy
@@ -26,191 +22,196 @@ from PySide6.QtWidgets import QWidget
 from agents_runner.environments import Environment
 from agents_runner.environments import resolve_environment_github_repo
 from agents_runner.gh.work_items import GitHubWorkItem
+from agents_runner.gh.work_items import get_authenticated_github_login
 from agents_runner.prompts import load_prompt
 from agents_runner.ui.dialogs.github_workroom_dialog import GitHubWorkroomDialog
 from agents_runner.ui.lucide_icons import lucide_icon
+from agents_runner.ui.utils import resolve_chat_bubble_tone
 from agents_runner.ui.utils import stain_color
 from agents_runner.ui.widgets import BouncingLoadingBar
+from agents_runner.ui.widgets import ChatBubbleAction
+from agents_runner.ui.widgets import ChatBubbleData
+from agents_runner.ui.widgets import ChatBubbleWidget
 from midori_ai_logger import MidoriAiLogger
 
 logger = MidoriAiLogger(channel=None, name=__name__)
 
 
 class _GitHubWorkRow(QWidget):
-    _ACTION_PANEL_HIDDEN_OFFSET = 14
-    _ACTION_PANEL_WIDTH = 86
-
     clicked = Signal(object)
     primary_requested = Signal(object)
+    reply_requested = Signal(object)
     open_requested = Signal(object)
 
     def __init__(self, *, item_type: str, parent: QWidget | None = None) -> None:
         super().__init__(parent)
-        self._item = None
+        self._item: GitHubWorkItem | None = None
         self._item_type = str(item_type or "issue").strip().lower()
+        self._stain = "slate"
+        self._current_login = ""
+        self._row_animation: QPropertyAnimation | None = None
 
         self.setObjectName("TaskRow")
         self.setAttribute(Qt.WA_StyledBackground, True)
         self.setProperty("stain", "slate")
         self.setCursor(Qt.PointingHandCursor)
-        self.setFixedHeight(56)
-        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.setMinimumHeight(108)
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
 
-        layout = QHBoxLayout(self)
-        layout.setContentsMargins(12, 8, 12, 8)
-        layout.setSpacing(10)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(0)
 
-        self._title = QLabel("—")
-        self._title.setStyleSheet("font-weight: 650; color: rgba(237, 239, 245, 235);")
-        self._title.setMinimumWidth(260)
-
-        self._meta = QLabel("—")
-        self._meta.setStyleSheet("color: rgba(237, 239, 245, 160);")
-
-        self._actions_host = QWidget(self)
-        self._actions_host.setFixedWidth(self._ACTION_PANEL_WIDTH)
-        self._actions_host.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
-        self._actions_panel = QWidget(self._actions_host)
-        actions_layout = QHBoxLayout(self._actions_panel)
-        actions_layout.setContentsMargins(0, 0, 0, 0)
-        actions_layout.setSpacing(8)
-
-        self._btn_primary = QToolButton()
-        self._btn_primary.setObjectName("RowTrash")
-        self._btn_primary.setToolButtonStyle(Qt.ToolButtonIconOnly)
-        self._btn_primary.clicked.connect(
+        self._bubble = ChatBubbleWidget()
+        self._bubble.reply_requested.connect(
+            lambda: self.reply_requested.emit(self._item)
+        )
+        self._bubble.open_requested.connect(
+            lambda: self.open_requested.emit(self._item)
+        )
+        self._bubble.primary_requested.connect(
             lambda: self.primary_requested.emit(self._item)
         )
+        layout.addWidget(self._bubble, 1)
 
-        self._btn_open = QToolButton()
-        self._btn_open.setObjectName("RowTrash")
-        self._btn_open.setToolButtonStyle(Qt.ToolButtonIconOnly)
-        self._btn_open.clicked.connect(lambda: self.open_requested.emit(self._item))
+    def _normalize_user(self, username: str) -> str:
+        return str(username or "").strip().lower().lstrip("@")
 
-        actions_layout.addWidget(self._btn_primary, 0, Qt.AlignRight)
-        actions_layout.addWidget(self._btn_open, 0, Qt.AlignRight)
+    def _is_self_author(self, author: str) -> bool:
+        return bool(self._current_login) and self._normalize_user(author) == str(
+            self._current_login or ""
+        )
 
-        layout.addWidget(self._title, 6)
-        layout.addWidget(self._meta, 5)
-        layout.addWidget(self._actions_host, 0)
+    def _format_time(self, value: str) -> str:
+        text = str(value or "").strip()
+        if not text:
+            return "—"
+        try:
+            parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+            return parsed.strftime("%Y-%m-%d %H:%M")
+        except Exception:
+            return text
 
-        self._actions_animation: QParallelAnimationGroup | None = None
-        self._actions_visible = False
-        self._configure_actions()
-        self._set_actions_visible(False, animate=False)
-
-    def _configure_actions(self) -> None:
-        if self._item_type == "pr":
-            self._btn_primary.setIcon(lucide_icon("git-pull-request"))
-            self._btn_primary.setToolTip("Review PR")
-        else:
-            self._btn_primary.setIcon(lucide_icon("bug"))
-            self._btn_primary.setToolTip("Fix Issue")
-
-        self._btn_open.setIcon(lucide_icon("eye"))
-        self._btn_open.setToolTip("Open workroom")
-
-    def _actions_opacity_effect(self) -> QGraphicsOpacityEffect:
-        effect = self._actions_panel.graphicsEffect()
+    def _opacity_effect(self) -> QGraphicsOpacityEffect:
+        effect = self.graphicsEffect()
         if isinstance(effect, QGraphicsOpacityEffect):
             return effect
-        effect = QGraphicsOpacityEffect(self._actions_panel)
-        effect.setOpacity(1.0 if self._actions_visible else 0.0)
-        self._actions_panel.setGraphicsEffect(effect)
+        effect = QGraphicsOpacityEffect(self)
+        effect.setOpacity(1.0)
+        self.setGraphicsEffect(effect)
         return effect
 
-    def _layout_actions_panel(self) -> None:
-        panel_width = int(self._actions_host.width())
-        panel_height = int(self._actions_host.height())
-        self._actions_panel.resize(panel_width, panel_height)
-        x = 0 if self._actions_visible else self._ACTION_PANEL_HIDDEN_OFFSET
-        self._actions_panel.move(x, 0)
+    def play_entrance(self, *, delay_ms: int = 0) -> None:
+        effect = self._opacity_effect()
+        effect.setOpacity(0.0)
+        if self._row_animation is not None:
+            self._row_animation.stop()
+            self._row_animation = None
 
-    def _set_actions_visible(self, visible: bool, *, animate: bool = True) -> None:
-        target_visible = bool(visible)
-        self._actions_visible = target_visible
+        def _start() -> None:
+            anim = QPropertyAnimation(effect, b"opacity", self)
+            anim.setDuration(220)
+            anim.setStartValue(0.0)
+            anim.setEndValue(1.0)
+            anim.finished.connect(self._on_entrance_finished)
+            anim.start()
+            self._row_animation = anim
 
-        if self._actions_animation is not None:
-            self._actions_animation.stop()
-            self._actions_animation = None
+        if delay_ms > 0:
+            QTimer.singleShot(delay_ms, _start)
+        else:
+            _start()
 
-        effect = self._actions_opacity_effect()
-        target_x = 0 if target_visible else self._ACTION_PANEL_HIDDEN_OFFSET
-        target_opacity = 1.0 if target_visible else 0.0
-
-        self._actions_panel.setAttribute(
-            Qt.WA_TransparentForMouseEvents, not target_visible
-        )
-
-        if not animate:
-            current_y = int(self._actions_panel.pos().y())
-            self._actions_panel.move(target_x, current_y)
-            effect.setOpacity(target_opacity)
-            return
-
-        start_pos = QPoint(
-            int(self._actions_panel.pos().x()), int(self._actions_panel.pos().y())
-        )
-        end_pos = QPoint(target_x, int(self._actions_panel.pos().y()))
-        start_opacity = float(effect.opacity())
-
-        pos_anim = QPropertyAnimation(self._actions_panel, b"pos", self)
-        pos_anim.setDuration(180)
-        pos_anim.setStartValue(start_pos)
-        pos_anim.setEndValue(end_pos)
-        pos_anim.setEasingCurve(QEasingCurve.Type.InOutCubic)
-
-        opacity_anim = QPropertyAnimation(effect, b"opacity", self)
-        opacity_anim.setDuration(180)
-        opacity_anim.setStartValue(start_opacity)
-        opacity_anim.setEndValue(target_opacity)
-        opacity_anim.setEasingCurve(QEasingCurve.Type.InOutCubic)
-
-        group = QParallelAnimationGroup(self)
-        group.addAnimation(pos_anim)
-        group.addAnimation(opacity_anim)
-
-        def _on_finished() -> None:
-            self._actions_animation = None
-            if not self._actions_visible:
-                self._actions_panel.setAttribute(Qt.WA_TransparentForMouseEvents, True)
-
-        group.finished.connect(_on_finished)
-        group.start()
-        self._actions_animation = group
+    def _on_entrance_finished(self) -> None:
+        self._row_animation = None
+        effect = self.graphicsEffect()
+        if isinstance(effect, QGraphicsOpacityEffect):
+            effect.setOpacity(1.0)
+            self.setGraphicsEffect(None)
 
     def set_stain(self, stain: str) -> None:
         value = str(stain or "slate").strip().lower() or "slate"
+        self._stain = value
         if str(self.property("stain") or "") == value:
+            self._refresh_bubble()
             return
         self.setProperty("stain", value)
         self.style().unpolish(self)
         self.style().polish(self)
         self.update()
+        self._refresh_bubble()
 
-    def set_item(self, item: GitHubWorkItem, *, meta_text: str) -> None:
-        self._item = item
+    def _refresh_bubble(self) -> None:
+        item = self._item
+        if item is None:
+            return
+        preview = str(item.body or "").strip().replace("\n", " ")
+        if not preview:
+            preview = "(no preview)"
+        if len(preview) > 200:
+            preview = f"{preview[:197].rstrip()}..."
+        role = "self" if self._is_self_author(item.author) else "other"
         prefix = "PR" if item.item_type == "pr" else "Issue"
-        self._title.setText(f"{prefix} #{item.number}: {item.title}")
+        title = f"{prefix} #{item.number}: {item.title}"
+        timestamp = f"by {item.author or 'unknown'} · updated {self._format_time(item.updated_at)}"
+        if self._item_type == "pr":
+            primary_label = "Review"
+            primary_icon = "git-pull-request"
+        else:
+            primary_label = "Fix"
+            primary_icon = "bug"
 
-        self._meta.setText(meta_text)
+        self._bubble.set_tone(
+            resolve_chat_bubble_tone(
+                role=role,
+                env_stain=self._stain,
+                username=item.author or "unknown",
+            )
+        )
+        self._bubble.set_data(
+            ChatBubbleData(
+                author=title,
+                timestamp=timestamp,
+                body=preview,
+                role=role,
+                actions=(
+                    ChatBubbleAction(
+                        action_id="reply",
+                        label="Reply",
+                        icon_name="reply",
+                        tooltip="Open thread and focus composer",
+                    ),
+                    ChatBubbleAction(
+                        action_id="primary",
+                        label=primary_label,
+                        icon_name=primary_icon,
+                        tooltip="Generate task prompt",
+                    ),
+                    ChatBubbleAction(
+                        action_id="open",
+                        label="Open",
+                        icon_name="external-link",
+                        tooltip="Open full workroom",
+                    ),
+                ),
+            )
+        )
+
+    def set_item(
+        self,
+        item: GitHubWorkItem,
+        *,
+        current_login: str,
+    ) -> None:
+        self._item = item
+        self._current_login = str(current_login or "").strip().lower()
+        self._refresh_bubble()
 
     def mousePressEvent(self, event: QMouseEvent) -> None:
-        if event.button() == Qt.LeftButton:
+        target = self.childAt(event.position().toPoint())
+        if event.button() == Qt.LeftButton and not isinstance(target, QToolButton):
             self.clicked.emit(self._item)
         super().mousePressEvent(event)
-
-    def resizeEvent(self, event: QResizeEvent) -> None:
-        super().resizeEvent(event)
-        self._layout_actions_panel()
-
-    def enterEvent(self, event: QEnterEvent) -> None:
-        self._set_actions_visible(True, animate=True)
-        super().enterEvent(event)
-
-    def leaveEvent(self, event: QEvent) -> None:
-        self._set_actions_visible(False, animate=True)
-        super().leaveEvent(event)
 
 
 class _GitHubWorkSkeletonRow(QWidget):
@@ -219,13 +220,13 @@ class _GitHubWorkSkeletonRow(QWidget):
         self.setObjectName("TaskRow")
         self.setAttribute(Qt.WA_StyledBackground, True)
         self.setProperty("stain", "slate")
-        self.setFixedHeight(56)
+        self.setFixedHeight(108)
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
 
         layout = QHBoxLayout(self)
         layout.setContentsMargins(12, 8, 12, 8)
         layout.setSpacing(0)
-        self._pulse = BouncingLoadingBar(width=240, height=40, chunk_fraction=0.40)
+        self._pulse = BouncingLoadingBar(width=240, height=76, chunk_fraction=0.40)
         self._pulse.set_mode("shimmer_sweep")
         self._pulse.start()
         layout.addWidget(self._pulse, 1)
@@ -271,10 +272,16 @@ class GitHubWorkListPage(QWidget):
         self._confirmation_mode = "always"
         self._active_stain = ""
         self._last_fetch_issue = ""
+        self._current_login = (
+            str(get_authenticated_github_login() or "").strip().lower()
+        )
 
         self._rows: dict[int, _GitHubWorkRow] = {}
         self._skeleton_rows: list[_GitHubWorkSkeletonRow] = []
         self._initial_load_seen_keys: set[str] = set()
+        self._render_items: list[GitHubWorkItem] = []
+        self._render_index = 0
+        self._render_batch_size = 12
 
         root = QVBoxLayout(self)
         root.setContentsMargins(0, 0, 0, 0)
@@ -299,7 +306,7 @@ class GitHubWorkListPage(QWidget):
         c1 = QLabel("Item")
         c1.setStyleSheet("color: rgba(237, 239, 245, 150); font-weight: 650;")
         c1.setMinimumWidth(260)
-        c3 = QLabel("Info")
+        c3 = QLabel("Thread")
         c3.setStyleSheet("color: rgba(237, 239, 245, 150); font-weight: 650;")
         self._column_labels = (c1, c3)
 
@@ -320,6 +327,9 @@ class GitHubWorkListPage(QWidget):
         self._list_layout.setSpacing(6)
         self._list_layout.addStretch(1)
         self._scroll.setWidget(self._list)
+        self._scroll.verticalScrollBar().valueChanged.connect(
+            self._on_scroll_value_changed
+        )
 
         card_layout.addWidget(columns)
         card_layout.addWidget(self._scroll, 1)
@@ -497,6 +507,8 @@ class GitHubWorkListPage(QWidget):
                 widget.deleteLater()
         self._rows.clear()
         self._skeleton_rows.clear()
+        self._render_items = []
+        self._render_index = 0
 
     def _render_loading_rows(self, *, stain: str) -> None:
         self._clear_rows()
@@ -508,26 +520,52 @@ class GitHubWorkListPage(QWidget):
 
     def _render_rows(self, items: list[GitHubWorkItem], *, stain: str) -> None:
         self._clear_rows()
+        self._render_items = list(items)
+        self._render_index = 0
+        self._append_next_batch(stain=stain)
 
-        for item in items:
+    def _append_next_batch(self, *, stain: str) -> None:
+        total = len(self._render_items)
+        if self._render_index >= total:
+            return
+
+        start = self._render_index
+        end = min(total, start + self._render_batch_size)
+        delay = 0
+        for item in self._render_items[start:end]:
             row = _GitHubWorkRow(item_type=self._item_type)
             row.set_stain(stain)
-            row.set_item(
-                item,
-                meta_text=(
-                    f"by {item.author or 'unknown'}  |  updated {self._format_time(item.updated_at)}"
-                ),
-            )
+            row.set_item(item, current_login=self._current_login)
             row.clicked.connect(self._open_item)
             row.open_requested.connect(self._open_item)
+            row.reply_requested.connect(self._reply_to_item)
             row.primary_requested.connect(self._request_prompt_from_item)
             self._list_layout.insertWidget(self._list_layout.count() - 1, row)
+            row.play_entrance(delay_ms=delay)
+            delay += 30
             self._rows[item.number] = row
+
+        self._render_index = end
+
+    def _on_scroll_value_changed(self, value: int) -> None:
+        _ = value
+        if not self._render_items or self._render_index >= len(self._render_items):
+            return
+        bar = self._scroll.verticalScrollBar()
+        if bar.value() + bar.pageStep() >= bar.maximum() - 48:
+            self._append_next_batch(stain=self._current_stain())
 
     def _open_item(self, item: object) -> None:
         if not isinstance(item, GitHubWorkItem):
             return
+        self._open_item_dialog(item, focus_comment=False)
 
+    def _reply_to_item(self, item: object) -> None:
+        if not isinstance(item, GitHubWorkItem):
+            return
+        self._open_item_dialog(item, focus_comment=True)
+
+    def _open_item_dialog(self, item: GitHubWorkItem, *, focus_comment: bool) -> None:
         if self._prefer_browser and item.url:
             QDesktopServices.openUrl(QUrl(item.url))
             return
@@ -545,6 +583,8 @@ class GitHubWorkListPage(QWidget):
             number=item.number,
             item_url=item.url,
             confirmation_mode=self._confirmation_mode,
+            environment_stain=self._current_stain(),
+            focus_comment=focus_comment,
             parent=self,
         )
         dialog.prompt_requested.connect(

--- a/agents_runner/ui/utils.py
+++ b/agents_runner/ui/utils.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import hashlib
+
+from dataclasses import dataclass
 from datetime import datetime
 
 from PySide6.QtGui import QColor
@@ -115,4 +118,173 @@ def apply_environment_combo_tint(combo: QComboBox, stain: str) -> None:
                 "}",
             ]
         )
+    )
+
+
+@dataclass(frozen=True)
+class ChatBubbleTone:
+    fill: QColor
+    border: QColor
+    text_primary: QColor
+    text_secondary: QColor
+    action_fill: QColor
+    action_border: QColor
+    action_hover_fill: QColor
+    action_hover_border: QColor
+
+
+def _hue_distance(a: int, b: int) -> int:
+    if a < 0 or b < 0:
+        return 180
+    distance = abs(int(a) - int(b)) % 360
+    return min(distance, 360 - distance)
+
+
+def _relative_luminance(color: QColor) -> float:
+    def _linear(channel: int) -> float:
+        value = float(max(0, min(255, int(channel)))) / 255.0
+        if value <= 0.03928:
+            return value / 12.92
+        return ((value + 0.055) / 1.055) ** 2.4
+
+    r = _linear(color.red())
+    g = _linear(color.green())
+    b = _linear(color.blue())
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+
+def _contrast_ratio(a: QColor, b: QColor) -> float:
+    la = _relative_luminance(a)
+    lb = _relative_luminance(b)
+    lighter = max(la, lb)
+    darker = min(la, lb)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def _normalize_username(username: str) -> str:
+    value = str(username or "").strip().lower().lstrip("@")
+    return value or "unknown"
+
+
+def _hash_hsl_color(seed: str) -> QColor:
+    digest = hashlib.sha256(seed.encode("utf-8")).digest()
+    raw_hue = int.from_bytes(digest[0:2], byteorder="big", signed=False) % 360
+    # Quantize hue in coarse buckets to reduce near-identical colors.
+    hue_step = 24
+    hue = int(round(raw_hue / hue_step) * hue_step) % 360
+    saturation = 160 + int(digest[2] % 72)  # 160-231
+    lightness = 96 + int(digest[3] % 56)  # 96-151
+    return QColor.fromHsl(hue, saturation, lightness, 255)
+
+
+def _candidate_far_from_environment(candidate: QColor, env: QColor) -> bool:
+    if _hue_distance(candidate.hslHue(), env.hslHue()) < 34:
+        return False
+    if abs(_relative_luminance(candidate) - _relative_luminance(env)) < 0.12:
+        return False
+    return True
+
+
+def _ensure_contrast(fill: QColor, text: QColor, *, min_ratio: float) -> QColor:
+    candidate = QColor(fill.red(), fill.green(), fill.blue(), fill.alpha())
+    for _ in range(10):
+        if _contrast_ratio(candidate, text) >= min_ratio:
+            return candidate
+        darkened = blend_rgb(candidate, QColor(0, 0, 0), 0.16)
+        candidate = QColor(
+            darkened.red(), darkened.green(), darkened.blue(), fill.alpha()
+        )
+    return candidate
+
+
+def username_bubble_color(
+    username: str,
+    *,
+    env_stain: str,
+    strict: bool = True,
+) -> QColor:
+    normalized = _normalize_username(username)
+    env = stain_color(env_stain)
+    max_attempts = 24
+    for attempt in range(1, max_attempts + 1):
+        # Salting with "a" is color-system-only and keeps output deterministic.
+        salted = f"{normalized}{'a' * attempt}"
+        candidate = _hash_hsl_color(salted)
+        if not strict or _candidate_far_from_environment(candidate, env):
+            return candidate
+
+    fallback = _hash_hsl_color(f"{normalized}{'a' * max_attempts}")
+    hue = fallback.hslHue()
+    if hue < 0:
+        hue = 210
+    rotated = QColor.fromHsl(
+        (hue + 120) % 360, fallback.hslSaturation(), fallback.lightness()
+    )
+    return rotated
+
+
+def resolve_chat_bubble_tone(
+    *,
+    role: str,
+    env_stain: str,
+    username: str,
+) -> ChatBubbleTone:
+    normalized_role = str(role or "").strip().lower()
+    base = (
+        stain_color(env_stain)
+        if normalized_role == "self"
+        else username_bubble_color(username, env_stain=env_stain, strict=True)
+    )
+    canvas = QColor(18, 20, 28)
+    text_primary = QColor(237, 239, 245, 235)
+    text_secondary = QColor(237, 239, 245, 170)
+
+    fill_base = blend_rgb(canvas, base, 0.40)
+    fill = QColor(fill_base.red(), fill_base.green(), fill_base.blue(), 222)
+    fill = _ensure_contrast(fill, text_primary, min_ratio=4.8)
+
+    border_base = blend_rgb(canvas, base, 0.66)
+    border = QColor(border_base.red(), border_base.green(), border_base.blue(), 220)
+
+    action_fill_base = blend_rgb(canvas, base, 0.52)
+    action_fill = QColor(
+        action_fill_base.red(),
+        action_fill_base.green(),
+        action_fill_base.blue(),
+        164,
+    )
+
+    action_border_base = blend_rgb(canvas, base, 0.76)
+    action_border = QColor(
+        action_border_base.red(),
+        action_border_base.green(),
+        action_border_base.blue(),
+        228,
+    )
+
+    action_hover_fill_base = blend_rgb(action_fill, QColor(255, 255, 255), 0.18)
+    action_hover_fill = QColor(
+        action_hover_fill_base.red(),
+        action_hover_fill_base.green(),
+        action_hover_fill_base.blue(),
+        188,
+    )
+
+    action_hover_border_base = blend_rgb(action_border, QColor(255, 255, 255), 0.22)
+    action_hover_border = QColor(
+        action_hover_border_base.red(),
+        action_hover_border_base.green(),
+        action_hover_border_base.blue(),
+        236,
+    )
+
+    return ChatBubbleTone(
+        fill=fill,
+        border=border,
+        text_primary=text_primary,
+        text_secondary=text_secondary,
+        action_fill=action_fill,
+        action_border=action_border,
+        action_hover_fill=action_hover_fill,
+        action_hover_border=action_hover_border,
     )

--- a/agents_runner/ui/widgets/__init__.py
+++ b/agents_runner/ui/widgets/__init__.py
@@ -3,6 +3,9 @@ from .animated_button import AnimatedPushButton, AnimatedToolButton
 from .animated_checkbox import AnimatedCheckBox
 from .arc_spinner import ArcSpinner
 from .artifact_highlighter import ArtifactSyntaxHighlighter, detect_language
+from .chat_bubble import ChatBubbleAction
+from .chat_bubble import ChatBubbleData
+from .chat_bubble import ChatBubbleWidget
 from .edge_fade_scroll_area import EdgeFadeScrollArea
 from .glass_card import GlassCard
 from .loading_bar import BouncingLoadingBar
@@ -22,6 +25,9 @@ __all__ = [
     "ArcSpinner",
     "ArtifactSyntaxHighlighter",
     "BouncingLoadingBar",
+    "ChatBubbleAction",
+    "ChatBubbleData",
+    "ChatBubbleWidget",
     "EdgeFadeScrollArea",
     "GlassCard",
     "LogHighlighter",

--- a/agents_runner/ui/widgets/chat_bubble.py
+++ b/agents_runner/ui/widgets/chat_bubble.py
@@ -1,16 +1,23 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+import html
+import importlib
 
+from dataclasses import dataclass
+from typing import Any
+
+from PySide6.QtCore import QEvent
 from PySide6.QtCore import QPointF
 from PySide6.QtCore import Qt
 from PySide6.QtCore import Signal
+from PySide6.QtGui import QEnterEvent
 from PySide6.QtGui import QPaintEvent
 from PySide6.QtGui import QPainter
 from PySide6.QtGui import QPainterPath
 from PySide6.QtGui import QPolygonF
 from PySide6.QtWidgets import QHBoxLayout
 from PySide6.QtWidgets import QLabel
+from PySide6.QtWidgets import QLayout
 from PySide6.QtWidgets import QSizePolicy
 from PySide6.QtWidgets import QToolButton
 from PySide6.QtWidgets import QVBoxLayout
@@ -20,6 +27,84 @@ from agents_runner.ui.lucide_icons import lucide_icon
 from agents_runner.ui.utils import ChatBubbleTone
 from agents_runner.ui.utils import resolve_chat_bubble_tone
 from agents_runner.ui.utils import rgba
+
+
+def _load_markdown_module() -> Any | None:
+    try:
+        return importlib.import_module("markdown")
+    except Exception:
+        return None
+
+
+_MARKDOWN_MODULE: Any | None = _load_markdown_module()
+
+
+def _fallback_plain_html(source: str) -> str:
+    escaped = html.escape(str(source or ""))
+    escaped = escaped.replace("\r\n", "\n").replace("\r", "\n")
+    escaped = escaped.replace("\n", "<br/>")
+    return f"<p>{escaped}</p>"
+
+
+def _render_markdown_html(source: str) -> str:
+    module = _MARKDOWN_MODULE
+    if module is None:
+        return _fallback_plain_html(source)
+
+    try:
+        rendered = str(
+            module.markdown(
+                str(source or ""),
+                extensions=[
+                    "fenced_code",
+                    "tables",
+                    "sane_lists",
+                    "nl2br",
+                    "codehilite",
+                ],
+                extension_configs={
+                    "codehilite": {
+                        "guess_lang": False,
+                        "noclasses": True,
+                        "pygments_style": "monokai",
+                    }
+                },
+                output_format="html5",
+            )
+            or ""
+        ).strip()
+    except Exception:
+        return _fallback_plain_html(source)
+
+    if not rendered:
+        return "<p></p>"
+
+    styled = rendered.replace(
+        "<pre>",
+        (
+            "<pre style='margin: 8px 0; padding: 8px; border: 1px solid "
+            "rgba(141, 149, 164, 0.45); background-color: rgba(11, 13, 18, 0.85); "
+            "white-space: pre-wrap; word-wrap: break-word;'>"
+        ),
+    )
+    styled = styled.replace(
+        "<code>",
+        (
+            "<code style='font-family: JetBrains Mono, Fira Code, "
+            "DejaVu Sans Mono, monospace;'>"
+        ),
+    )
+    return styled
+
+
+def _clear_layout(layout: QLayout) -> None:
+    while layout.count() > 0:
+        item = layout.takeAt(0)
+        if item is None:
+            continue
+        widget = item.widget()
+        if widget is not None:
+            widget.setParent(None)
 
 
 @dataclass(frozen=True)
@@ -105,6 +190,7 @@ class ChatBubbleWidget(QWidget):
     reply_requested = Signal()
     open_requested = Signal()
     primary_requested = Signal()
+    delete_requested = Signal()
 
     _MAX_BUBBLE_WIDTH = 720
 
@@ -114,12 +200,18 @@ class ChatBubbleWidget(QWidget):
             role="other", env_stain="slate", username="unknown"
         )
         self._flipped = False
+        self._timestamp_text = ""
+        self._body_source = ""
         self._action_buttons: dict[str, QToolButton] = {}
 
         root = QHBoxLayout(self)
         root.setContentsMargins(0, 0, 0, 0)
-        root.setSpacing(0)
+        root.setSpacing(8)
         self._root = root
+
+        self._hover_timestamp = QLabel("")
+        self._hover_timestamp.setVisible(False)
+        self._hover_timestamp.setTextInteractionFlags(Qt.TextSelectableByMouse)
 
         self._surface = _BubbleSurface()
         self._surface.setMaximumWidth(self._MAX_BUBBLE_WIDTH)
@@ -130,68 +222,85 @@ class ChatBubbleWidget(QWidget):
         content.setSpacing(6)
         self._content_layout = content
 
-        header = QHBoxLayout()
-        header.setContentsMargins(0, 0, 0, 0)
-        header.setSpacing(8)
+        self._header_layout = QHBoxLayout()
+        self._header_layout.setContentsMargins(0, 0, 0, 0)
+        self._header_layout.setSpacing(8)
 
         self._author = QLabel("unknown")
-        self._author.setStyleSheet("font-size: 13px; font-weight: 700;")
         self._author.setTextInteractionFlags(Qt.TextSelectableByMouse)
 
-        self._timestamp = QLabel("")
-        self._timestamp.setStyleSheet("font-size: 12px;")
-        self._timestamp.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self._actions_host = QWidget()
+        self._actions_layout = QHBoxLayout(self._actions_host)
+        self._actions_layout.setContentsMargins(0, 0, 0, 0)
+        self._actions_layout.setSpacing(4)
 
-        header.addWidget(self._author, 0)
-        header.addStretch(1)
-        header.addWidget(self._timestamp, 0, Qt.AlignRight)
-        self._content_layout.addLayout(header)
+        self._content_layout.addLayout(self._header_layout)
 
         self._body = QLabel("")
         self._body.setWordWrap(True)
-        self._body.setTextFormat(Qt.PlainText)
-        self._body.setTextInteractionFlags(Qt.TextSelectableByMouse)
-        self._body.setStyleSheet("font-size: 13px; font-weight: 500;")
+        self._body.setTextFormat(Qt.RichText)
+        self._body.setOpenExternalLinks(True)
+        self._body.setTextInteractionFlags(
+            Qt.TextSelectableByMouse | Qt.LinksAccessibleByMouse
+        )
         self._content_layout.addWidget(self._body)
-
-        self._actions_row = QWidget()
-        self._actions_layout = QHBoxLayout(self._actions_row)
-        self._actions_layout.setContentsMargins(0, 2, 0, 0)
-        self._actions_layout.setSpacing(6)
-        self._actions_layout.addStretch(1)
-        self._content_layout.addWidget(self._actions_row)
 
         self._apply_alignment()
         self._apply_tone()
 
+    def _set_hover_timestamp_visible(self, visible: bool) -> None:
+        self._hover_timestamp.setVisible(bool(visible and self._timestamp_text.strip()))
+
     def _apply_alignment(self) -> None:
-        while self._root.count() > 0:
-            item = self._root.takeAt(0)
-            widget = item.widget()
-            if widget is not None and widget is not self._surface:
-                widget.setParent(None)
+        _clear_layout(self._root)
 
         if self._flipped:
+            self._root.addWidget(self._hover_timestamp, 0, Qt.AlignLeft | Qt.AlignTop)
             self._root.addStretch(1)
             self._root.addWidget(self._surface, 0)
             self._surface.set_tail_side("right")
-            self._actions_layout.setAlignment(Qt.AlignRight)
         else:
             self._root.addWidget(self._surface, 0)
             self._root.addStretch(1)
+            self._root.addWidget(self._hover_timestamp, 0, Qt.AlignRight | Qt.AlignTop)
             self._surface.set_tail_side("left")
-            self._actions_layout.setAlignment(Qt.AlignLeft)
+
+        _clear_layout(self._header_layout)
+        if self._flipped:
+            self._header_layout.addWidget(self._author, 0)
+            self._header_layout.addStretch(1)
+            self._header_layout.addWidget(self._actions_host, 0, Qt.AlignRight)
+        else:
+            self._header_layout.addWidget(self._actions_host, 0, Qt.AlignLeft)
+            self._header_layout.addWidget(self._author, 0)
+            self._header_layout.addStretch(1)
+
+    def _render_body(self) -> None:
+        rendered = _render_markdown_html(self._body_source)
+        self._body.setText(f"<div style='margin: 0; padding: 0;'>{rendered}</div>")
 
     def _apply_tone(self) -> None:
         self._surface.set_tone(self._tone)
         self._author.setStyleSheet(
             f"font-size: 13px; font-weight: 700; color: {rgba(self._tone.text_primary)};"
         )
-        self._timestamp.setStyleSheet(
+        self._hover_timestamp.setStyleSheet(
             f"font-size: 12px; color: {rgba(self._tone.text_secondary)};"
         )
         self._body.setStyleSheet(
-            f"font-size: 13px; font-weight: 500; color: {rgba(self._tone.text_primary)};"
+            "\n".join(
+                [
+                    "QLabel {",
+                    "  font-size: 13px;",
+                    "  font-weight: 500;",
+                    f"  color: {rgba(self._tone.text_primary)};",
+                    "}",
+                    "QLabel a {",
+                    f"  color: {rgba(self._tone.text_primary)};",
+                    "  text-decoration: underline;",
+                    "}",
+                ]
+            )
         )
         for button in self._action_buttons.values():
             button.setStyleSheet(
@@ -202,9 +311,7 @@ class ChatBubbleWidget(QWidget):
                         f"  background-color: {rgba(self._tone.action_fill)};",
                         f"  border: 1px solid {rgba(self._tone.action_border)};",
                         "  border-radius: 0px;",
-                        "  padding: 5px 8px;",
-                        "  font-size: 12px;",
-                        "  font-weight: 650;",
+                        "  padding: 4px;",
                         "}",
                         "QToolButton:hover {",
                         f"  background-color: {rgba(self._tone.action_hover_fill)};",
@@ -221,6 +328,8 @@ class ChatBubbleWidget(QWidget):
     def _clear_action_buttons(self) -> None:
         while self._actions_layout.count() > 0:
             item = self._actions_layout.takeAt(0)
+            if item is None:
+                continue
             widget = item.widget()
             if widget is not None:
                 widget.deleteLater()
@@ -237,6 +346,8 @@ class ChatBubbleWidget(QWidget):
             self.open_requested.emit()
         elif action == "primary":
             self.primary_requested.emit()
+        elif action == "delete":
+            self.delete_requested.emit()
 
     def set_tone(self, tone: ChatBubbleTone) -> None:
         self._tone = tone
@@ -253,8 +364,12 @@ class ChatBubbleWidget(QWidget):
         role = str(data.role or "").strip().lower()
         self.set_flipped(role == "self")
         self._author.setText(str(data.author or "unknown"))
-        self._timestamp.setText(str(data.timestamp or ""))
-        self._body.setText(str(data.body or ""))
+        self._timestamp_text = str(data.timestamp or "")
+        self._hover_timestamp.setText(self._timestamp_text)
+        self._set_hover_timestamp_visible(False)
+
+        self._body_source = str(data.body or "")
+        self._render_body()
 
         self._clear_action_buttons()
         if data.actions:
@@ -263,19 +378,28 @@ class ChatBubbleWidget(QWidget):
                 if not action_id:
                     continue
                 button = QToolButton()
-                button.setText(str(action.label or action_id.title()))
+                button.setToolButtonStyle(Qt.ToolButtonIconOnly)
+                button.setFixedSize(24, 24)
                 icon_name = str(action.icon_name or "").strip()
                 if icon_name:
                     button.setIcon(lucide_icon(icon_name))
                 tooltip = str(action.tooltip or "").strip()
-                if tooltip:
-                    button.setToolTip(tooltip)
-                button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+                if not tooltip:
+                    tooltip = str(action.label or action_id.title())
+                button.setToolTip(tooltip)
                 button.clicked.connect(
                     lambda _checked=False, aid=action_id: self._emit_action(aid)
                 )
                 self._actions_layout.addWidget(button, 0)
                 self._action_buttons[action_id] = button
-        self._actions_layout.addStretch(1)
-        self._actions_row.setVisible(bool(self._action_buttons))
+
+        self._actions_host.setVisible(bool(self._action_buttons))
         self._apply_tone()
+
+    def enterEvent(self, event: QEnterEvent) -> None:
+        super().enterEvent(event)
+        self._set_hover_timestamp_visible(True)
+
+    def leaveEvent(self, event: QEvent) -> None:
+        super().leaveEvent(event)
+        self._set_hover_timestamp_visible(False)

--- a/agents_runner/ui/widgets/chat_bubble.py
+++ b/agents_runner/ui/widgets/chat_bubble.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from PySide6.QtCore import QPointF
+from PySide6.QtCore import Qt
+from PySide6.QtCore import Signal
+from PySide6.QtGui import QPaintEvent
+from PySide6.QtGui import QPainter
+from PySide6.QtGui import QPainterPath
+from PySide6.QtGui import QPolygonF
+from PySide6.QtWidgets import QHBoxLayout
+from PySide6.QtWidgets import QLabel
+from PySide6.QtWidgets import QSizePolicy
+from PySide6.QtWidgets import QToolButton
+from PySide6.QtWidgets import QVBoxLayout
+from PySide6.QtWidgets import QWidget
+
+from agents_runner.ui.lucide_icons import lucide_icon
+from agents_runner.ui.utils import ChatBubbleTone
+from agents_runner.ui.utils import resolve_chat_bubble_tone
+from agents_runner.ui.utils import rgba
+
+
+@dataclass(frozen=True)
+class ChatBubbleAction:
+    action_id: str
+    label: str
+    icon_name: str = ""
+    tooltip: str = ""
+
+
+@dataclass(frozen=True)
+class ChatBubbleData:
+    author: str
+    timestamp: str
+    body: str
+    role: str = "other"
+    actions: tuple[ChatBubbleAction, ...] = ()
+
+
+class _BubbleSurface(QWidget):
+    _TAIL_WIDTH = 12
+    _TAIL_HEIGHT = 8
+    _TAIL_INSET = 14
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._tail_side = "left"
+        self._tone = resolve_chat_bubble_tone(
+            role="other", env_stain="slate", username="unknown"
+        )
+        self.setAttribute(Qt.WA_StyledBackground, True)
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
+
+    def set_tail_side(self, side: str) -> None:
+        normalized = "right" if str(side or "").strip().lower() == "right" else "left"
+        if normalized == self._tail_side:
+            return
+        self._tail_side = normalized
+        self.update()
+
+    def set_tone(self, tone: ChatBubbleTone) -> None:
+        self._tone = tone
+        self.update()
+
+    def paintEvent(self, event: QPaintEvent) -> None:
+        super().paintEvent(event)
+        rect = self.rect().adjusted(0, 0, -1, -1)
+        if rect.width() <= 0 or rect.height() <= 0:
+            return
+
+        body = rect.adjusted(0, 0, 0, -self._TAIL_HEIGHT)
+        path = QPainterPath()
+        path.addRect(body)
+
+        if self._tail_side == "right":
+            tail_start = body.right() - self._TAIL_INSET - self._TAIL_WIDTH
+        else:
+            tail_start = body.left() + self._TAIL_INSET
+
+        if self._tail_side == "left":
+            p1 = QPointF(float(tail_start), float(body.bottom()))
+            p2 = QPointF(float(tail_start + self._TAIL_WIDTH), float(body.bottom()))
+        else:
+            p1 = QPointF(float(tail_start + self._TAIL_WIDTH), float(body.bottom()))
+            p2 = QPointF(float(tail_start), float(body.bottom()))
+        p3 = QPointF(float(p1.x()), float(body.bottom() + self._TAIL_HEIGHT))
+
+        tail = QPolygonF([p1, p2, p3])
+        tail_path = QPainterPath()
+        tail_path.addPolygon(tail)
+        tail_path.closeSubpath()
+        path = path.united(tail_path)
+
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing, False)
+        painter.setPen(self._tone.border)
+        painter.setBrush(self._tone.fill)
+        painter.drawPath(path)
+
+
+class ChatBubbleWidget(QWidget):
+    action_requested = Signal(str)
+    reply_requested = Signal()
+    open_requested = Signal()
+    primary_requested = Signal()
+
+    _MAX_BUBBLE_WIDTH = 720
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._tone = resolve_chat_bubble_tone(
+            role="other", env_stain="slate", username="unknown"
+        )
+        self._flipped = False
+        self._action_buttons: dict[str, QToolButton] = {}
+
+        root = QHBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+        root.setSpacing(0)
+        self._root = root
+
+        self._surface = _BubbleSurface()
+        self._surface.setMaximumWidth(self._MAX_BUBBLE_WIDTH)
+        self._surface.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
+
+        content = QVBoxLayout(self._surface)
+        content.setContentsMargins(12, 9, 12, 14)
+        content.setSpacing(6)
+        self._content_layout = content
+
+        header = QHBoxLayout()
+        header.setContentsMargins(0, 0, 0, 0)
+        header.setSpacing(8)
+
+        self._author = QLabel("unknown")
+        self._author.setStyleSheet("font-size: 13px; font-weight: 700;")
+        self._author.setTextInteractionFlags(Qt.TextSelectableByMouse)
+
+        self._timestamp = QLabel("")
+        self._timestamp.setStyleSheet("font-size: 12px;")
+        self._timestamp.setTextInteractionFlags(Qt.TextSelectableByMouse)
+
+        header.addWidget(self._author, 0)
+        header.addStretch(1)
+        header.addWidget(self._timestamp, 0, Qt.AlignRight)
+        self._content_layout.addLayout(header)
+
+        self._body = QLabel("")
+        self._body.setWordWrap(True)
+        self._body.setTextFormat(Qt.PlainText)
+        self._body.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self._body.setStyleSheet("font-size: 13px; font-weight: 500;")
+        self._content_layout.addWidget(self._body)
+
+        self._actions_row = QWidget()
+        self._actions_layout = QHBoxLayout(self._actions_row)
+        self._actions_layout.setContentsMargins(0, 2, 0, 0)
+        self._actions_layout.setSpacing(6)
+        self._actions_layout.addStretch(1)
+        self._content_layout.addWidget(self._actions_row)
+
+        self._apply_alignment()
+        self._apply_tone()
+
+    def _apply_alignment(self) -> None:
+        while self._root.count() > 0:
+            item = self._root.takeAt(0)
+            widget = item.widget()
+            if widget is not None and widget is not self._surface:
+                widget.setParent(None)
+
+        if self._flipped:
+            self._root.addStretch(1)
+            self._root.addWidget(self._surface, 0)
+            self._surface.set_tail_side("right")
+            self._actions_layout.setAlignment(Qt.AlignRight)
+        else:
+            self._root.addWidget(self._surface, 0)
+            self._root.addStretch(1)
+            self._surface.set_tail_side("left")
+            self._actions_layout.setAlignment(Qt.AlignLeft)
+
+    def _apply_tone(self) -> None:
+        self._surface.set_tone(self._tone)
+        self._author.setStyleSheet(
+            f"font-size: 13px; font-weight: 700; color: {rgba(self._tone.text_primary)};"
+        )
+        self._timestamp.setStyleSheet(
+            f"font-size: 12px; color: {rgba(self._tone.text_secondary)};"
+        )
+        self._body.setStyleSheet(
+            f"font-size: 13px; font-weight: 500; color: {rgba(self._tone.text_primary)};"
+        )
+        for button in self._action_buttons.values():
+            button.setStyleSheet(
+                "\n".join(
+                    [
+                        "QToolButton {",
+                        f"  color: {rgba(self._tone.text_primary)};",
+                        f"  background-color: {rgba(self._tone.action_fill)};",
+                        f"  border: 1px solid {rgba(self._tone.action_border)};",
+                        "  border-radius: 0px;",
+                        "  padding: 5px 8px;",
+                        "  font-size: 12px;",
+                        "  font-weight: 650;",
+                        "}",
+                        "QToolButton:hover {",
+                        f"  background-color: {rgba(self._tone.action_hover_fill)};",
+                        f"  border: 1px solid {rgba(self._tone.action_hover_border)};",
+                        "}",
+                        "QToolButton:pressed {",
+                        f"  background-color: {rgba(self._tone.action_hover_fill)};",
+                        f"  border: 1px solid {rgba(self._tone.action_hover_border)};",
+                        "}",
+                    ]
+                )
+            )
+
+    def _clear_action_buttons(self) -> None:
+        while self._actions_layout.count() > 0:
+            item = self._actions_layout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
+        self._action_buttons.clear()
+
+    def _emit_action(self, action_id: str) -> None:
+        action = str(action_id or "").strip().lower()
+        if not action:
+            return
+        self.action_requested.emit(action)
+        if action == "reply":
+            self.reply_requested.emit()
+        elif action == "open":
+            self.open_requested.emit()
+        elif action == "primary":
+            self.primary_requested.emit()
+
+    def set_tone(self, tone: ChatBubbleTone) -> None:
+        self._tone = tone
+        self._apply_tone()
+
+    def set_flipped(self, flipped: bool) -> None:
+        new_value = bool(flipped)
+        if new_value == self._flipped:
+            return
+        self._flipped = new_value
+        self._apply_alignment()
+
+    def set_data(self, data: ChatBubbleData) -> None:
+        role = str(data.role or "").strip().lower()
+        self.set_flipped(role == "self")
+        self._author.setText(str(data.author or "unknown"))
+        self._timestamp.setText(str(data.timestamp or ""))
+        self._body.setText(str(data.body or ""))
+
+        self._clear_action_buttons()
+        if data.actions:
+            for action in data.actions:
+                action_id = str(action.action_id or "").strip().lower()
+                if not action_id:
+                    continue
+                button = QToolButton()
+                button.setText(str(action.label or action_id.title()))
+                icon_name = str(action.icon_name or "").strip()
+                if icon_name:
+                    button.setIcon(lucide_icon(icon_name))
+                tooltip = str(action.tooltip or "").strip()
+                if tooltip:
+                    button.setToolTip(tooltip)
+                button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+                button.clicked.connect(
+                    lambda _checked=False, aid=action_id: self._emit_action(aid)
+                )
+                self._actions_layout.addWidget(button, 0)
+                self._action_buttons[action_id] = button
+        self._actions_layout.addStretch(1)
+        self._actions_row.setVisible(bool(self._action_buttons))
+        self._apply_tone()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = "==3.13.11"
 dependencies = [
     "cryptography>=46.0.3",
     "faster-whisper>=1.2.1",
+    "markdown>=3.8.2",
     "midori_ai_logger",
     "pydantic>=2.11.0",
     "pygments>=2.17.0",


### PR DESCRIPTION
## Summary
- upgrade popup timeline bubbles to Discord-style interaction with icon actions at the top corner
- move timestamps to hover-only opposite-side metadata (left for self/right for others)
- render bubble body text as markdown with fenced code highlighting and clickable links
- redesign the popup composer into a single input container with `mic` on the left and `send` on the right
- remove noisy popup status text and remove the `No comments yet` system bubble
- update open-state button labels to `Close (PR/Issue)` and `Reopen (PR/Issue)`
- add comment deletion support for authored comments
- fix `_GitHubWorkRow` click crash by guarding super mousePress handling during row teardown races
- fix missing reply action icon by switching to available Lucide icon `corner-up-right`

## Details
- `agents_runner/ui/widgets/chat_bubble.py`
  - added markdown rendering pipeline (`markdown` + `codehilite`) with code-block styling
  - moved action controls to icon-only header controls
  - added hover-only side timestamp label and delete signal support
- `agents_runner/ui/dialogs/github_workroom_dialog.py`
  - replaced standalone comment button/status text with integrated composer shell (`mic | input | send`)
  - wired speech-to-text flow for popup comment input
  - removed `Loaded X comments` and `No comments yet` outputs
  - added delete action handling for self-authored comments
  - updated open/reopen button text to include item kind
  - replaced invalid reply icon name (`reply`) with valid Lucide icon (`corner-up-right`)
- `agents_runner/ui/pages/github_work_list.py`
  - hardened `_GitHubWorkRow.mousePressEvent` to avoid runtime crash when row C++ object is torn down during queued click delivery
- `agents_runner/gh/work_items.py`
  - added `delete_issue_comment(...)` helper using GitHub API DELETE endpoint
- `pyproject.toml`
  - added `markdown>=3.8.2` dependency for bubble markdown rendering

## Verification
- `uv run ruff format agents_runner/ui/widgets/chat_bubble.py agents_runner/ui/dialogs/github_workroom_dialog.py agents_runner/gh/work_items.py pyproject.toml` (pass)
- `uv run ruff check agents_runner/ui/widgets/chat_bubble.py agents_runner/ui/dialogs/github_workroom_dialog.py agents_runner/gh/work_items.py` (pass)
- `uv run python -m compileall agents_runner/ui/widgets/chat_bubble.py agents_runner/ui/dialogs/github_workroom_dialog.py agents_runner/gh/work_items.py` (pass)
- `QT_QPA_PLATFORM=offscreen uv run python - <<'PY' ...` chat bubble widget smoke with markdown payload (pass)
- `uv run basedpyright agents_runner/ui/widgets/chat_bubble.py agents_runner/ui/dialogs/github_workroom_dialog.py agents_runner/gh/work_items.py` (run; reports existing PySide enum typing issues in this environment)
- `uv run ruff format agents_runner/ui/pages/github_work_list.py agents_runner/ui/dialogs/github_workroom_dialog.py` (pass)
- `uv run ruff check agents_runner/ui/pages/github_work_list.py agents_runner/ui/dialogs/github_workroom_dialog.py` (pass)
- `uv run python -m compileall agents_runner/ui/pages/github_work_list.py agents_runner/ui/dialogs/github_workroom_dialog.py` (pass)
- `uv run basedpyright agents_runner/ui/pages/github_work_list.py agents_runner/ui/dialogs/github_workroom_dialog.py` (run; reports existing PySide enum/coordinator typing issues in this environment)

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
