### PR TITLE
[FIX] Use static interactive command defaults

### DIFF
--- a/agents_runner/tests/test_interactive_agent_override.py
+++ b/agents_runner/tests/test_interactive_agent_override.py
@@ -149,8 +149,6 @@ def test_interactive_task_uses_codex_default_and_copilot_override(
     monkeypatch.setenv("HOME", str(tmp_path))
     window._settings_data["host_codex_dir"] = "~/.codex-default"
     window._settings_data["host_copilot_dir"] = "~/.copilot-override"
-    window._settings_data["interactive_command"] = "--sandbox danger-full-access"
-    window._settings_data["interactive_command_copilot"] = "--add-dir /override"
 
     terminal_option = TerminalOption(
         terminal_id="test-terminal",
@@ -196,7 +194,8 @@ def test_interactive_task_uses_codex_default_and_copilot_override(
     assert default_task.agent_instance_id == ""
     assert default_task.agent_cli_args == "--env-flag"
     assert (
-        window._interactive_prep_context[default_task_id]["command"] == "echo default"
+        window._interactive_prep_context[default_task_id]["command"]
+        == "--sandbox danger-full-access"
     )
 
     override = {
@@ -229,5 +228,5 @@ def test_interactive_task_uses_codex_default_and_copilot_override(
     assert override_task.agent_cli_args == "--override-flag"
     assert (
         window._interactive_prep_context[override_task_id]["command"]
-        == "--add-dir /override"
+        == "--add-dir /home/midori-ai/workspace"
     )

--- a/agents_runner/tests/test_interactive_agent_override.py
+++ b/agents_runner/tests/test_interactive_agent_override.py
@@ -130,7 +130,9 @@ class _DummyMainWindow(MainWindowSettingsMixin, MainWindowTasksInteractiveMixin)
         return
 
 
-def test_interactive_task_uses_copilot_override(monkeypatch, tmp_path) -> None:
+def test_interactive_task_uses_codex_default_and_copilot_override(
+    monkeypatch, tmp_path
+) -> None:
     workdir = tmp_path / "workspace"
     workdir.mkdir(parents=True, exist_ok=True)
 
@@ -144,6 +146,9 @@ def test_interactive_task_uses_copilot_override(monkeypatch, tmp_path) -> None:
     env.midoriai_template_likelihood = 1.0
 
     window = _DummyMainWindow(env, tmp_path, workdir)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    window._settings_data["host_codex_dir"] = "~/.codex-default"
+    window._settings_data["host_copilot_dir"] = "~/.copilot-override"
 
     terminal_option = TerminalOption(
         terminal_id="test-terminal",
@@ -168,6 +173,27 @@ def test_interactive_task_uses_copilot_override(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(interactive_module, "QThread", _FakeThread)
     monkeypatch.setattr(interactive_module, "is_gh_available", lambda: False)
 
+    window._start_interactive_task_from_ui(
+        prompt="default",
+        command="echo default",
+        host_codex="",
+        env_id=env.env_id,
+        terminal_id="test-terminal",
+        base_branch="",
+        agent_override=None,
+        extra_preflight_script="",
+    )
+
+    assert len(window._tasks) == 1
+    default_task_id = window._dashboard.last_task_id
+    assert default_task_id is not None
+    default_task = window._tasks[default_task_id]
+    assert default_task.agent_cli == "codex"
+    assert default_task.host_config_dir == str(tmp_path / ".codex-default")
+    assert Path(default_task.host_config_dir).is_absolute()
+    assert default_task.agent_instance_id == ""
+    assert default_task.agent_cli_args == "--env-flag"
+
     override = {
         "agent_cli": "copilot",
         "agent_id": "copilot-1",
@@ -177,7 +203,7 @@ def test_interactive_task_uses_copilot_override(monkeypatch, tmp_path) -> None:
     window._start_interactive_task_from_ui(
         prompt="hello",
         command="echo hello",
-        host_codex=str(tmp_path / "codex"),
+        host_codex=str(tmp_path / "codex-explicit"),
         env_id=env.env_id,
         terminal_id="test-terminal",
         base_branch="",
@@ -185,9 +211,14 @@ def test_interactive_task_uses_copilot_override(monkeypatch, tmp_path) -> None:
         extra_preflight_script="",
     )
 
-    assert len(window._tasks) == 1
-    task = next(iter(window._tasks.values()))
-    assert task.agent_cli == "copilot"
-    assert task.agent_instance_id == "copilot-1"
-    assert task.host_config_dir == str(tmp_path / "copilot")
-    assert task.agent_cli_args == "--override-flag --env-flag"
+    assert len(window._tasks) == 2
+    override_task_id = window._dashboard.last_task_id
+    assert override_task_id is not None
+    assert override_task_id != default_task_id
+    override_task = window._tasks[override_task_id]
+    assert override_task.agent_cli == "copilot"
+    assert override_task.agent_instance_id == "copilot-1"
+    assert override_task.host_config_dir == str(tmp_path / ".copilot-override")
+    assert Path(override_task.host_config_dir).is_absolute()
+    assert override_task.host_config_dir != default_task.host_config_dir
+    assert override_task.agent_cli_args == "--override-flag"

--- a/agents_runner/tests/test_interactive_agent_override.py
+++ b/agents_runner/tests/test_interactive_agent_override.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from agents_runner.environments import Environment
+from agents_runner.environments import WORKSPACE_NONE
+from agents_runner.terminal_apps import TerminalOption
+from agents_runner.ui.main_window_settings import MainWindowSettingsMixin
+from agents_runner.ui.main_window_tasks_interactive import MainWindowTasksInteractiveMixin
+import agents_runner.ui.main_window_tasks_interactive as interactive_module
+
+
+class _FakeSignal:
+    def connect(self, *_args, **_kwargs) -> None:
+        return
+
+
+class _FakeThread:
+    def __init__(self, _parent=None) -> None:
+        self.started = _FakeSignal()
+        self.finished = _FakeSignal()
+
+    def start(self) -> None:
+        return
+
+    def quit(self) -> None:
+        return
+
+    def deleteLater(self) -> None:
+        return
+
+
+class _FakePrepWorker:
+    def __init__(self, **_kwargs) -> None:
+        self.stage = _FakeSignal()
+        self.log = _FakeSignal()
+        self.succeeded = _FakeSignal()
+        self.failed = _FakeSignal()
+
+    def moveToThread(self, _thread) -> None:
+        return
+
+    def run(self) -> None:
+        return
+
+    def deleteLater(self) -> None:
+        return
+
+
+class _FakePrepBridge:
+    def __init__(self, **_kwargs) -> None:
+        return
+
+    def on_stage(self, *_args, **_kwargs) -> None:
+        return
+
+    def on_log(self, *_args, **_kwargs) -> None:
+        return
+
+    def on_succeeded(self, *_args, **_kwargs) -> None:
+        return
+
+    def on_failed(self, *_args, **_kwargs) -> None:
+        return
+
+    def deleteLater(self) -> None:
+        return
+
+
+class _FakeMessageBox:
+    @staticmethod
+    def critical(*_args, **_kwargs) -> None:
+        return
+
+    @staticmethod
+    def warning(*_args, **_kwargs) -> None:
+        return
+
+
+@dataclass
+class _DummyDashboard:
+    last_task_id: str | None = None
+
+    def upsert_task(self, task, *, stain=None, spinner_color=None) -> None:
+        self.last_task_id = task.task_id
+
+
+class _DummyNewTask:
+    def reset_for_new_run(self) -> None:
+        return
+
+
+class _DummyMainWindow(MainWindowSettingsMixin, MainWindowTasksInteractiveMixin):
+    def __init__(self, env: Environment, tmp_path: Path, workdir: Path) -> None:
+        self._settings_data = {
+            "use": "codex",
+            "host_codex_dir": str(tmp_path / "codex"),
+            "host_copilot_dir": str(tmp_path / "copilot"),
+            "host_claude_dir": str(tmp_path / "claude"),
+            "host_gemini_dir": str(tmp_path / "gemini"),
+            "append_pixelarch_context": False,
+            "preflight_enabled": False,
+            "preflight_script": "",
+        }
+        self._environments = {env.env_id: env}
+        self._tasks: dict[str, object] = {}
+        self._interactive_prep_context: dict[str, object] = {}
+        self._interactive_prep_workers: dict[str, object] = {}
+        self._interactive_prep_threads: dict[str, object] = {}
+        self._interactive_prep_bridges: dict[str, object] = {}
+        self._dashboard = _DummyDashboard()
+        self._new_task = _DummyNewTask()
+        self._state_path = str(tmp_path / "state.toml")
+        self._workdir = str(workdir)
+
+    def _active_environment_id(self) -> str:
+        return next(iter(self._environments.keys()))
+
+    def _new_task_workspace(self, _env, *, task_id: str) -> tuple[str, bool, str]:
+        return self._workdir, True, ""
+
+    def _schedule_save(self) -> None:
+        return
+
+    def _maybe_auto_navigate_on_task_start(self, *, interactive: bool) -> None:
+        return
+
+    def _on_task_log(self, _task_id: str, _line: str) -> None:
+        return
+
+
+def test_interactive_task_uses_copilot_override(monkeypatch, tmp_path) -> None:
+    workdir = tmp_path / "workspace"
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    env = Environment(
+        env_id="env-override",
+        name="Override",
+        workspace_type=WORKSPACE_NONE,
+        workspace_target=str(workdir),
+        agent_cli_args="--env-flag",
+    )
+    env.midoriai_template_likelihood = 1.0
+
+    window = _DummyMainWindow(env, tmp_path, workdir)
+
+    terminal_option = TerminalOption(
+        terminal_id="test-terminal",
+        label="Test",
+        kind="linux-exe",
+        exe="/bin/true",
+    )
+
+    monkeypatch.setattr(
+        interactive_module,
+        "detect_terminal_options",
+        lambda: [terminal_option],
+    )
+    monkeypatch.setattr(
+        interactive_module.shutil,
+        "which",
+        lambda name: "/usr/bin/docker" if name == "docker" else None,
+    )
+    monkeypatch.setattr(interactive_module, "QMessageBox", _FakeMessageBox)
+    monkeypatch.setattr(interactive_module, "InteractivePrepWorker", _FakePrepWorker)
+    monkeypatch.setattr(interactive_module, "InteractivePrepBridge", _FakePrepBridge)
+    monkeypatch.setattr(interactive_module, "QThread", _FakeThread)
+    monkeypatch.setattr(interactive_module, "is_gh_available", lambda: False)
+
+    override = {
+        "agent_cli": "copilot",
+        "agent_id": "copilot-1",
+        "cli_flags": "--override-flag",
+    }
+
+    window._start_interactive_task_from_ui(
+        prompt="hello",
+        command="echo hello",
+        host_codex=str(tmp_path / "codex"),
+        env_id=env.env_id,
+        terminal_id="test-terminal",
+        base_branch="",
+        agent_override=override,
+        extra_preflight_script="",
+    )
+
+    assert len(window._tasks) == 1
+    task = next(iter(window._tasks.values()))
+    assert task.agent_cli == "copilot"
+    assert task.agent_instance_id == "copilot-1"
+    assert task.host_config_dir == str(tmp_path / "copilot")
+    assert task.agent_cli_args == "--override-flag --env-flag"

--- a/agents_runner/tests/test_interactive_agent_override.py
+++ b/agents_runner/tests/test_interactive_agent_override.py
@@ -149,6 +149,8 @@ def test_interactive_task_uses_codex_default_and_copilot_override(
     monkeypatch.setenv("HOME", str(tmp_path))
     window._settings_data["host_codex_dir"] = "~/.codex-default"
     window._settings_data["host_copilot_dir"] = "~/.copilot-override"
+    window._settings_data["interactive_command"] = "--sandbox danger-full-access"
+    window._settings_data["interactive_command_copilot"] = "--add-dir /override"
 
     terminal_option = TerminalOption(
         terminal_id="test-terminal",
@@ -193,6 +195,9 @@ def test_interactive_task_uses_codex_default_and_copilot_override(
     assert Path(default_task.host_config_dir).is_absolute()
     assert default_task.agent_instance_id == ""
     assert default_task.agent_cli_args == "--env-flag"
+    assert (
+        window._interactive_prep_context[default_task_id]["command"] == "echo default"
+    )
 
     override = {
         "agent_cli": "copilot",
@@ -202,7 +207,7 @@ def test_interactive_task_uses_codex_default_and_copilot_override(
 
     window._start_interactive_task_from_ui(
         prompt="hello",
-        command="echo hello",
+        command="--sandbox danger-full-access",
         host_codex=str(tmp_path / "codex-explicit"),
         env_id=env.env_id,
         terminal_id="test-terminal",
@@ -222,3 +227,7 @@ def test_interactive_task_uses_codex_default_and_copilot_override(
     assert Path(override_task.host_config_dir).is_absolute()
     assert override_task.host_config_dir != default_task.host_config_dir
     assert override_task.agent_cli_args == "--override-flag"
+    assert (
+        window._interactive_prep_context[override_task_id]["command"]
+        == "--add-dir /override"
+    )

--- a/agents_runner/ui/main_window_tasks_interactive.py
+++ b/agents_runner/ui/main_window_tasks_interactive.py
@@ -222,9 +222,21 @@ class MainWindowTasksInteractiveMixin:
                 return
 
         # Build command with agent-specific handling
-        raw_command = str(command or "").strip()
-        if not raw_command:
-            raw_command = self._default_interactive_command(agent_cli)
+        raw_command = ""
+        if override:
+            override_key = self._interactive_command_key(agent_cli)
+            override_command = str(self._settings_data.get(override_key) or "").strip()
+            if not override_command:
+                override_command = self._default_interactive_command(agent_cli)
+            raw_command = self._sanitize_interactive_command_value(
+                override_key, override_command
+            )
+            if not raw_command:
+                raw_command = self._default_interactive_command(agent_cli)
+        else:
+            raw_command = str(command or "").strip()
+            if not raw_command:
+                raw_command = self._default_interactive_command(agent_cli)
         command = raw_command
         extra_preflight_script = str(extra_preflight_script or "")
         is_help_launch = self._is_agent_help_interactive_launch(

--- a/agents_runner/ui/main_window_tasks_interactive.py
+++ b/agents_runner/ui/main_window_tasks_interactive.py
@@ -222,22 +222,7 @@ class MainWindowTasksInteractiveMixin:
                 return
 
         # Build command with agent-specific handling
-        raw_command = ""
-        if override:
-            override_key = self._interactive_command_key(agent_cli)
-            override_command = str(self._settings_data.get(override_key) or "").strip()
-            if not override_command:
-                override_command = self._default_interactive_command(agent_cli)
-            raw_command = self._sanitize_interactive_command_value(
-                override_key, override_command
-            )
-            if not raw_command:
-                raw_command = self._default_interactive_command(agent_cli)
-        else:
-            raw_command = str(command or "").strip()
-            if not raw_command:
-                raw_command = self._default_interactive_command(agent_cli)
-        command = raw_command
+        command = self._default_interactive_command(agent_cli)
         extra_preflight_script = str(extra_preflight_script or "")
         is_help_launch = self._is_agent_help_interactive_launch(
             prompt=prompt, command=command

--- a/agents_runner/ui/main_window_tasks_interactive.py
+++ b/agents_runner/ui/main_window_tasks_interactive.py
@@ -208,19 +208,18 @@ class MainWindowTasksInteractiveMixin:
             agent_instance_id = str(agent_cli or "").strip()
 
         agent_cli_args: list[str] = []
-        if env and env.agent_cli_args.strip():
+        if override and selected_cli_flags:
+            try:
+                agent_cli_args = shlex.split(selected_cli_flags)
+            except ValueError as exc:
+                QMessageBox.warning(self, "Invalid agent CLI flags", str(exc))
+                return
+        elif env and env.agent_cli_args.strip():
             try:
                 agent_cli_args = shlex.split(env.agent_cli_args)
             except ValueError as exc:
                 QMessageBox.warning(self, "Invalid agent CLI flags", str(exc))
                 return
-        if override and selected_cli_flags:
-            try:
-                override_args = shlex.split(selected_cli_flags)
-            except ValueError as exc:
-                QMessageBox.warning(self, "Invalid agent CLI flags", str(exc))
-                return
-            agent_cli_args = override_args + agent_cli_args
 
         # Build command with agent-specific handling
         raw_command = str(command or "").strip()

--- a/agents_runner/ui/main_window_tasks_interactive_docker.py
+++ b/agents_runner/ui/main_window_tasks_interactive_docker.py
@@ -497,15 +497,6 @@ def launch_docker_terminal_task(
         main_window._settings_data["interactive_terminal_id"] = str(
             getattr(terminal_opt, "terminal_id", "")
         )
-        interactive_key = main_window._interactive_command_key(agent_cli)
-        if not main_window._is_agent_help_interactive_launch(
-            prompt=prompt, command=command
-        ):
-            main_window._settings_data[interactive_key] = (
-                main_window._sanitize_interactive_command_value(
-                    interactive_key, command
-                )
-            )
         main_window._apply_active_environment_to_new_task()
         main_window._schedule_save()
 

--- a/agents_runner/ui/main_window_tasks_interactive_docker.py
+++ b/agents_runner/ui/main_window_tasks_interactive_docker.py
@@ -57,6 +57,30 @@ def _publishes_container_port(spec: str, port: int) -> bool:
     return False
 
 
+def _redact_env_assignment(value: str) -> str:
+    base = str(value or "")
+    if "=" not in base:
+        return base
+    key, _ = base.split("=", 1)
+    if not key:
+        return "***"
+    return f"{key}=***"
+
+
+def _redact_env_args_for_log(env_args: list[str]) -> list[str]:
+    redacted: list[str] = []
+    expect_value = False
+    for arg in env_args:
+        if expect_value:
+            redacted.append(_redact_env_assignment(arg))
+            expect_value = False
+            continue
+        redacted.append(arg)
+        if arg == "-e":
+            expect_value = True
+    return redacted
+
+
 def launch_docker_terminal_task(
     main_window: object,
     task: Task,
@@ -377,6 +401,11 @@ def launch_docker_terminal_task(
             f"{git_identity_clause()}{preflight_clause}{verify_clause}{target_cmd}"
         )
 
+        main_window._on_task_log(
+            task_id,
+            format_log("agent", "cmd", "INFO", target_cmd),
+        )
+
         # Build Docker command
         docker_cmd = _build_docker_command(
             container_name=container_name,
@@ -391,6 +420,25 @@ def launch_docker_terminal_task(
             docker_env_passthrough=[],
             image=runtime_image,
             container_script=container_script,
+        )
+
+        docker_cmd_for_log = _build_docker_command(
+            container_name=container_name,
+            host_codex=host_codex,
+            host_workdir=host_workdir,
+            container_agent_dir=container_agent_dir,
+            container_workdir=container_workdir,
+            extra_mount_args=extra_mount_args,
+            preflight_mounts=preflight_mounts,
+            env_args=_redact_env_args_for_log(env_args),
+            port_args=port_args,
+            docker_env_passthrough=[],
+            image=runtime_image,
+            container_script=container_script,
+        )
+        main_window._on_task_log(
+            task_id,
+            format_log("docker", "cmd", "INFO", docker_cmd_for_log),
         )
 
         # Prepare finish file for exit code tracking


### PR DESCRIPTION
## Summary
- always use per-agent default interactive commands (ignore settings + UI command field)
- stop persisting interactive commands to state
- update interactive override test expectations

## Testing
- not run (not requested)

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
