### PR TITLE
Use PR head branch for PR pings

### DIFF
--- a/agents_runner/docker/agent_worker_github.py
+++ b/agents_runner/docker/agent_worker_github.py
@@ -38,6 +38,8 @@ class GitHubOperations:
                 config.host_workdir,
                 task_id=config.task_id,
                 base_branch=config.gh_base_branch or None,
+                pr_head_ref=config.gh_pr_head_ref or None,
+                pr_base_ref=config.gh_pr_base_ref or None,
                 prefer_gh=config.gh_prefer_gh_cli,
                 recreate_if_needed=config.gh_recreate_if_needed,
                 on_log=on_log,

--- a/agents_runner/docker/config.py
+++ b/agents_runner/docker/config.py
@@ -38,6 +38,8 @@ class DockerRunnerConfig:
     gh_prefer_gh_cli: bool = True
     gh_recreate_if_needed: bool = True
     gh_base_branch: str | None = None
+    gh_pr_head_ref: str | None = None
+    gh_pr_base_ref: str | None = None
     gh_context_file_path: str | None = None  # Host path to GitHub context file
     # Hard timeout for post-run artifact collection/finalization (best-effort).
     artifact_collection_timeout_s: float = 30.0

--- a/agents_runner/docker/preflight_worker.py
+++ b/agents_runner/docker/preflight_worker.py
@@ -122,6 +122,8 @@ class DockerPreflightWorker:
                         self._config.host_workdir,
                         task_id=self._config.task_id,
                         base_branch=self._config.gh_base_branch or None,
+                        pr_head_ref=self._config.gh_pr_head_ref or None,
+                        pr_base_ref=self._config.gh_pr_base_ref or None,
                         prefer_gh=self._config.gh_prefer_gh_cli,
                         recreate_if_needed=self._config.gh_recreate_if_needed,
                         on_log=self._on_log,

--- a/agents_runner/gh/work_items.py
+++ b/agents_runner/gh/work_items.py
@@ -34,6 +34,15 @@ class GitHubComment:
 
 
 @dataclass(frozen=True)
+class GitHubReview:
+    review_id: int
+    body: str
+    author: str
+    submitted_at: str
+    url: str
+
+
+@dataclass(frozen=True)
 class GitHubWorkItem:
     item_type: str
     number: int
