### PR TITLE
Support nested artifacts and folder previews

### DIFF
--- a/agents_runner/artifacts.py
+++ b/agents_runner/artifacts.py
@@ -10,6 +10,7 @@ import json
 import logging
 import mimetypes
 import multiprocessing
+import os
 import queue
 import shutil
 import time
@@ -304,7 +305,7 @@ def collect_artifacts_from_container(
         return []
 
     try:
-        files = [f for f in artifacts_staging.iterdir() if f.is_file()]
+        files = _iter_staging_files(artifacts_staging)
 
         if not files:
             logger.debug(f"No artifacts found in staging: {artifacts_staging}")
@@ -315,18 +316,24 @@ def collect_artifacts_from_container(
         # Encrypt each file
         for file_path in files:
             try:
+                relative_path = file_path.relative_to(artifacts_staging).as_posix()
                 artifact_uuid = encrypt_artifact(
-                    task_dict, env_name, str(file_path), file_path.name
+                    task_dict, env_name, str(file_path), relative_path
                 )
                 if artifact_uuid:
                     artifact_uuids.append(artifact_uuid)
                     logger.info(
-                        f"Collected artifact: {file_path.name} -> {artifact_uuid}"
+                        f"Collected artifact: {relative_path} -> {artifact_uuid}"
                     )
                     # Remove from staging after successful encryption
-                    file_path.unlink()
+                    try:
+                        file_path.unlink()
+                    except Exception as unlink_error:
+                        logger.warning(
+                            f"Failed to remove staged artifact {relative_path}: {unlink_error}"
+                        )
             except Exception as e:
-                logger.error(f"Failed to collect artifact {file_path.name}: {e}")
+                logger.error(f"Failed to collect artifact {file_path}: {e}")
                 continue
 
     except Exception as e:
@@ -486,6 +493,51 @@ def get_staging_dir(task_id: str) -> Path:
     return artifacts_dir / "staging"
 
 
+def _iter_staging_files(staging_dir: Path) -> list[Path]:
+    files: list[Path] = []
+    if not staging_dir.exists():
+        return files
+
+    try:
+        root_resolved = staging_dir.resolve()
+    except Exception as e:
+        logger.error(f"Failed to resolve staging dir {staging_dir}: {e}")
+        return files
+
+    def _on_walk_error(exc: OSError) -> None:
+        logger.warning(f"Failed to walk staging dir {staging_dir}: {exc}")
+
+    for root, dirs, filenames in os.walk(
+        staging_dir, followlinks=False, onerror=_on_walk_error
+    ):
+        root_path = Path(root)
+        pruned_dirs: list[str] = []
+        for dirname in dirs:
+            dir_path = root_path / dirname
+            try:
+                if dir_path.is_symlink():
+                    continue
+            except Exception:
+                continue
+            pruned_dirs.append(dirname)
+        dirs[:] = pruned_dirs
+
+        for filename in filenames:
+            file_path = root_path / filename
+            try:
+                if file_path.is_symlink():
+                    continue
+                resolved = file_path.resolve(strict=True)
+            except Exception:
+                continue
+            if not resolved.is_relative_to(root_resolved):
+                logger.warning(f"Skipping staged file outside root: {file_path}")
+                continue
+            files.append(file_path)
+
+    return files
+
+
 def list_staging_artifacts(task_id: str) -> list[StagingArtifactMeta]:
     """
     List artifacts in staging directory (for running tasks).
@@ -504,17 +556,15 @@ def list_staging_artifacts(task_id: str) -> list[StagingArtifactMeta]:
     artifacts: list[StagingArtifactMeta] = []
 
     try:
-        for file_path in staging_dir.iterdir():
-            if not file_path.is_file():
-                continue
-
+        for file_path in _iter_staging_files(staging_dir):
             stat = file_path.stat()
-            mime_type, _ = mimetypes.guess_type(file_path.name)
+            relative_path = file_path.relative_to(staging_dir).as_posix()
+            mime_type, _ = mimetypes.guess_type(relative_path)
             if mime_type is None:
                 mime_type = "application/octet-stream"
 
             artifact = StagingArtifactMeta(
-                filename=file_path.name,
+                filename=relative_path,
                 path=file_path,
                 size_bytes=stat.st_size,
                 modified_at=datetime.fromtimestamp(stat.st_mtime, timezone.utc),
@@ -543,20 +593,36 @@ def get_staging_artifact_path(task_id: str, filename: str) -> Path | None:
         Path to staging file, or None if not found
     """
     staging_dir = get_staging_dir(task_id)
+    if Path(filename).is_absolute():
+        logger.error(f"Absolute path rejected for staging artifact: {filename}")
+        return None
+
     file_path = staging_dir / filename
 
-    if file_path.exists() and file_path.is_file():
-        # Security: Verify file is within staging directory (prevent path traversal)
-        try:
-            if file_path.resolve().parent != staging_dir.resolve():
-                logger.error(f"Path traversal attempt: {filename}")
-                return None
-        except Exception as e:
-            logger.error(f"Failed to resolve path {filename}: {e}")
+    try:
+        if file_path.is_symlink():
+            logger.error(f"Symlink rejected for staging artifact: {filename}")
             return None
-        return file_path
+    except Exception as e:
+        logger.error(f"Failed to inspect path {filename}: {e}")
+        return None
 
-    return None
+    try:
+        resolved_root = staging_dir.resolve()
+        resolved_path = file_path.resolve(strict=True)
+    except Exception as e:
+        logger.error(f"Failed to resolve path {filename}: {e}")
+        return None
+
+    # Security: Verify file is within staging directory (prevent path traversal)
+    if not resolved_path.is_relative_to(resolved_root):
+        logger.error(f"Path traversal attempt: {filename}")
+        return None
+
+    if not resolved_path.is_file():
+        return None
+
+    return file_path
 
 
 @dataclass
@@ -592,7 +658,7 @@ def get_artifact_info(task_id: str) -> ArtifactInfo:
 
     if exists:
         try:
-            file_count = sum(1 for f in staging_dir.iterdir() if f.is_file())
+            file_count = len(_iter_staging_files(staging_dir))
         except Exception as e:
             logger.debug(f"Failed to count files in {staging_dir}: {e}")
             file_count = 0

--- a/agents_runner/ui/artifacts/file_watcher.py
+++ b/agents_runner/ui/artifacts/file_watcher.py
@@ -8,6 +8,7 @@ in the staging directory during task runtime.
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 
 from PySide6.QtCore import (
@@ -138,16 +139,7 @@ class ArtifactFileWatcher(QObject):
         if self._watcher is None:
             return
 
-        # Watch directory
-        self._watcher.addPath(str(self._staging_dir))
-
-        # Watch existing files
-        try:
-            for file_path in self._staging_dir.iterdir():
-                if file_path.is_file():
-                    self._watcher.addPath(str(file_path))
-        except Exception as e:
-            logger.error(f"Failed to add initial files to watcher: {e}")
+        self._refresh_watched_directories()
 
         logger.debug(f"Started watching: {self._staging_dir}")
 
@@ -179,7 +171,7 @@ class ArtifactFileWatcher(QObject):
     def _on_directory_changed(self, path: str) -> None:
         """Directory contents changed (file added/removed)."""
         logger.debug(f"Directory changed: {path}")
-        self._refresh_watched_files()
+        self._refresh_watched_directories()
         self._schedule_emit()
 
     def _on_file_changed(self, path: str) -> None:
@@ -215,8 +207,8 @@ class ArtifactFileWatcher(QObject):
         logger.debug("Emitting files_changed signal")
         self.files_changed.emit()
 
-    def _refresh_watched_files(self) -> None:
-        """Update list of watched files."""
+    def _refresh_watched_directories(self) -> None:
+        """Update list of watched directories."""
         if not self._staging_dir.exists():
             return
 
@@ -225,20 +217,46 @@ class ArtifactFileWatcher(QObject):
             if watcher is None:
                 return
 
-            current_files = {str(f) for f in self._staging_dir.iterdir() if f.is_file()}
-            watched_files = set(watcher.files())
+            current_dirs = self._collect_directories()
+            watched_dirs = set(watcher.directories())
 
-            # Add new files
-            new_files = current_files - watched_files
-            if new_files:
-                watcher.addPaths(list(new_files))
-                logger.debug(f"Added {len(new_files)} new files to watcher")
+            new_dirs = current_dirs - watched_dirs
+            if new_dirs:
+                watcher.addPaths(list(new_dirs))
+                logger.debug(f"Added {len(new_dirs)} new directories to watcher")
 
-            # Remove deleted files
-            deleted_files = watched_files - current_files
-            if deleted_files:
-                watcher.removePaths(list(deleted_files))
-                logger.debug(f"Removed {len(deleted_files)} deleted files from watcher")
+            removed_dirs = watched_dirs - current_dirs
+            if removed_dirs:
+                watcher.removePaths(list(removed_dirs))
+                logger.debug(f"Removed {len(removed_dirs)} deleted directories from watcher")
 
         except Exception as e:
-            logger.error(f"Failed to refresh watched files: {e}")
+            logger.error(f"Failed to refresh watched directories: {e}")
+
+    def _collect_directories(self) -> set[str]:
+        """Collect all directories under the staging dir (recursive)."""
+        if not self._staging_dir.exists():
+            return set()
+
+        directories: set[str] = {str(self._staging_dir)}
+
+        def _on_walk_error(exc: OSError) -> None:
+            logger.warning(f"Failed to walk staging dir {self._staging_dir}: {exc}")
+
+        for root, dirnames, _ in os.walk(
+            self._staging_dir, followlinks=False, onerror=_on_walk_error
+        ):
+            root_path = Path(root)
+            pruned_dirs: list[str] = []
+            for dirname in dirnames:
+                dir_path = root_path / dirname
+                try:
+                    if dir_path.is_symlink():
+                        continue
+                except Exception:
+                    continue
+                pruned_dirs.append(dirname)
+                directories.add(str(dir_path))
+            dirnames[:] = pruned_dirs
+
+        return directories

--- a/agents_runner/ui/pages/artifacts_tab.py
+++ b/agents_runner/ui/pages/artifacts_tab.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 from pathlib import Path
 
 from PySide6.QtCore import QObject, QEvent, Qt, QTimer
@@ -41,10 +42,50 @@ from agents_runner.ui.pages.artifacts_utils import (
     cleanup_temp_files,
 )
 from agents_runner.ui.widgets.glass_card import GlassCard
+from agents_runner.ui.widgets.breadcrumbs import BreadcrumbBar
 from agents_runner.ui.widgets.artifact_highlighter import ArtifactSyntaxHighlighter
 from midori_ai_logger import MidoriAiLogger
 
 logger = MidoriAiLogger(channel=None, name=__name__)
+
+
+@dataclass
+class FolderListItem:
+    name: str
+    path: str
+    item_count: int
+
+
+@dataclass
+class _FolderNode:
+    name: str
+    path: str
+    folders: dict[str, "_FolderNode"]
+    files: list[ArtifactMeta | StagingArtifactMeta]
+
+
+class ArtifactRowWidget(QWidget):
+    def __init__(
+        self,
+        name: str,
+        info_text: str,
+        *,
+        name_style: str,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(8, 6, 8, 6)
+        layout.setSpacing(2)
+
+        name_label = QLabel(name)
+        name_label.setStyleSheet(name_style)
+
+        info_label = QLabel(info_text)
+        info_label.setStyleSheet("font-size: 11px; color: rgba(237, 239, 245, 140);")
+
+        layout.addWidget(name_label)
+        layout.addWidget(info_label)
 
 
 def _emit_watcher_lifecycle_debug(message: str) -> None:
@@ -78,6 +119,9 @@ class ArtifactsTab(QWidget):
         self._refresh_timer.setSingleShot(True)
         self._refresh_timer.timeout.connect(self._refresh_file_list)
         self._preview_loader: PreviewLoader | None = None
+        self._current_folder_path: str = ""
+        self._folder_root: _FolderNode | None = None
+        self._suppress_selection: bool = False
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
@@ -115,8 +159,13 @@ class ArtifactsTab(QWidget):
         self._artifact_list = QListWidget()
         self._artifact_list.setSpacing(4)
         self._artifact_list.currentRowChanged.connect(self._on_selection_changed)
+        self._artifact_list.itemClicked.connect(self._on_item_clicked)
 
         left_layout.addLayout(list_header)
+        self._breadcrumb = BreadcrumbBar()
+        self._breadcrumb.back_clicked.connect(self._on_breadcrumb_back)
+        self._breadcrumb.segment_clicked.connect(self._on_breadcrumb_segment_clicked)
+        left_layout.addWidget(self._breadcrumb)
         left_layout.addWidget(self._artifact_list, 1)
 
         right_panel = GlassCard()
@@ -243,9 +292,90 @@ class ArtifactsTab(QWidget):
                 self._preview_loader.update_thumbnail_scale()
         return super().eventFilter(watched, event)
 
+    def _artifact_relative_path(
+        self, artifact: ArtifactMeta | StagingArtifactMeta
+    ) -> str:
+        if isinstance(artifact, StagingArtifactMeta):
+            return artifact.filename
+        return artifact.original_filename
+
+    def _build_folder_tree(self) -> None:
+        root = _FolderNode(name="Artifacts", path="", folders={}, files=[])
+
+        for artifact in self._artifacts:
+            rel_path = self._artifact_relative_path(artifact).strip()
+            if not rel_path:
+                continue
+            parts = [part for part in rel_path.split("/") if part]
+            if not parts:
+                continue
+            node = root
+            for part in parts[:-1]:
+                child = node.folders.get(part)
+                if child is None:
+                    child_path = f"{node.path}/{part}" if node.path else part
+                    child = _FolderNode(
+                        name=part, path=child_path, folders={}, files=[]
+                    )
+                    node.folders[part] = child
+                node = child
+            node.files.append(artifact)
+
+        self._folder_root = root
+
+    def _get_folder_node(self, path: str) -> _FolderNode | None:
+        root = self._folder_root
+        if root is None:
+            return None
+        if not path:
+            return root
+
+        node = root
+        for part in path.split("/"):
+            next_node = node.folders.get(part)
+            if next_node is None:
+                return None
+            node = next_node
+        return node
+
+    def _ensure_current_folder(self) -> _FolderNode | None:
+        node = self._get_folder_node(self._current_folder_path)
+        if node is None:
+            self._current_folder_path = ""
+            node = self._get_folder_node(self._current_folder_path)
+        return node
+
+    def _update_breadcrumb(self) -> None:
+        parts = [p for p in self._current_folder_path.split("/") if p]
+        segments: list[tuple[str, str]] = [("Artifacts", "")]
+        path_accum = ""
+        for part in parts:
+            path_accum = f"{path_accum}/{part}" if path_accum else part
+            segments.append((part, path_accum))
+        self._breadcrumb.set_segments(segments)
+        self._breadcrumb.set_back_enabled(bool(parts))
+
+    def _on_breadcrumb_back(self) -> None:
+        if not self._current_folder_path:
+            return
+        parts = [p for p in self._current_folder_path.split("/") if p]
+        self._current_folder_path = "/".join(parts[:-1])
+        self._update_artifact_list()
+
+    def _on_breadcrumb_segment_clicked(self, path: str) -> None:
+        self._current_folder_path = path
+        self._update_artifact_list()
+
+    def _on_item_clicked(self, item: QListWidgetItem) -> None:
+        data = item.data(Qt.UserRole)
+        if isinstance(data, FolderListItem):
+            self._current_folder_path = data.path
+            self._update_artifact_list()
+
     def set_task(self, task: Task) -> None:
         """Load artifacts for a task and determine mode based on status."""
         self._current_task = task
+        self._current_folder_path = ""
         cleanup_temp_files(self._temp_files)
         if self._preview_loader:
             self._preview_loader.cleanup_temp_files()
@@ -344,6 +474,7 @@ class ArtifactsTab(QWidget):
             self._artifacts = list_artifacts(self._current_task.task_id)
         else:
             self._artifacts = []
+        self._build_folder_tree()
         self._update_artifact_list()
 
     def _on_files_changed(self) -> None:
@@ -361,76 +492,160 @@ class ArtifactsTab(QWidget):
         else:
             self._artifacts = list_artifacts(self._current_task.task_id)
 
+        self._build_folder_tree()
         self._update_artifact_list()
 
     def _update_artifact_list(self) -> None:
         """Update UI list widget with current artifacts."""
+        self._suppress_selection = True
         self._artifact_list.clear()
-        self._artifact_count.setText(f"({len(self._artifacts)})")
+        folder = self._ensure_current_folder()
+        self._update_breadcrumb()
 
-        if not self._artifacts:
-            # Update empty state message based on mode
+        if folder is None:
+            self._artifact_count.setText("(0)")
+            self._empty_state.setText("No artifacts collected for this task")
+            self._empty_state.show()
+            self._preview_area.hide()
+            self._btn_open.setEnabled(False)
+            self._btn_edit.setEnabled(False)
+            self._btn_download.setEnabled(False)
+            self._suppress_selection = False
+            return
+
+        folders = sorted(folder.folders.values(), key=lambda entry: entry.name.lower())
+        files = sorted(
+            folder.files,
+            key=lambda artifact: Path(self._artifact_relative_path(artifact))
+            .name.lower(),
+        )
+
+        self._artifact_count.setText(f"({len(files)})")
+
+        if not folders and not files:
             if self._mode == "staging" and self._current_task:
                 staging_dir = get_staging_dir(self._current_task.task_id)
+                watch_target = (
+                    staging_dir / self._current_folder_path
+                    if self._current_folder_path
+                    else staging_dir
+                )
                 self._empty_state.setText(
-                    f"No artifacts yet\n\nWatching: {staging_dir}"
+                    f"No artifacts yet\n\nWatching: {watch_target}"
                 )
             else:
-                self._empty_state.setText("No artifacts collected for this task")
+                empty_text = (
+                    "No artifacts in this folder"
+                    if self._current_folder_path
+                    else "No artifacts collected for this task"
+                )
+                self._empty_state.setText(empty_text)
 
             self._empty_state.show()
             self._preview_area.hide()
             self._btn_open.setEnabled(False)
             self._btn_edit.setEnabled(False)
             self._btn_download.setEnabled(False)
+            self._suppress_selection = False
             return
 
         self._empty_state.hide()
 
-        for artifact in self._artifacts:
+        first_file_row: int | None = None
+
+        for folder_entry in folders:
             item = QListWidgetItem()
-            item.setData(Qt.UserRole, artifact)
+            item_data = FolderListItem(
+                name=folder_entry.name,
+                path=folder_entry.path,
+                item_count=len(folder_entry.folders) + len(folder_entry.files),
+            )
+            item.setData(Qt.UserRole, item_data)
 
-            widget = QWidget()
-            layout = QVBoxLayout(widget)
-            layout.setContentsMargins(8, 6, 8, 6)
-            layout.setSpacing(2)
-
-            if isinstance(artifact, StagingArtifactMeta):
-                # Staging artifact - green color
-                name = QLabel(artifact.filename)
-                name.setStyleSheet("font-weight: 600; color: rgba(100, 255, 100, 235);")
-
-                info_text = f"{format_size(artifact.size_bytes)} • {format_timestamp(artifact.modified_at.isoformat())}"
-            else:
-                # Encrypted artifact - normal color
-                name = QLabel(artifact.original_filename)
-                name.setStyleSheet("font-weight: 600; color: rgba(237, 239, 245, 235);")
-
-                info_text = f"{format_size(artifact.size_bytes)} • {format_timestamp(artifact.encrypted_at)}"
-
-            info = QLabel(info_text)
-            info.setStyleSheet("font-size: 11px; color: rgba(237, 239, 245, 140);")
-
-            layout.addWidget(name)
-            layout.addWidget(info)
+            info_text = (
+                f"{item_data.item_count} items"
+                if item_data.item_count != 1
+                else "1 item"
+            )
+            widget = ArtifactRowWidget(
+                folder_entry.name,
+                info_text,
+                name_style="font-weight: 600; color: rgba(237, 239, 245, 220);",
+            )
 
             item.setSizeHint(widget.sizeHint())
             self._artifact_list.addItem(item)
             self._artifact_list.setItemWidget(item, widget)
 
-        if self._artifacts:
-            self._artifact_list.setCurrentRow(0)
+        for artifact in files:
+            item = QListWidgetItem()
+            item.setData(Qt.UserRole, artifact)
+
+            display_name = Path(self._artifact_relative_path(artifact)).name
+            if isinstance(artifact, StagingArtifactMeta):
+                name_style = "font-weight: 600; color: rgba(100, 255, 100, 235);"
+                info_text = (
+                    f"{format_size(artifact.size_bytes)} • "
+                    f"{format_timestamp(artifact.modified_at.isoformat())}"
+                )
+            else:
+                name_style = "font-weight: 600; color: rgba(237, 239, 245, 235);"
+                info_text = (
+                    f"{format_size(artifact.size_bytes)} • "
+                    f"{format_timestamp(artifact.encrypted_at)}"
+                )
+
+            widget = ArtifactRowWidget(
+                display_name,
+                info_text,
+                name_style=name_style,
+            )
+
+            item.setSizeHint(widget.sizeHint())
+            self._artifact_list.addItem(item)
+            self._artifact_list.setItemWidget(item, widget)
+
+            if first_file_row is None:
+                first_file_row = self._artifact_list.row(item)
+
+        if first_file_row is not None:
+            self._artifact_list.setCurrentRow(first_file_row)
+        else:
+            self._artifact_list.clearSelection()
+            self._preview_area.hide()
+            self._btn_open.setEnabled(False)
+            self._btn_edit.setEnabled(False)
+            self._btn_download.setEnabled(False)
+
+        self._suppress_selection = False
 
     def _on_selection_changed(self, current_row: int) -> None:
-        if current_row < 0 or current_row >= len(self._artifacts):
+        if self._suppress_selection:
+            return
+
+        if current_row < 0:
+            self._preview_area.hide()
+            self._btn_open.setEnabled(False)
+            self._btn_edit.setEnabled(False)
+            self._btn_download.setEnabled(False)
+            return
+        item = self._artifact_list.item(current_row)
+        if item is None:
             self._preview_area.hide()
             self._btn_open.setEnabled(False)
             self._btn_edit.setEnabled(False)
             self._btn_download.setEnabled(False)
             return
 
-        artifact = self._artifacts[current_row]
+        item_data = item.data(Qt.UserRole)
+        if isinstance(item_data, FolderListItem) or item_data is None:
+            self._preview_area.hide()
+            self._btn_open.setEnabled(False)
+            self._btn_edit.setEnabled(False)
+            self._btn_download.setEnabled(False)
+            return
+
+        artifact = item_data
         self._preview_area.show()
         self._btn_open.setEnabled(True)
 
@@ -522,11 +737,13 @@ class ArtifactsTab(QWidget):
         )
 
     def _on_open_clicked(self) -> None:
-        current_row = self._artifact_list.currentRow()
-        if current_row < 0 or not self._current_task:
+        item = self._artifact_list.currentItem()
+        if item is None or not self._current_task:
             return
 
-        artifact = self._artifacts[current_row]
+        artifact = item.data(Qt.UserRole)
+        if not isinstance(artifact, (ArtifactMeta, StagingArtifactMeta)):
+            return
 
         if isinstance(artifact, StagingArtifactMeta):
             open_staging_artifact(artifact)
@@ -540,11 +757,13 @@ class ArtifactsTab(QWidget):
 
     def _on_edit_clicked(self) -> None:
         """Edit selected artifact in external editor."""
-        current_row = self._artifact_list.currentRow()
-        if current_row < 0 or not self._current_task:
+        item = self._artifact_list.currentItem()
+        if item is None or not self._current_task:
             return
 
-        artifact = self._artifacts[current_row]
+        artifact = item.data(Qt.UserRole)
+        if not isinstance(artifact, (ArtifactMeta, StagingArtifactMeta)):
+            return
 
         # Only allow editing for staging artifacts
         if not isinstance(artifact, StagingArtifactMeta):
@@ -561,11 +780,13 @@ class ArtifactsTab(QWidget):
         edit_staging_artifact(artifact)
 
     def _on_download_clicked(self) -> None:
-        current_row = self._artifact_list.currentRow()
-        if current_row < 0 or not self._current_task:
+        item = self._artifact_list.currentItem()
+        if item is None or not self._current_task:
             return
 
-        artifact = self._artifacts[current_row]
+        artifact = item.data(Qt.UserRole)
+        if not isinstance(artifact, ArtifactMeta):
+            return
         dest_path, _ = QFileDialog.getSaveFileName(
             self, "Save Artifact", artifact.original_filename, "All Files (*.*)"
         )

--- a/agents_runner/ui/pages/artifacts_tab.py
+++ b/agents_runner/ui/pages/artifacts_tab.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 
 from PySide6.QtCore import QObject, QEvent, Qt, QTimer
@@ -160,6 +161,7 @@ class ArtifactsTab(QWidget):
         self._artifact_list.setSpacing(4)
         self._artifact_list.currentRowChanged.connect(self._on_selection_changed)
         self._artifact_list.itemClicked.connect(self._on_item_clicked)
+        self._artifact_list.itemDoubleClicked.connect(self._on_item_double_clicked)
 
         left_layout.addLayout(list_header)
         self._breadcrumb = BreadcrumbBar()
@@ -345,6 +347,89 @@ class ArtifactsTab(QWidget):
             node = self._get_folder_node(self._current_folder_path)
         return node
 
+    def _artifact_modified_at(
+        self, artifact: ArtifactMeta | StagingArtifactMeta
+    ) -> datetime | None:
+        if isinstance(artifact, StagingArtifactMeta):
+            return artifact.modified_at
+        try:
+            return datetime.fromisoformat(artifact.encrypted_at)
+        except Exception:
+            return None
+
+    def _summarize_folder(
+        self, node: _FolderNode
+    ) -> tuple[int, int, int, datetime | None, list[str]]:
+        folder_count = 0
+        file_count = 0
+        total_size = 0
+        latest_modified: datetime | None = None
+        samples: list[str] = []
+
+        def walk(current: _FolderNode, base: str) -> None:
+            nonlocal folder_count, file_count, total_size, latest_modified, samples
+
+            for artifact in sorted(
+                current.files,
+                key=lambda entry: Path(self._artifact_relative_path(entry)).name.lower(),
+            ):
+                file_count += 1
+                total_size += int(artifact.size_bytes)
+                modified = self._artifact_modified_at(artifact)
+                if modified and (
+                    latest_modified is None or modified > latest_modified
+                ):
+                    latest_modified = modified
+                if len(samples) < 5:
+                    filename = Path(self._artifact_relative_path(artifact)).name
+                    samples.append(f"{base}/{filename}" if base else filename)
+
+            for folder_name in sorted(current.folders.keys(), key=str.lower):
+                folder_count += 1
+                child = current.folders[folder_name]
+                child_base = f"{base}/{folder_name}" if base else folder_name
+                walk(child, child_base)
+
+        walk(node, "")
+        return folder_count, file_count, total_size, latest_modified, samples
+
+    def _show_folder_preview(self, folder_path: str) -> None:
+        node = self._get_folder_node(folder_path)
+        if node is None:
+            return
+
+        folder_count, file_count, total_size, latest_modified, samples = (
+            self._summarize_folder(node)
+        )
+        latest_text = (
+            format_timestamp(latest_modified.isoformat())
+            if latest_modified is not None
+            else "—"
+        )
+        sample_text = "\n".join(samples) if samples else "—"
+
+        header = node.name if folder_path else "Artifacts"
+        summary = (
+            f"{header}\n\n"
+            f"Files: {file_count}\n"
+            f"Folders: {folder_count}\n"
+            f"Total size: {format_size(total_size)}\n"
+            f"Last modified: {latest_text}\n\n"
+            f"Sample files:\n{sample_text}"
+        )
+
+        self._preview_area.show()
+        self._preview_label.setAlignment(Qt.AlignLeft | Qt.AlignTop)
+        self._preview_label.setText(summary)
+        self._preview_label.show()
+        self._thumbnail.hide()
+        self._text_preview.hide()
+        if self._preview_loader:
+            self._preview_loader.thumbnail_original = None
+        self._btn_open.setEnabled(False)
+        self._btn_edit.setEnabled(False)
+        self._btn_download.setEnabled(False)
+
     def _update_breadcrumb(self) -> None:
         parts = [p for p in self._current_folder_path.split("/") if p]
         segments: list[tuple[str, str]] = [("Artifacts", "")]
@@ -367,6 +452,11 @@ class ArtifactsTab(QWidget):
         self._update_artifact_list()
 
     def _on_item_clicked(self, item: QListWidgetItem) -> None:
+        data = item.data(Qt.UserRole)
+        if isinstance(data, FolderListItem):
+            self._show_folder_preview(data.path)
+
+    def _on_item_double_clicked(self, item: QListWidgetItem) -> None:
         data = item.data(Qt.UserRole)
         if isinstance(data, FolderListItem):
             self._current_folder_path = data.path
@@ -618,6 +708,9 @@ class ArtifactsTab(QWidget):
             self._btn_download.setEnabled(False)
 
         self._suppress_selection = False
+        current_row = self._artifact_list.currentRow()
+        if current_row >= 0:
+            self._on_selection_changed(current_row)
 
     def _on_selection_changed(self, current_row: int) -> None:
         if self._suppress_selection:
@@ -638,7 +731,10 @@ class ArtifactsTab(QWidget):
             return
 
         item_data = item.data(Qt.UserRole)
-        if isinstance(item_data, FolderListItem) or item_data is None:
+        if isinstance(item_data, FolderListItem):
+            self._show_folder_preview(item_data.path)
+            return
+        if item_data is None:
             self._preview_area.hide()
             self._btn_open.setEnabled(False)
             self._btn_edit.setEnabled(False)
@@ -653,6 +749,7 @@ class ArtifactsTab(QWidget):
         self._thumbnail.hide()
         self._text_preview.hide()
         self._preview_label.show()
+        self._preview_label.setAlignment(Qt.AlignCenter)
         if self._preview_loader:
             self._preview_loader.thumbnail_original = None
 

--- a/agents_runner/ui/widgets/__init__.py
+++ b/agents_runner/ui/widgets/__init__.py
@@ -3,6 +3,7 @@ from .animated_button import AnimatedPushButton, AnimatedToolButton
 from .animated_checkbox import AnimatedCheckBox
 from .arc_spinner import ArcSpinner
 from .artifact_highlighter import ArtifactSyntaxHighlighter, detect_language
+from .breadcrumbs import BreadcrumbBar
 from .chat_bubble import ChatBubbleAction
 from .chat_bubble import ChatBubbleData
 from .chat_bubble import ChatBubbleWidget
@@ -24,6 +25,7 @@ __all__ = [
     "AnimatedToolButton",
     "ArcSpinner",
     "ArtifactSyntaxHighlighter",
+    "BreadcrumbBar",
     "BouncingLoadingBar",
     "ChatBubbleAction",
     "ChatBubbleData",

--- a/agents_runner/ui/widgets/breadcrumbs.py
+++ b/agents_runner/ui/widgets/breadcrumbs.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QResizeEvent
+from PySide6.QtWidgets import QHBoxLayout, QLabel, QSizePolicy, QToolButton, QWidget
+
+from agents_runner.ui.lucide_icons import lucide_icon
+
+
+class BreadcrumbBar(QWidget):
+    back_clicked = Signal()
+    segment_clicked = Signal(str)
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+
+        self._back_btn = QToolButton()
+        self._back_btn.setIcon(lucide_icon("arrow-left"))
+        self._back_btn.setToolButtonStyle(Qt.ToolButtonIconOnly)
+        self._back_btn.setCursor(Qt.PointingHandCursor)
+        self._back_btn.setAutoRaise(True)
+        self._back_btn.setStyleSheet("border-radius: 0px;")
+        self._back_btn.clicked.connect(self.back_clicked.emit)
+
+        self._segments_wrap = QWidget(self)
+        self._segments_wrap.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
+        )
+        self._segments_layout = QHBoxLayout(self._segments_wrap)
+        self._segments_layout.setContentsMargins(0, 0, 0, 0)
+        self._segments_layout.setSpacing(2)
+
+        self._ellipsis = QLabel("...")
+        self._ellipsis.setStyleSheet("color: rgba(237, 239, 245, 160); font-size: 11px;")
+        self._ellipsis.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
+        self._ellipsis.hide()
+
+        self._segments_layout.addWidget(self._ellipsis)
+        self._segment_buttons: list[QToolButton] = []
+
+        layout.addWidget(self._back_btn, 0, Qt.AlignLeft)
+        layout.addWidget(self._segments_wrap, 1)
+
+    def set_segments(self, segments: list[tuple[str, str]]) -> None:
+        for button in self._segment_buttons:
+            self._segments_layout.removeWidget(button)
+            button.deleteLater()
+        self._segment_buttons.clear()
+
+        for index, (label, path) in enumerate(segments):
+            button = QToolButton()
+            button.setToolButtonStyle(Qt.ToolButtonTextOnly)
+            button.setAutoRaise(True)
+            button.setCursor(Qt.PointingHandCursor)
+            button.setStyleSheet(
+                "border-radius: 0px; color: rgba(237, 239, 245, 200); font-size: 11px; padding: 0px;"
+            )
+            text = label if index == 0 else f" / {label}"
+            button.setText(text)
+            button.clicked.connect(
+                lambda checked=False, segment_path=path: self.segment_clicked.emit(
+                    segment_path
+                )
+            )
+            self._segments_layout.addWidget(button)
+            self._segment_buttons.append(button)
+
+        self._update_visible_segments()
+
+    def set_back_enabled(self, enabled: bool) -> None:
+        self._back_btn.setEnabled(enabled)
+
+    def resizeEvent(self, event: QResizeEvent) -> None:
+        super().resizeEvent(event)
+        self._update_visible_segments()
+
+    def _update_visible_segments(self) -> None:
+        if not self._segment_buttons:
+            self._ellipsis.hide()
+            return
+
+        available = self._segments_wrap.width()
+        if available <= 0:
+            return
+
+        spacing = self._segments_layout.spacing()
+        widths = [button.sizeHint().width() for button in self._segment_buttons]
+        ellipsis_width = self._ellipsis.sizeHint().width()
+
+        start_index = 0
+        for idx in range(len(widths)):
+            count = len(widths) - idx
+            width = sum(widths[idx:])
+            if count > 1:
+                width += spacing * (count - 1)
+            if idx > 0:
+                width += ellipsis_width + spacing
+            if width <= available:
+                start_index = idx
+                break
+        else:
+            start_index = len(widths) - 1
+
+        show_ellipsis = start_index > 0
+        self._ellipsis.setVisible(show_ellipsis)
+
+        for idx, button in enumerate(self._segment_buttons):
+            button.setVisible(idx >= start_index)


### PR DESCRIPTION
## Summary
- collect and list staging artifacts recursively with path safety
- watch nested staging directories and refresh on changes
- add breadcrumb folder navigation for artifacts list
- fix initial preview selection and add folder preview + double-click open

## Issue
- Fixes #154

## Testing
- not run (not requested)

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
