### PR TITLE
Bootstrap setup-agents.sh before IDE/Desktop startup

### DIFF
--- a/agents_runner/core/shell_templates.py
+++ b/agents_runner/core/shell_templates.py
@@ -45,6 +45,27 @@ def git_identity_clause() -> str:
     )
 
 
+def setup_agents_bootstrap_clause(*, container_repo_root: str) -> str:
+    """
+    Build shell clause to run repo-local setup-agents.sh when present.
+
+    Args:
+        container_repo_root: Container path to mounted repository root
+    """
+    repo_root = str(container_repo_root or "").strip() or "."
+    script_path = f"{repo_root.rstrip('/')}/setup-agents.sh"
+    return (
+        f"SETUP_AGENTS_SCRIPT={shlex.quote(script_path)}; "
+        'if [ -f "${SETUP_AGENTS_SCRIPT}" ]; then '
+        f"{shell_log_statement('docker', 'preflight', 'INFO', 'repo-bootstrap: running setup-agents.sh')}; "
+        '/bin/bash "${SETUP_AGENTS_SCRIPT}"; '
+        f"{shell_log_statement('docker', 'preflight', 'INFO', 'repo-bootstrap: done')}; "
+        "else "
+        f"{shell_log_statement('docker', 'preflight', 'INFO', 'repo-bootstrap: setup-agents.sh not found; skipping')}; "
+        "fi; "
+    )
+
+
 def build_git_clone_command(
     *,
     gh_repo: str,

--- a/agents_runner/docker/agent_worker_container.py
+++ b/agents_runner/docker/agent_worker_container.py
@@ -35,7 +35,11 @@ from agents_runner.github_token import resolve_github_token
 from agents_runner.ide_systems import IDE_DISPLAY_HOST_DESKTOP
 from agents_runner.ide_systems import get_ide_system
 from agents_runner.log_format import format_log, wrap_container_log
-from agents_runner.core.shell_templates import git_identity_clause, shell_log_statement
+from agents_runner.core.shell_templates import (
+    git_identity_clause,
+    setup_agents_bootstrap_clause,
+    shell_log_statement,
+)
 
 from agents_runner.docker.config import DockerRunnerConfig
 from agents_runner.docker.process import run_docker, inspect_state
@@ -282,6 +286,10 @@ class ContainerExecutor:
             clause, mounts = self._build_system_preflight()
             preflight_clause += clause
             preflight_mounts.extend(mounts)
+
+        preflight_clause += setup_agents_bootstrap_clause(
+            container_repo_root=self._config.container_workdir
+        )
 
         # IDE preflight
         if (

--- a/agents_runner/ui/main_window_tasks_interactive_docker.py
+++ b/agents_runner/ui/main_window_tasks_interactive_docker.py
@@ -34,6 +34,7 @@ from agents_runner.ide_systems import normalize_ide_display_target
 from agents_runner.log_format import format_log
 from agents_runner.terminal_apps import launch_in_terminal
 from agents_runner.core.shell_templates import git_identity_clause
+from agents_runner.core.shell_templates import setup_agents_bootstrap_clause
 from agents_runner.core.shell_templates import shell_log_statement
 from agents_runner.ui.task_model import Task
 from agents_runner.ui.utils import safe_str
@@ -297,6 +298,7 @@ def launch_docker_terminal_task(
     # runtime desktop services still need to start for each container launch.
     preflight_clause, preflight_mounts, tmp_paths = _prepare_preflight_scripts(
         task_token=task_token,
+        container_workdir=container_workdir,
         ide_preflight_script=str(ide_preflight_script or ""),
         desktop_preflight_script=desktop_preflight_script,
         settings_preflight_script=settings_preflight_script,
@@ -584,6 +586,7 @@ def launch_docker_terminal_task(
 
 def _prepare_preflight_scripts(
     task_token: str,
+    container_workdir: str,
     ide_preflight_script: str,
     desktop_preflight_script: str,
     settings_preflight_script: str | None,
@@ -598,6 +601,7 @@ def _prepare_preflight_scripts(
 
     Args:
         task_token: Unique task token for temp file naming
+        container_workdir: Container path to mounted repository root
         ide_preflight_script: IDE install phase script content
         desktop_preflight_script: Desktop phase script content
         settings_preflight_script: Global preflight script
@@ -689,6 +693,10 @@ def _prepare_preflight_scripts(
                 '/bin/bash "${PREFLIGHT_SYSTEM}"; '
                 f"{shell_log_statement('docker', 'preflight', 'INFO', 'system: done')}; "
             )
+
+        preflight_clause += setup_agents_bootstrap_clause(
+            container_repo_root=container_workdir
+        )
 
         def _append_optional_phase(
             *,


### PR DESCRIPTION
## Summary
- added a shared repo bootstrap shell clause that auto-detects setup-agents.sh at the mounted repo root
- run agent path now executes the bootstrap phase before IDE and desktop preflight phases
- run interactive path now executes the bootstrap phase before IDE and desktop preflight phases

## Verification
- `uv run ruff format agents_runner/core/shell_templates.py agents_runner/docker/agent_worker_container.py agents_runner/ui/main_window_tasks_interactive_docker.py`
- `uv run ruff check .`
- `uv run python -m py_compile agents_runner/core/shell_templates.py agents_runner/docker/agent_worker_container.py agents_runner/ui/main_window_tasks_interactive_docker.py`
- `uv run basedpyright` reports existing repository-wide baseline errors (pre-existing)

## Status
- done

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