@@ -318,6 +327,107 @@ def list_issue_comments(
     return comments
 
 
+def list_pull_request_review_comments(
+    repo_owner: str,
+    repo_name: str,
+    *,
+    pull_number: int,
+    limit: int = 100,
+) -> list[GitHubComment]:
+    repo = _repo_full_name(repo_owner, repo_name)
+    data = run_gh_gh_json(
+        [
+            "api",
+            (
+                f"repos/{repo}/pulls/{int(pull_number)}/comments?"
+                f"per_page={max(1, int(limit))}"
+            ),
+            "-H",
+            "Accept: application/vnd.github+json",
+        ],
+        timeout_s=45.0,
+    )
+
+    rows = _as_object_list(data) or []
+    comments: list[GitHubComment] = []
+    for row in rows:
+        row_dict = _as_object_dict(row)
+        if row_dict is None:
+            continue
+
+        comment_id = _safe_int(row_dict.get("id"))
+        if comment_id <= 0:
+            continue
+
+        user_dict = _as_object_dict(row_dict.get("user"))
+        author = _safe_text(user_dict.get("login") if user_dict is not None else "")
+
+        comments.append(
+            GitHubComment(
+                comment_id=comment_id,
+                node_id=_safe_text(row_dict.get("node_id")),
+                body=_safe_text(row_dict.get("body")),
+                author=author,
+                created_at=_safe_text(row_dict.get("created_at")),
+                updated_at=_safe_text(row_dict.get("updated_at")),
+                url=_safe_text(row_dict.get("html_url")),
+                reactions=_parse_reaction_summary(row_dict.get("reactions")),
+            )
+        )
+
+    return comments
+
+
+def list_pull_request_reviews(
+    repo_owner: str,
+    repo_name: str,
+    *,
+    pull_number: int,
+    limit: int = 100,
+) -> list[GitHubReview]:
+    repo = _repo_full_name(repo_owner, repo_name)
+    data = run_gh_gh_json(
+        [
+            "api",
+            (
+                f"repos/{repo}/pulls/{int(pull_number)}/reviews?"
+                f"per_page={max(1, int(limit))}"
+            ),
+            "-H",
+            "Accept: application/vnd.github+json",
+        ],
+        timeout_s=45.0,
+    )
+
+    rows = _as_object_list(data) or []
+    reviews: list[GitHubReview] = []
+    for row in rows:
+        row_dict = _as_object_dict(row)
+        if row_dict is None:
+            continue
+
+        review_id = _safe_int(row_dict.get("id"))
+        if review_id <= 0:
+            continue
+
+        user_dict = _as_object_dict(row_dict.get("user"))
+        author = _safe_text(user_dict.get("login") if user_dict is not None else "")
+
+        url = _safe_text(row_dict.get("html_url")) or _safe_text(row_dict.get("url"))
+
+        reviews.append(
+            GitHubReview(
+                review_id=review_id,
+                body=_safe_text(row_dict.get("body")),
+                author=author,
+                submitted_at=_safe_text(row_dict.get("submitted_at")),
+                url=url,
+            )
+        )
+
+    return reviews
+
+
 def get_pull_request_workroom(
     repo_owner: str,
     repo_name: str,
@@ -553,6 +663,33 @@ def add_issue_comment_reaction(
             "--method",
             "POST",
             f"repos/{repo}/issues/comments/{int(comment_id)}/reactions",
+            "-H",
+            "Accept: application/vnd.github+json",
+            "-f",
+            f"content={reaction_value}",
+        ],
+        timeout_s=30.0,
+    )
+
+
+def add_pull_request_review_comment_reaction(
+    repo_owner: str,
+    repo_name: str,
+    *,
+    comment_id: int,
+    reaction: str,
+) -> None:
+    repo = _repo_full_name(repo_owner, repo_name)
+    reaction_value = _safe_text(reaction)
+    if reaction_value not in {"+1", "-1", "eyes", "rocket", "hooray"}:
+        raise GhManagementError(f"unsupported reaction: {reaction_value}")
+
+    run_gh_gh_json(
+        [
+            "api",
+            "--method",
+            "POST",
+            f"repos/{repo}/pulls/comments/{int(comment_id)}/reactions",
             "-H",
             "Accept: application/vnd.github+json",
             "-f",

--- a/agents_runner/gh/work_items.py
+++ b/agents_runner/gh/work_items.py
@@ -54,6 +54,11 @@ class GitHubWorkItem:
     updated_at: str
     body: str = ""
     is_draft: bool = False
+    head_ref: str = ""
+    base_ref: str = ""
+    head_repo_owner: str = ""
+    head_repo_name: str = ""
+    is_cross_repo: bool = False
 
 
 @dataclass(frozen=True)
@@ -191,6 +196,43 @@ def _parse_work_item(item_type: str, raw: object) -> GitHubWorkItem | None:
     if raw_author is not None:
         author = _safe_text(raw_author.get("login"))
 
+    head_ref = ""
+    base_ref = ""
+    head_repo_owner = ""
+    head_repo_name = ""
+    is_cross_repo = False
+    if item_type == "pr":
+        head_ref = _safe_text(raw_dict.get("headRefName"))
+        base_ref = _safe_text(raw_dict.get("baseRefName"))
+        is_cross_repo = bool(raw_dict.get("isCrossRepository") or False)
+
+        head_repo_owner_data = raw_dict.get("headRepositoryOwner")
+        if isinstance(head_repo_owner_data, str):
+            head_repo_owner = _safe_text(head_repo_owner_data)
+        else:
+            owner_dict = _as_object_dict(head_repo_owner_data)
+            if owner_dict is not None:
+                head_repo_owner = _safe_text(owner_dict.get("login"))
+
+        head_repo_data = raw_dict.get("headRepository")
+        if isinstance(head_repo_data, str):
+            head_repo_text = _safe_text(head_repo_data)
+            if "/" in head_repo_text:
+                owner_part, name_part = head_repo_text.split("/", 1)
+                if not head_repo_owner:
+                    head_repo_owner = _safe_text(owner_part)
+                head_repo_name = _safe_text(name_part)
+            else:
+                head_repo_name = head_repo_text
+        else:
+            repo_dict = _as_object_dict(head_repo_data)
+            if repo_dict is not None:
+                head_repo_name = _safe_text(repo_dict.get("name"))
+                if not head_repo_owner:
+                    repo_owner = _as_object_dict(repo_dict.get("owner"))
+                    if repo_owner is not None:
+                        head_repo_owner = _safe_text(repo_owner.get("login"))
+
     return GitHubWorkItem(
         item_type=item_type,
         number=number,
@@ -202,6 +244,11 @@ def _parse_work_item(item_type: str, raw: object) -> GitHubWorkItem | None:
         created_at=_safe_text(raw_dict.get("createdAt")),
         updated_at=_safe_text(raw_dict.get("updatedAt")),
         is_draft=bool(raw_dict.get("isDraft") or False),
+        head_ref=head_ref,
+        base_ref=base_ref,
+        head_repo_owner=head_repo_owner,
+        head_repo_name=head_repo_name,
+        is_cross_repo=is_cross_repo,
     )
 
 
@@ -231,7 +278,10 @@ def list_open_pull_requests(
             "--limit",
             str(max(1, int(limit))),
             "--json",
-            "number,title,body,state,url,author,createdAt,updatedAt,isDraft",
+            (
+                "number,title,body,state,url,author,createdAt,updatedAt,isDraft,"
+                "headRefName,baseRefName,isCrossRepository,headRepository,headRepositoryOwner"
+            ),
         ],
         timeout_s=45.0,
     )

--- a/agents_runner/gh_management.py
+++ b/agents_runner/gh_management.py
@@ -22,6 +22,8 @@ from agents_runner.gh.task_plan import (
     plan_repo_task,
     prepare_branch_for_task,
 )
+from agents_runner.gh.process import require_ok
+from agents_runner.gh.process import run_gh
 from agents_runner.log_format import format_log
 
 __all__ = [
@@ -69,6 +71,8 @@ def prepare_github_repo_for_task(
     *,
     task_id: str,
     base_branch: str | None = None,
+    pr_head_ref: str | None = None,
+    pr_base_ref: str | None = None,
     prefer_gh: bool = True,
     recreate_if_needed: bool = True,
     on_log: Callable[[str], None] | None = None,
@@ -168,6 +172,95 @@ def prepare_github_repo_for_task(
                     )
                 )
                 return result
+
+            pr_head = str(pr_head_ref or "").strip()
+            pr_base = str(pr_base_ref or "").strip()
+            if pr_head:
+                repo_root = git_repo_root(dest_dir) or dest_dir
+                current_branch = git_current_branch(repo_root)
+                if current_branch and current_branch == pr_head:
+                    return {
+                        "repo_root": repo_root,
+                        "base_branch": pr_base or str(base_branch or ""),
+                        "branch": pr_head,
+                    }
+                if not git_is_clean(repo_root):
+                    _log(
+                        format_log(
+                            "gh",
+                            "branch",
+                            "WARN",
+                            "repo has uncommitted changes; skipping PR branch checkout",
+                        )
+                    )
+                    return {
+                        "repo_root": repo_root,
+                        "base_branch": pr_base or str(base_branch or ""),
+                        "branch": current_branch or "",
+                    }
+                try:
+                    _log(
+                        format_log(
+                            "gh",
+                            "branch",
+                            "INFO",
+                            f"fetching PR head branch {pr_head}",
+                        )
+                    )
+                    fetch_proc = run_gh(
+                        ["git", "-C", repo_root, "fetch", "origin", pr_head],
+                        timeout_s=30.0,
+                    )
+                    require_ok(
+                        fetch_proc,
+                        args=["git", "-C", repo_root, "fetch", "origin", pr_head],
+                    )
+                    checkout_proc = run_gh(
+                        [
+                            "git",
+                            "-C",
+                            repo_root,
+                            "checkout",
+                            "-B",
+                            pr_head,
+                            f"origin/{pr_head}",
+                        ],
+                        timeout_s=30.0,
+                    )
+                    require_ok(
+                        checkout_proc,
+                        args=[
+                            "git",
+                            "-C",
+                            repo_root,
+                            "checkout",
+                            "-B",
+                            pr_head,
+                            f"origin/{pr_head}",
+                        ],
+                    )
+                    _log(
+                        format_log(
+                            "gh",
+                            "branch",
+                            "INFO",
+                            f"checked out PR head branch {pr_head}",
+                        )
+                    )
+                    return {
+                        "repo_root": repo_root,
+                        "base_branch": pr_base or str(base_branch or ""),
+                        "branch": pr_head,
+                    }
+                except Exception as exc:
+                    _log(
+                        format_log(
+                            "gh",
+                            "branch",
+                            "WARN",
+                            f"failed to checkout PR head branch {pr_head}: {exc}",
+                        )
+                    )
 
             plan = plan_repo_task(
                 dest_dir,

--- a/agents_runner/prompts/github_prompting.py
+++ b/agents_runner/prompts/github_prompting.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import re
+
+
+_AGENTS_NOVA_MENTION_RE = re.compile(r"(?i)@agentsnova\b")
+
+
+def has_agentsnova_mention(text: str) -> bool:
+    return bool(_AGENTS_NOVA_MENTION_RE.search(str(text or "")))
+
+
+def strip_agentsnova_mention(text: str) -> str:
+    cleaned = _AGENTS_NOVA_MENTION_RE.sub("", str(text or ""))
+    cleaned = re.sub(r"[ \t]+", " ", cleaned)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return cleaned.strip()
+
+
+def escape_prompt_braces(text: str) -> str:
+    return str(text or "").replace("{", "{{").replace("}", "}}")
+
+
+def build_default_request_line(
+    *,
+    item_type: str,
+    repo_owner: str,
+    repo_name: str,
+    number: int,
+) -> str:
+    normalized = str(item_type or "").strip().lower()
+    if normalized == "pr":
+        return (
+            "Review GitHub pull request "
+            f"#{int(number)} for repository {repo_owner}/{repo_name}."
+        )
+    return (
+        "Fix GitHub issue "
+        f"#{int(number)} for repository {repo_owner}/{repo_name}."
+    )
+
+
+def build_primary_request(*, mention_text: str, fallback: str) -> str:
+    cleaned = strip_agentsnova_mention(mention_text)
+    if cleaned:
+        return f"User request (from GitHub):\n{escape_prompt_braces(cleaned)}"
+    return escape_prompt_braces(fallback)

--- a/agents_runner/prompts/issue_fix_template.md
+++ b/agents_runner/prompts/issue_fix_template.md
@@ -3,12 +3,10 @@
 Build a task prompt for fixing a GitHub issue from the Tasks -> Issues workflow.
 
 ## Prompt
-Fix GitHub issue #{ISSUE_NUMBER} for repository {REPO_OWNER}/{REPO_NAME}.
-
 Issue URL: {ISSUE_URL}
 Issue title: {ISSUE_TITLE}
 
-Suggested workflow:
+Helpful info:
 1. Read the full issue details (description, linked context, and comments) and restate the problem in your own words.
 2. Prefer using `gh` to review and manage issue context (details, discussion, and relevant updates), unless this repository explicitly asks for a different method.
 3. Reproduce the issue or, if reproduction is not possible, explain exactly why and identify the most likely failure path from code inspection.
@@ -17,3 +15,6 @@ Suggested workflow:
 6. Verify behavior with the most relevant checks for the changed area and report concrete results.
 7. Follow this repository's instructions (especially AGENTS.md and related docs) for workflow, formatting, and communication.
 8. At the end, update GitHub so the user is informed: post the appropriate issue / PR / comment update with status, what changed, and current outcome.
+
+-----
+{PRIMARY_REQUEST}

--- a/agents_runner/prompts/pr_review_template.md
+++ b/agents_runner/prompts/pr_review_template.md
@@ -3,12 +3,10 @@
 Build a task prompt for reviewing a GitHub pull request from the Tasks -> Pull Requests workflow.
 
 ## Prompt
-Review GitHub pull request #{PR_NUMBER} for repository {REPO_OWNER}/{REPO_NAME}.
-
 PR title: {PR_TITLE}
 PR URL: {PR_URL}
 
-Suggested workflow:
+Helpful info:
 1. Read and follow this repository's standards first, especially AGENTS.md and any repo-specific contribution/review instructions.
 2. Prefer using `gh` to review and manage PR context (PR details, changed files, commits, and discussion), unless this repository explicitly asks for a different method.
 3. Review the pull request against repository standards and expected behavior.
@@ -16,3 +14,6 @@ Suggested workflow:
 5. Produce your review in the repository's expected format.
 6. If standards are missing or unclear, choose a clear review format and proceed.
 7. At the end, update GitHub so the user is informed: post the appropriate issue / PR / comment update with review outcome, key findings, and current status.
+
+-----
+{PRIMARY_REQUEST}

--- a/agents_runner/ui/dialogs/github_workroom_dialog.py
+++ b/agents_runner/ui/dialogs/github_workroom_dialog.py
@@ -28,6 +28,8 @@ from agents_runner.gh.work_items import get_pull_request_workroom
 from agents_runner.gh.work_items import post_comment
 from agents_runner.gh.work_items import set_item_open_state
 from agents_runner.prompts import load_prompt
+from agents_runner.prompts.github_prompting import build_default_request_line
+from agents_runner.prompts.github_prompting import build_primary_request
 from agents_runner.stt.mic_recorder import FfmpegPulseRecorder
 from agents_runner.stt.mic_recorder import MicRecorderError
 from agents_runner.stt.mic_recorder import MicRecording
@@ -631,6 +633,17 @@ class GitHubWorkroomDialog(ThemedDialog):
         if room is None:
             return ""
 
+        default_request = build_default_request_line(
+            item_type=room.item_type,
+            repo_owner=room.repo_owner,
+            repo_name=room.repo_name,
+            number=room.number,
+        )
+        primary_request = build_primary_request(
+            mention_text="",
+            fallback=default_request,
+        )
+
         if room.item_type == "pr":
             return load_prompt(
                 "pr_review_template",
@@ -639,8 +652,7 @@ class GitHubWorkroomDialog(ThemedDialog):
                 PR_NUMBER=room.number,
                 PR_URL=room.url,
                 PR_TITLE=room.title,
-                MENTION_COMMENT_ID="",
-                TRIGGER_SOURCE="manual",
+                PRIMARY_REQUEST=primary_request,
             )
 
         return load_prompt(
@@ -650,8 +662,7 @@ class GitHubWorkroomDialog(ThemedDialog):
             ISSUE_NUMBER=room.number,
             ISSUE_URL=room.url,
             ISSUE_TITLE=room.title,
-            MENTION_COMMENT_ID="",
-            TRIGGER_SOURCE="manual",
+            PRIMARY_REQUEST=primary_request,
         )
 
     def _on_primary(self) -> None:

--- a/agents_runner/ui/main_window_auto_review.py
+++ b/agents_runner/ui/main_window_auto_review.py
@@ -24,18 +24,60 @@ class MainWindowAutoReviewMixin:
         if not selected_env_id:
             return
 
-        resolved_base_branch = self._resolve_auto_review_base_branch(
-            env_id=selected_env_id
+        item_type = str(payload_dict.get("item_type") or "").strip().lower()
+        is_pr = item_type == "pr"
+        repo_owner = str(payload_dict.get("repo_owner") or "").strip()
+        repo_name = str(payload_dict.get("repo_name") or "").strip()
+        pr_head_ref = str(payload_dict.get("pr_head_ref") or "").strip()
+        pr_base_ref = str(payload_dict.get("pr_base_ref") or "").strip()
+        pr_head_repo_owner = str(payload_dict.get("pr_head_repo_owner") or "").strip()
+        pr_head_repo_name = str(payload_dict.get("pr_head_repo_name") or "").strip()
+        pr_is_cross_repo = bool(payload_dict.get("pr_is_cross_repo") or False)
+
+        same_repo = True
+        if pr_head_repo_owner and pr_head_repo_name:
+            same_repo = (
+                pr_head_repo_owner.strip().lower() == repo_owner.strip().lower()
+                and pr_head_repo_name.strip().lower() == repo_name.strip().lower()
+            )
+        is_cross_repo = pr_is_cross_repo or (
+            pr_head_repo_owner and pr_head_repo_name and not same_repo
         )
-        if resolved_base_branch is None:
-            return
+
+        resolved_base_branch = ""
+        if is_pr and pr_base_ref:
+            resolved_base_branch = pr_base_ref
+        else:
+            resolved_base_branch = self._resolve_auto_review_base_branch(
+                env_id=selected_env_id
+            )
+            if resolved_base_branch is None:
+                return
 
         host_codex = str(self._settings_data.get("host_codex_dir") or "").strip()
+        pr_context: dict[str, object] | None = None
+        if is_pr:
+            pr_context = {
+                "repo_owner": repo_owner,
+                "repo_name": repo_name,
+                "pr_head_ref": pr_head_ref,
+                "pr_base_ref": pr_base_ref,
+                "pr_head_repo_owner": pr_head_repo_owner,
+                "pr_head_repo_name": pr_head_repo_name,
+                "pr_is_cross_repo": is_cross_repo,
+            }
         task_id = self._start_task_from_ui(
-            prompt, host_codex, selected_env_id, resolved_base_branch
+            prompt,
+            host_codex,
+            selected_env_id,
+            resolved_base_branch,
+            pr_context,
         )
         if not task_id:
             return
+
+        if is_pr and is_cross_repo:
+            self._post_fork_notice_comment(payload=payload_dict)
 
         if not bool(
             self._settings_data.get("agentsnova_auto_marker_comments_enabled", True)
@@ -43,6 +85,49 @@ class MainWindowAutoReviewMixin:
             return
 
         self._post_auto_review_marker_comment(payload=payload_dict, task_id=task_id)
+
+    def _post_fork_notice_comment(self, *, payload: dict[str, object]) -> None:
+        repo_owner = str(payload.get("repo_owner") or "").strip()
+        repo_name = str(payload.get("repo_name") or "").strip()
+        try:
+            number = int(payload.get("number") or 0)
+        except Exception:
+            number = 0
+        pr_head_ref = str(payload.get("pr_head_ref") or "").strip()
+        pr_head_repo_owner = str(payload.get("pr_head_repo_owner") or "").strip()
+        pr_head_repo_name = str(payload.get("pr_head_repo_name") or "").strip()
+        if not repo_owner or not repo_name or number <= 0:
+            return
+
+        if not hasattr(self, "_fork_notice_seen"):
+            self._fork_notice_seen = set()
+        notice_key = (
+            f"{repo_owner.lower()}/{repo_name.lower()}#{number}:"
+            f"{pr_head_repo_owner.lower()}/{pr_head_repo_name.lower()}:{pr_head_ref}"
+        )
+        if notice_key in self._fork_notice_seen:
+            return
+        self._fork_notice_seen.add(notice_key)
+
+        body = (
+            "Fork PR detected. Agents Runner cannot auto-checkout fork branches; "
+            "continuing on the base branch."
+        )
+        try:
+            post_comment(
+                repo_owner,
+                repo_name,
+                item_type="pr",
+                number=number,
+                body=body,
+            )
+        except Exception as exc:
+            logger.warning(
+                (
+                    "[github-auto-review] failed to post fork notice comment for "
+                    f"{repo_owner}/{repo_name} PR #{number}: {exc}"
+                )
+            )
 
     def _post_auto_review_marker_comment(
         self, *, payload: dict[str, object], task_id: str

--- a/agents_runner/ui/main_window_tasks_agent.py
+++ b/agents_runner/ui/main_window_tasks_agent.py
@@ -104,6 +104,7 @@ class MainWindowTasksAgentMixin:
         host_codex: str,
         env_id: str,
         base_branch: str,
+        pr_context: dict[str, object] | None = None,
     ) -> str | None:
         if shutil.which("docker") is None:
             QMessageBox.critical(
@@ -457,6 +458,41 @@ class MainWindowTasksAgentMixin:
         task.gh_use_host_cli = use_host_gh
 
         desired_base = str(base_branch or "").strip()
+        pr_head_ref = ""
+        pr_base_ref = ""
+        pr_head_repo_owner = ""
+        pr_head_repo_name = ""
+        pr_is_cross_repo = False
+        pr_repo_owner = ""
+        pr_repo_name = ""
+        if pr_context:
+            pr_head_ref = str(pr_context.get("pr_head_ref") or "").strip()
+            pr_base_ref = str(pr_context.get("pr_base_ref") or "").strip()
+            pr_head_repo_owner = str(
+                pr_context.get("pr_head_repo_owner") or ""
+            ).strip()
+            pr_head_repo_name = str(pr_context.get("pr_head_repo_name") or "").strip()
+            pr_is_cross_repo = bool(pr_context.get("pr_is_cross_repo") or False)
+            pr_repo_owner = str(pr_context.get("repo_owner") or "").strip()
+            pr_repo_name = str(pr_context.get("repo_name") or "").strip()
+        if pr_base_ref and not desired_base:
+            desired_base = pr_base_ref
+        if pr_head_ref:
+            same_repo = True
+            if (
+                pr_head_repo_owner
+                and pr_head_repo_name
+                and pr_repo_owner
+                and pr_repo_name
+            ):
+                same_repo = (
+                    pr_head_repo_owner.lower() == pr_repo_owner.lower()
+                    and pr_head_repo_name.lower() == pr_repo_name.lower()
+                )
+            if pr_is_cross_repo or (
+                pr_head_repo_owner and pr_head_repo_name and not same_repo
+            ):
+                pr_head_ref = ""
 
         # Save the selected branch for cloned environments
         if env and env.workspace_type == WORKSPACE_CLONED and desired_base:
@@ -657,14 +693,18 @@ class MainWindowTasksAgentMixin:
                         task_branch = "(already created by runner)"
                         head_commit = "(set after clone)"
 
+                    context_prompt = github_context_prompt_instructions(
+                        repo_url=repo_url,
+                        repo_owner=repo_owner,
+                        repo_name=repo_name,
+                        base_branch=base_branch,
+                        task_branch=task_branch,
+                        head_commit=head_commit,
+                    )
+                    pr_prompt = pr_metadata_prompt_instructions(pr_container_path)
                     runner_prompt = insert_prompt_sections_before_user_prompt(
                         runner_prompt,
-                        [
-                            (
-                                f"{github_context_prompt_instructions(repo_url=repo_url, repo_owner=repo_owner, repo_name=repo_name, base_branch=base_branch, task_branch=task_branch, head_commit=head_commit)}"
-                                f"{pr_metadata_prompt_instructions(pr_container_path)}"
-                            )
-                        ],
+                        [f"{context_prompt}{pr_prompt}"],
                     )
                     # Clarify two-phase process for cloned repo environments
                     if workspace_type == WORKSPACE_CLONED:
@@ -728,6 +768,8 @@ class MainWindowTasksAgentMixin:
             gh_prefer_gh_cli=use_host_gh,
             gh_recreate_if_needed=True,
             gh_base_branch=desired_base or None,
+            gh_pr_head_ref=pr_head_ref or None,
+            gh_pr_base_ref=pr_base_ref or None,
             gh_context_file_path=gh_context_file,
         )
         task._runner_config = config

--- a/agents_runner/ui/pages/github_work_coordinator.py
+++ b/agents_runner/ui/pages/github_work_coordinator.py
@@ -493,6 +493,11 @@ class GitHubWorkCoordinator(QObject):
             mention_url = str(review.get("mention_url") or "")
             mention_author = str(review.get("mention_author") or "")
             mention_created_at = str(review.get("mention_created_at") or "")
+            pr_head_ref = str(review.get("pr_head_ref") or "")
+            pr_base_ref = str(review.get("pr_base_ref") or "")
+            pr_head_repo_owner = str(review.get("pr_head_repo_owner") or "")
+            pr_head_repo_name = str(review.get("pr_head_repo_name") or "")
+            pr_is_cross_repo = bool(review.get("pr_is_cross_repo") or False)
 
             prompt = self._build_task_prompt(
                 item_type=item_type,
@@ -518,6 +523,11 @@ class GitHubWorkCoordinator(QObject):
                 "mention_author": mention_author,
                 "mention_created_at": mention_created_at,
                 "mention_key": mention_key,
+                "pr_head_ref": pr_head_ref,
+                "pr_base_ref": pr_base_ref,
+                "pr_head_repo_owner": pr_head_repo_owner,
+                "pr_head_repo_name": pr_head_repo_name,
+                "pr_is_cross_repo": pr_is_cross_repo,
             }
             self.auto_review_requested.emit(env_id, payload)
 
@@ -546,6 +556,11 @@ class GitHubWorkCoordinator(QObject):
 
         results: list[dict[str, object]] = []
         for item in items:
+            pr_head_ref = str(getattr(item, "head_ref", "") or "")
+            pr_base_ref = str(getattr(item, "base_ref", "") or "")
+            pr_head_repo_owner = str(getattr(item, "head_repo_owner", "") or "")
+            pr_head_repo_name = str(getattr(item, "head_repo_name", "") or "")
+            pr_is_cross_repo = bool(getattr(item, "is_cross_repo", False))
             item_key = self._mention_item_key(
                 repo_owner=repo_owner,
                 repo_name=repo_name,
@@ -759,6 +774,11 @@ class GitHubWorkCoordinator(QObject):
                         "number": item.number,
                         "url": item.url,
                         "title": item.title,
+                        "pr_head_ref": pr_head_ref,
+                        "pr_base_ref": pr_base_ref,
+                        "pr_head_repo_owner": pr_head_repo_owner,
+                        "pr_head_repo_name": pr_head_repo_name,
+                        "pr_is_cross_repo": pr_is_cross_repo,
                         "mention_key": mention_key,
                         "trigger_source": source,
                         "mention_text": candidate.get("mention_text", ""),

--- a/agents_runner/ui/pages/github_work_coordinator.py
+++ b/agents_runner/ui/pages/github_work_coordinator.py
@@ -20,10 +20,16 @@ from agents_runner.gh.work_items import GitHubComment
 from agents_runner.gh.work_items import GitHubWorkItem
 from agents_runner.gh.work_items import add_issue_comment_reaction
 from agents_runner.gh.work_items import add_issue_reaction
+from agents_runner.gh.work_items import add_pull_request_review_comment_reaction
 from agents_runner.gh.work_items import list_issue_comments
 from agents_runner.gh.work_items import list_open_issues
 from agents_runner.gh.work_items import list_open_pull_requests
+from agents_runner.gh.work_items import list_pull_request_review_comments
+from agents_runner.gh.work_items import list_pull_request_reviews
 from agents_runner.prompts import load_prompt
+from agents_runner.prompts.github_prompting import build_default_request_line
+from agents_runner.prompts.github_prompting import build_primary_request
+from agents_runner.prompts.github_prompting import has_agentsnova_mention
 from agents_runner.ui.pages.github_trust import effective_trusted_users
 from midori_ai_logger import MidoriAiLogger
 
@@ -59,8 +65,7 @@ class GitHubWorkCoordinator(QObject):
         self._cache: dict[tuple[str, str], GitHubWorkCacheEntry] = {}
         self._inflight_keys: set[tuple[str, str]] = set()
 
-        self._auto_review_seen_comment_ids: set[int] = set()
-        self._auto_review_seen_item_mentions: set[str] = set()
+        self._auto_review_seen_mentions: set[str] = set()
         self._auto_review_emit_keys: set[str] = set()
 
         self._state_lock = threading.Lock()
@@ -457,10 +462,9 @@ class GitHubWorkCoordinator(QObject):
                 continue
 
             trigger_source = str(review.get("trigger_source") or "").strip().lower()
-            try:
-                mention_comment_id = int(review.get("mention_comment_id") or 0)
-            except Exception:
-                mention_comment_id = 0
+            mention_key = str(review.get("mention_key") or "").strip()
+            if not mention_key:
+                continue
 
             item_key = str(review.get("item_key") or "").strip()
             if not item_key:
@@ -473,26 +477,22 @@ class GitHubWorkCoordinator(QObject):
 
             emit_key = (
                 f"{repo_owner.strip().lower()}/{repo_name.strip().lower()}:"
-                f"{item_type}:{number}:{trigger_source}:{max(0, mention_comment_id)}"
+                f"{item_type}:{number}:{trigger_source}:{mention_key}"
             )
 
             with self._state_lock:
-                if mention_comment_id > 0 and (
-                    mention_comment_id in self._auto_review_seen_comment_ids
-                ):
-                    continue
-                if trigger_source == "body_mention" and (
-                    item_key in self._auto_review_seen_item_mentions
-                ):
+                if mention_key in self._auto_review_seen_mentions:
                     continue
                 if emit_key in self._auto_review_emit_keys:
                     continue
 
-                if mention_comment_id > 0:
-                    self._auto_review_seen_comment_ids.add(mention_comment_id)
-                if trigger_source == "body_mention":
-                    self._auto_review_seen_item_mentions.add(item_key)
+                self._auto_review_seen_mentions.add(mention_key)
                 self._auto_review_emit_keys.add(emit_key)
+
+            mention_text = str(review.get("mention_text") or "")
+            mention_url = str(review.get("mention_url") or "")
+            mention_author = str(review.get("mention_author") or "")
+            mention_created_at = str(review.get("mention_created_at") or "")
 
             prompt = self._build_task_prompt(
                 item_type=item_type,
@@ -501,8 +501,7 @@ class GitHubWorkCoordinator(QObject):
                 number=number,
                 url=str(review.get("url") or "").strip(),
                 title=str(review.get("title") or "").strip(),
-                trigger_source=trigger_source,
-                mention_comment_id=mention_comment_id,
+                mention_text=mention_text,
             )
             if not prompt:
                 continue
@@ -513,7 +512,12 @@ class GitHubWorkCoordinator(QObject):
                 "item_type": item_type,
                 "number": number,
                 "trigger_source": trigger_source,
-                "mention_comment_id": mention_comment_id,
+                "mention_source": trigger_source,
+                "mention_text": mention_text,
+                "mention_url": mention_url,
+                "mention_author": mention_author,
+                "mention_created_at": mention_created_at,
+                "mention_key": mention_key,
             }
             self.auto_review_requested.emit(env_id, payload)
 
@@ -538,8 +542,7 @@ class GitHubWorkCoordinator(QObject):
         )
 
         with self._state_lock:
-            queued_snapshot = set(self._auto_review_seen_comment_ids)
-            queued_item_snapshot = set(self._auto_review_seen_item_mentions)
+            queued_snapshot = set(self._auto_review_seen_mentions)
 
         results: list[dict[str, object]] = []
         for item in items:
@@ -549,7 +552,6 @@ class GitHubWorkCoordinator(QObject):
                 item_type=item.item_type,
                 number=item.number,
             )
-            queued_for_item = False
             comments = list_issue_comments(
                 repo_owner,
                 repo_name,
@@ -560,41 +562,196 @@ class GitHubWorkCoordinator(QObject):
                 marker_created_at_s,
                 marker_comment_id,
             ) = self._latest_marker_checkpoint(comments)
-            ordered_comments = sorted(
-                comments,
-                key=lambda comment: (
-                    self._parse_iso_timestamp_s(comment.created_at) or 0.0,
-                    max(0, int(getattr(comment, "comment_id", 0) or 0)),
+            candidates: list[dict[str, object]] = []
+
+            def _add_comment_candidate(
+                comment: GitHubComment,
+                *,
+                source: str,
+                allow_id_compare: bool,
+            ) -> None:
+                if not self._is_trusted_comment_author(comment, trusted_users):
+                    return
+                if not has_agentsnova_mention(comment.body):
+                    return
+                mention_created_at = str(comment.created_at or "")
+                mention_created_at_s = self._parse_iso_timestamp_s(mention_created_at)
+                mention_comment_id = comment.comment_id if allow_id_compare else 0
+                if not self._is_mention_newer_than_marker(
+                    mention_created_at_s=mention_created_at_s,
+                    mention_comment_id=mention_comment_id,
+                    marker_created_at_s=marker_created_at_s,
+                    marker_comment_id=marker_comment_id,
+                ):
+                    return
+                mention_key = f"{source}:{comment.comment_id}"
+                candidates.append(
+                    {
+                        "source": source,
+                        "mention_key": mention_key,
+                        "mention_text": str(comment.body or ""),
+                        "mention_author": str(comment.author or ""),
+                        "mention_created_at": mention_created_at,
+                        "mention_url": str(comment.url or ""),
+                        "created_at_s": mention_created_at_s or 0.0,
+                        "sort_id": comment.comment_id,
+                        "comment": comment,
+                    }
+                )
+
+            for comment in comments:
+                _add_comment_candidate(
+                    comment,
+                    source="issue_comment",
+                    allow_id_compare=True,
+                )
+
+            if item.item_type == "pr":
+                review_comments = list_pull_request_review_comments(
+                    repo_owner,
+                    repo_name,
+                    pull_number=item.number,
+                    limit=100,
+                )
+                for comment in review_comments:
+                    _add_comment_candidate(
+                        comment,
+                        source="review_comment",
+                        allow_id_compare=False,
+                    )
+
+                review_bodies = list_pull_request_reviews(
+                    repo_owner,
+                    repo_name,
+                    pull_number=item.number,
+                    limit=100,
+                )
+                for review in review_bodies:
+                    author = str(review.author or "").strip().lower()
+                    if not author or author not in trusted_users:
+                        continue
+                    if not has_agentsnova_mention(review.body):
+                        continue
+                    mention_created_at = str(review.submitted_at or "")
+                    mention_created_at_s = self._parse_iso_timestamp_s(
+                        mention_created_at
+                    )
+                    if not self._is_mention_newer_than_marker(
+                        mention_created_at_s=mention_created_at_s,
+                        mention_comment_id=0,
+                        marker_created_at_s=marker_created_at_s,
+                        marker_comment_id=marker_comment_id,
+                    ):
+                        continue
+                    mention_key = f"review_body:{review.review_id}"
+                    candidates.append(
+                        {
+                            "source": "review_body",
+                            "mention_key": mention_key,
+                            "mention_text": str(review.body or ""),
+                            "mention_author": str(review.author or ""),
+                            "mention_created_at": mention_created_at,
+                            "mention_url": str(review.url or ""),
+                            "created_at_s": mention_created_at_s or 0.0,
+                            "sort_id": review.review_id,
+                        }
+                    )
+
+            body_text = str(getattr(item, "body", "") or "")
+            title_text = str(getattr(item, "title", "") or "")
+            body_has_mention = has_agentsnova_mention(body_text)
+            title_has_mention = has_agentsnova_mention(title_text)
+            if body_has_mention or title_has_mention:
+                if self._is_trusted_item_author(item=item, trusted_users=trusted_users):
+                    mention_text = body_text if body_has_mention else title_text
+                    updated_at = str(getattr(item, "updated_at", "") or "")
+                    created_at = str(getattr(item, "created_at", "") or "")
+                    mention_created_at = updated_at or created_at
+                    mention_created_at_s = self._parse_iso_timestamp_s(
+                        mention_created_at
+                    )
+                    if self._is_mention_newer_than_marker(
+                        mention_created_at_s=mention_created_at_s,
+                        mention_comment_id=0,
+                        marker_created_at_s=marker_created_at_s,
+                        marker_comment_id=marker_comment_id,
+                    ):
+                        source = "pr_body" if item.item_type == "pr" else "issue_body"
+                        mention_key = f"{source}:{item_key}"
+                        mention_author = str(getattr(item, "author", "") or "")
+                        candidates.append(
+                            {
+                                "source": source,
+                                "mention_key": mention_key,
+                                "mention_text": str(mention_text or ""),
+                                "mention_author": mention_author,
+                                "mention_created_at": mention_created_at,
+                                "mention_url": str(item.url or ""),
+                                "created_at_s": mention_created_at_s or 0.0,
+                                "sort_id": item.number,
+                            }
+                        )
+
+            if not candidates:
+                continue
+
+            ordered_candidates = sorted(
+                candidates,
+                key=lambda candidate: (
+                    float(candidate.get("created_at_s", 0.0) or 0.0),
+                    int(candidate.get("sort_id", 0) or 0),
                 ),
                 reverse=True,
             )
 
-            for comment in ordered_comments:
-                if not self._is_trusted_comment_author(comment, trusted_users):
+            for candidate in ordered_candidates:
+                mention_key = str(candidate.get("mention_key") or "").strip()
+                if not mention_key:
                     continue
-                body = str(comment.body or "").lower()
-                if "@agentsnova" not in body:
+                if mention_key in queued_snapshot:
                     continue
-                mention_created_at_s = self._parse_iso_timestamp_s(comment.created_at)
-                if not self._is_mention_newer_than_marker(
-                    mention_created_at_s=mention_created_at_s,
-                    mention_comment_id=comment.comment_id,
-                    marker_created_at_s=marker_created_at_s,
-                    marker_comment_id=marker_comment_id,
-                ):
-                    continue
-                if comment.comment_id in queued_snapshot:
-                    continue
-                if auto_reactions_enabled and self._can_apply_reaction(comment=comment):
-                    try:
-                        add_issue_comment_reaction(
-                            repo_owner,
-                            repo_name,
-                            comment_id=comment.comment_id,
-                            reaction="eyes",
-                        )
-                    except Exception:
-                        pass
+
+                source = str(candidate.get("source") or "").strip().lower()
+                comment = candidate.get("comment")
+                if auto_reactions_enabled:
+                    if (
+                        source == "issue_comment"
+                        and isinstance(comment, GitHubComment)
+                        and self._can_apply_reaction(comment=comment)
+                    ):
+                        try:
+                            add_issue_comment_reaction(
+                                repo_owner,
+                                repo_name,
+                                comment_id=comment.comment_id,
+                                reaction="eyes",
+                            )
+                        except Exception:
+                            pass
+                    if (
+                        source == "review_comment"
+                        and isinstance(comment, GitHubComment)
+                        and self._can_apply_reaction(comment=comment)
+                    ):
+                        try:
+                            add_pull_request_review_comment_reaction(
+                                repo_owner,
+                                repo_name,
+                                comment_id=comment.comment_id,
+                                reaction="eyes",
+                            )
+                        except Exception:
+                            pass
+                    if source in {"pr_body", "issue_body"}:
+                        try:
+                            add_issue_reaction(
+                                repo_owner,
+                                repo_name,
+                                issue_number=item.number,
+                                reaction="eyes",
+                            )
+                        except Exception:
+                            pass
 
                 results.append(
                     {
@@ -602,52 +759,19 @@ class GitHubWorkCoordinator(QObject):
                         "number": item.number,
                         "url": item.url,
                         "title": item.title,
-                        "mention_comment_id": comment.comment_id,
-                        "trigger_source": "comment_mention",
+                        "mention_key": mention_key,
+                        "trigger_source": source,
+                        "mention_text": candidate.get("mention_text", ""),
+                        "mention_author": candidate.get("mention_author", ""),
+                        "mention_created_at": candidate.get("mention_created_at", ""),
+                        "mention_url": candidate.get("mention_url", ""),
                         "item_key": item_key,
                     }
                 )
-                queued_for_item = True
+                queued_snapshot.add(mention_key)
                 if len(results) >= 3:
                     return results
                 break
-
-            if queued_for_item:
-                continue
-
-            if item_key in queued_item_snapshot:
-                continue
-
-            if not self._item_has_agentsnova_mention(item):
-                continue
-            if not self._is_trusted_item_author(item=item, trusted_users=trusted_users):
-                continue
-            if marker_created_at_s is not None or marker_comment_id > 0:
-                continue
-            if auto_reactions_enabled:
-                try:
-                    add_issue_reaction(
-                        repo_owner,
-                        repo_name,
-                        issue_number=item.number,
-                        reaction="eyes",
-                    )
-                except Exception:
-                    pass
-            results.append(
-                {
-                    "item_type": item.item_type,
-                    "number": item.number,
-                    "url": item.url,
-                    "title": item.title,
-                    "mention_comment_id": 0,
-                    "trigger_source": "body_mention",
-                    "item_key": item_key,
-                }
-            )
-            queued_item_snapshot.add(item_key)
-            if len(results) >= 3:
-                return results
 
         return results
 
@@ -760,12 +884,6 @@ class GitHubWorkCoordinator(QObject):
         return comment.reactions.eyes <= 0
 
     @staticmethod
-    def _item_has_agentsnova_mention(item: GitHubWorkItem) -> bool:
-        body = str(getattr(item, "body", "") or "").strip().lower()
-        title = str(getattr(item, "title", "") or "").strip().lower()
-        return "@agentsnova" in body or "@agentsnova" in title
-
-    @staticmethod
     def _normalize_item_type(value: object) -> str:
         normalized = str(value or "").strip().lower()
         return "pr" if normalized == "pr" else "issue"
@@ -801,18 +919,19 @@ class GitHubWorkCoordinator(QObject):
         number: int,
         url: str,
         title: str,
-        trigger_source: str,
-        mention_comment_id: int,
+        mention_text: str,
     ) -> str:
         normalized_item_type = str(item_type or "").strip().lower()
-        try:
-            parsed_mention_comment_id = int(mention_comment_id)
-        except Exception:
-            parsed_mention_comment_id = 0
-        mention_id = (
-            str(parsed_mention_comment_id) if parsed_mention_comment_id > 0 else ""
+        default_request = build_default_request_line(
+            item_type=normalized_item_type,
+            repo_owner=repo_owner,
+            repo_name=repo_name,
+            number=number,
         )
-        source = str(trigger_source or "").strip().lower() or "manual"
+        primary_request = build_primary_request(
+            mention_text=mention_text,
+            fallback=default_request,
+        )
 
         if normalized_item_type == "pr":
             return load_prompt(
@@ -822,8 +941,7 @@ class GitHubWorkCoordinator(QObject):
                 PR_NUMBER=number,
                 PR_URL=url,
                 PR_TITLE=title,
-                MENTION_COMMENT_ID=mention_id,
-                TRIGGER_SOURCE=source,
+                PRIMARY_REQUEST=primary_request,
             ).strip()
 
         return load_prompt(
@@ -833,8 +951,7 @@ class GitHubWorkCoordinator(QObject):
             ISSUE_NUMBER=number,
             ISSUE_URL=url,
             ISSUE_TITLE=title,
-            MENTION_COMMENT_ID=mention_id,
-            TRIGGER_SOURCE=source,
+            PRIMARY_REQUEST=primary_request,
         ).strip()
 
     def _eligible_poll_environment_ids(self) -> list[str]:

--- a/agents_runner/ui/pages/github_work_list.py
+++ b/agents_runner/ui/pages/github_work_list.py
@@ -258,7 +258,7 @@ class _GitHubWorkSkeletonRow(QWidget):
 
 class GitHubWorkListPage(QWidget):
     environment_changed = Signal(str)
-    prompt_append_requested = Signal(str, str)
+    prompt_append_requested = Signal(str, str, object)
 
     def __init__(
         self,
@@ -561,7 +561,7 @@ class GitHubWorkListPage(QWidget):
         )
         dialog.prompt_requested.connect(
             lambda prompt: self.prompt_append_requested.emit(
-                self._active_env_id, prompt
+                self._active_env_id, prompt, None
             )
         )
         dialog.exec()
@@ -575,6 +575,17 @@ class GitHubWorkListPage(QWidget):
         )
         repo_owner = str(getattr(repo_context, "repo_owner", "") or "")
         repo_name = str(getattr(repo_context, "repo_name", "") or "")
+        pr_context: dict[str, object] | None = None
+        if item.item_type == "pr":
+            pr_context = {
+                "repo_owner": repo_owner,
+                "repo_name": repo_name,
+                "pr_head_ref": str(getattr(item, "head_ref", "") or ""),
+                "pr_base_ref": str(getattr(item, "base_ref", "") or ""),
+                "pr_head_repo_owner": str(getattr(item, "head_repo_owner", "") or ""),
+                "pr_head_repo_name": str(getattr(item, "head_repo_name", "") or ""),
+                "pr_is_cross_repo": bool(getattr(item, "is_cross_repo", False)),
+            }
 
         prompt = self._build_task_prompt(
             item_type=item.item_type,
@@ -589,7 +600,7 @@ class GitHubWorkListPage(QWidget):
         if not prompt:
             return
 
-        self.prompt_append_requested.emit(self._active_env_id, prompt)
+        self.prompt_append_requested.emit(self._active_env_id, prompt, pr_context)
 
     def _build_task_prompt(
         self,

--- a/agents_runner/ui/pages/github_work_list.py
+++ b/agents_runner/ui/pages/github_work_list.py
@@ -27,6 +27,8 @@ from agents_runner.environments import Environment
 from agents_runner.environments import resolve_environment_github_repo
 from agents_runner.gh.work_items import GitHubWorkItem
 from agents_runner.prompts import load_prompt
+from agents_runner.prompts.github_prompting import build_default_request_line
+from agents_runner.prompts.github_prompting import build_primary_request
 from agents_runner.ui.dialogs.github_workroom_dialog import GitHubWorkroomDialog
 from agents_runner.ui.lucide_icons import lucide_icon
 from agents_runner.ui.utils import stain_color
@@ -581,8 +583,7 @@ class GitHubWorkListPage(QWidget):
             number=item.number,
             url=item.url,
             title=item.title,
-            trigger_source="manual",
-            mention_comment_id=0,
+            mention_text="",
         )
 
         if not prompt:
@@ -599,18 +600,19 @@ class GitHubWorkListPage(QWidget):
         number: int,
         url: str,
         title: str,
-        trigger_source: str,
-        mention_comment_id: int,
+        mention_text: str,
     ) -> str:
         normalized_item_type = str(item_type or "").strip().lower()
-        try:
-            parsed_mention_comment_id = int(mention_comment_id)
-        except Exception:
-            parsed_mention_comment_id = 0
-        mention_id = (
-            str(parsed_mention_comment_id) if parsed_mention_comment_id > 0 else ""
+        default_request = build_default_request_line(
+            item_type=normalized_item_type,
+            repo_owner=repo_owner,
+            repo_name=repo_name,
+            number=number,
         )
-        source = str(trigger_source or "").strip().lower() or "manual"
+        primary_request = build_primary_request(
+            mention_text=mention_text,
+            fallback=default_request,
+        )
 
         if normalized_item_type == "pr":
             return load_prompt(
@@ -620,8 +622,7 @@ class GitHubWorkListPage(QWidget):
                 PR_NUMBER=number,
                 PR_URL=url,
                 PR_TITLE=title,
-                MENTION_COMMENT_ID=mention_id,
-                TRIGGER_SOURCE=source,
+                PRIMARY_REQUEST=primary_request,
             ).strip()
 
         return load_prompt(
@@ -631,8 +632,7 @@ class GitHubWorkListPage(QWidget):
             ISSUE_NUMBER=number,
             ISSUE_URL=url,
             ISSUE_TITLE=title,
-            MENTION_COMMENT_ID=mention_id,
-            TRIGGER_SOURCE=source,
+            PRIMARY_REQUEST=primary_request,
         ).strip()
 
     def _sync_refresh_visibility(self) -> None:

--- a/agents_runner/ui/pages/new_task.py
+++ b/agents_runner/ui/pages/new_task.py
@@ -53,7 +53,7 @@ class NewTaskPage(QWidget):
     _BASE_BRANCH_LOADING_SENTINEL = "__loading__"
     _BASE_BRANCH_LOADING_DELAY_MS = 250
 
-    requested_run = Signal(str, str, str, str)
+    requested_run = Signal(str, str, str, str, object)
     requested_launch = Signal(str, str, str, str, str, str, str)
     back_requested = Signal()
     environment_changed = Signal(str)
@@ -105,6 +105,7 @@ class NewTaskPage(QWidget):
         self._pending_repo_branches_timer.timeout.connect(
             self._apply_pending_repo_branches_update
         )
+        self._pending_pr_context: dict[str, object] | None = None
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
@@ -204,7 +205,8 @@ class NewTaskPage(QWidget):
 
         self._command = QLineEdit("--sandbox danger-full-access")
         self._command.setPlaceholderText(
-            "Args for the Agent CLI (e.g. --sandbox danger-full-access or --add-dir …), or a full container command (e.g. bash)"
+            "Args for the Agent CLI (e.g. --sandbox danger-full-access or --add-dir "
+            "…), or a full container command (e.g. bash)"
         )
         # Hidden from UI but functionality preserved
         self._command.setVisible(False)
@@ -402,7 +404,9 @@ class NewTaskPage(QWidget):
         if not self._confirm_auto_base_branch(env_id, base_branch):
             return
 
-        self.requested_run.emit(prompt, host_codex, env_id, base_branch)
+        pr_context = self._pending_pr_context
+        self.requested_run.emit(prompt, host_codex, env_id, base_branch, pr_context)
+        self._pending_pr_context = None
 
     def _on_get_agent_help(self) -> None:
         if not self._workspace_ready:
@@ -1252,6 +1256,7 @@ class NewTaskPage(QWidget):
     def reset_for_new_run(self) -> None:
         self._prompt.setPlainText("")
         self._prompt.setFocus(Qt.OtherFocusReason)
+        self._pending_pr_context = None
 
     def append_prompt_text(self, text: str) -> None:
         addition = str(text or "").strip()
@@ -1268,6 +1273,9 @@ class NewTaskPage(QWidget):
         cursor.movePosition(QTextCursor.End)
         self._prompt.setTextCursor(cursor)
         self._prompt.setFocus(Qt.OtherFocusReason)
+
+    def set_pending_pr_context(self, context: dict[str, object] | None) -> None:
+        self._pending_pr_context = context if isinstance(context, dict) else None
 
     def focus_prompt(self) -> None:
         self._prompt.setFocus(Qt.OtherFocusReason)

--- a/agents_runner/ui/pages/tasks.py
+++ b/agents_runner/ui/pages/tasks.py
@@ -594,11 +594,15 @@ class TasksPage(QWidget):
         if focus_prompt:
             self._new_task.focus_prompt()
 
-    def _append_prompt_to_new_task(self, env_id: str, prompt: str) -> None:
+    def _append_prompt_to_new_task(
+        self, env_id: str, prompt: str, pr_context: object
+    ) -> None:
         target_env_id = str(env_id or "").strip()
         if target_env_id:
             self._new_task.set_environment_id(target_env_id)
 
+        context = pr_context if isinstance(pr_context, dict) else None
+        self._new_task.set_pending_pr_context(context)
         self._new_task.append_prompt_text(prompt)
         self.show_new_task_tab(focus_prompt=True)
 


### PR DESCRIPTION
## Summary
- Capture PR head/base/fork metadata and pass it through auto-review payloads.
- Switch PR pings to use the PR head branch (same-repo only) with fallback.
- Auto-reply on fork PR pings noting branch checkout is skipped.

## Testing
- Not run (not requested).

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
