### PR TITLE
[DOCS] Add gh comment caution to ping templates

### DIFF
--- a/agents_runner/prompts/issue_fix_template.md
+++ b/agents_runner/prompts/issue_fix_template.md
@@ -9,13 +9,14 @@ Issue title: {ISSUE_TITLE}
 Helpful info:
 1. Read the full issue details (description, linked context, and comments) and restate the problem in your own words.
 2. Prefer using `gh` to review and manage issue context (details, discussion, and relevant updates), unless this repository explicitly asks for a different method.
-3. Commit your changes as you work (don't just draft a commit message).
-4. Reproduce the issue or, if reproduction is not possible, explain exactly why and identify the most likely failure path from code inspection.
-5. Identify root cause with file-level evidence before making changes.
-6. Implement a minimal, focused fix that addresses root cause without unrelated refactors.
-7. Verify behavior with the most relevant checks for the changed area and report concrete results.
-8. Follow this repository's instructions (especially AGENTS.md and related docs) for workflow, formatting, and communication.
-9. At the end, update GitHub so the user is informed: post the appropriate issue / PR / comment update with status, what changed, and current outcome.
+3. Reminder: When posting `gh` comments, avoid wrapping routine status updates or file paths in backticks; use fenced code blocks only for actual code snippets to keep comments easy to parse.
+4. Commit your changes as you work (don't just draft a commit message).
+5. Reproduce the issue or, if reproduction is not possible, explain exactly why and identify the most likely failure path from code inspection.
+6. Identify root cause with file-level evidence before making changes.
+7. Implement a minimal, focused fix that addresses root cause without unrelated refactors.
+8. Verify behavior with the most relevant checks for the changed area and report concrete results.
+9. Follow this repository's instructions (especially AGENTS.md and related docs) for workflow, formatting, and communication.
+10. At the end, update GitHub so the user is informed: post the appropriate issue / PR / comment update with status, what changed, and current outcome.
 
 -----
 {PRIMARY_REQUEST}

--- a/agents_runner/prompts/pr_review_template.md
+++ b/agents_runner/prompts/pr_review_template.md
@@ -9,12 +9,13 @@ PR URL: {PR_URL}
 Helpful info:
 1. Read and follow this repository's standards first, especially AGENTS.md and any repo-specific contribution/review instructions.
 2. Prefer using `gh` to review and manage PR context (PR details, changed files, commits, and discussion), unless this repository explicitly asks for a different method.
-3. Commit your changes as you work (don't just draft a commit message).
-4. Review the pull request against repository standards and expected behavior.
-5. Run relevant local verification/tests as required by repository rules.
-6. Produce your review in the repository's expected format.
-7. If standards are missing or unclear, choose a clear review format and proceed.
-8. At the end, update GitHub so the user is informed: post the appropriate issue / PR / comment update with review outcome, key findings, and current status.
+3. Reminder: When posting `gh` comments, avoid wrapping routine status updates or file paths in backticks; use fenced code blocks only for actual code snippets to keep comments easy to parse.
+4. Commit your changes as you work (don't just draft a commit message).
+5. Review the pull request against repository standards and expected behavior.
+6. Run relevant local verification/tests as required by repository rules.
+7. Produce your review in the repository's expected format.
+8. If standards are missing or unclear, choose a clear review format and proceed.
+9. At the end, update GitHub so the user is informed: post the appropriate issue / PR / comment update with review outcome, key findings, and current status.
 
 -----
 {PRIMARY_REQUEST}


### PR DESCRIPTION
## Summary
- add a gh comment formatting reminder in the issue and PR ping prompt templates

## Testing
- not run (prompt template change)

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
