### PR TITLE
[Refactor] Plugin-driven agent config and interactive command settings

### DIFF
--- a/agents_runner/agent_systems/copilot/plugin.py
+++ b/agents_runner/agent_systems/copilot/plugin.py
@@ -83,7 +83,7 @@ class CopilotAgentSystemPlugin:
         return ["copilot", "--version"]
 
     def default_interactive_command(self) -> str:
-        return "--allow-all-tools --allow-all-paths --add-dir /home/midori-ai/workspace"
+        return "--add-dir /home/midori-ai/workspace"
 
     def sanitize_interactive_command_parts(self, *, cmd_parts: list[str]) -> list[str]:
         return list(cmd_parts)

--- a/agents_runner/tests/test_github_work_coordinator_polling_start.py
+++ b/agents_runner/tests/test_github_work_coordinator_polling_start.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 import time
 from collections.abc import Callable
 
-from PySide6.QtCore import QCoreApplication
 from PySide6.QtTest import QTest
+from PySide6.QtWidgets import QApplication
 
 import pytest
 
@@ -14,10 +14,10 @@ from agents_runner.environments import WORKSPACE_CLONED
 from agents_runner.ui.pages.github_work_coordinator import GitHubWorkCoordinator
 
 
-def _app() -> QCoreApplication:
-    app = QCoreApplication.instance()
+def _app() -> QApplication:
+    app = QApplication.instance()
     if app is None:
-        app = QCoreApplication([])
+        app = QApplication([])
     return app
 
 
@@ -171,9 +171,12 @@ def test_runtime_toggle_starts_polling_immediately(
     coordinator.set_settings_data({"github_polling_enabled": False})
 
 
-def test_is_polling_effective_ignores_env_checkbox_when_global_enabled() -> None:
+def test_is_polling_effective_ignores_env_checkbox_when_global_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     _app()
     coordinator = GitHubWorkCoordinator()
+    monkeypatch.setattr(coordinator, "_start_poll_cycle", lambda: None)
     env_id = "env-1"
     coordinator.set_environments(
         {

--- a/agents_runner/ui/main_window_settings.py
+++ b/agents_runner/ui/main_window_settings.py
@@ -28,6 +28,18 @@ logger = logging.getLogger(__name__)
 class MainWindowSettingsMixin:
     _AGENT_CONFIG_DIRS_KEY = "agent_config_dirs"
     _AGENT_INTERACTIVE_COMMANDS_KEY = "agent_interactive_commands"
+    _LEGACY_HOST_CONFIG_KEY_BY_AGENT = {
+        "codex": "host_codex_dir",
+        "claude": "host_claude_dir",
+        "copilot": "host_copilot_dir",
+        "gemini": "host_gemini_dir",
+    }
+    _LEGACY_INTERACTIVE_COMMAND_KEY_BY_AGENT = {
+        "codex": "interactive_command",
+        "claude": "interactive_command_claude",
+        "copilot": "interactive_command_copilot",
+        "gemini": "interactive_command_gemini",
+    }
     _REMOVED_LEGACY_SETTINGS_KEYS = (
         "host_codex_dir",
         "host_claude_dir",
@@ -94,17 +106,47 @@ class MainWindowSettingsMixin:
         self, settings: dict[str, object] | None = None
     ) -> dict[str, str]:
         source = settings if settings is not None else self._settings_data
+        configured = self._coerce_agent_map(source.get(self._AGENT_CONFIG_DIRS_KEY))
+        legacy = self._legacy_agent_map_from_settings(
+            source=source,
+            key_by_agent=self._LEGACY_HOST_CONFIG_KEY_BY_AGENT,
+        )
+        merged = dict(legacy)
+        merged.update(configured)
         return self._normalized_agent_config_dirs_map(
-            source.get(self._AGENT_CONFIG_DIRS_KEY)
+            merged,
         )
 
     def _get_agent_interactive_commands_map(
         self, settings: dict[str, object] | None = None
     ) -> dict[str, str]:
         source = settings if settings is not None else self._settings_data
-        return self._normalized_agent_interactive_commands_map(
+        configured = self._coerce_agent_map(
             source.get(self._AGENT_INTERACTIVE_COMMANDS_KEY)
         )
+        legacy = self._legacy_agent_map_from_settings(
+            source=source,
+            key_by_agent=self._LEGACY_INTERACTIVE_COMMAND_KEY_BY_AGENT,
+        )
+        merged = dict(legacy)
+        merged.update(configured)
+        return self._normalized_agent_interactive_commands_map(merged)
+
+    @staticmethod
+    def _legacy_agent_map_from_settings(
+        *,
+        source: dict[str, object],
+        key_by_agent: dict[str, str],
+    ) -> dict[str, str]:
+        values: dict[str, str] = {}
+        for agent_cli in available_agents():
+            legacy_key = key_by_agent.get(agent_cli, "")
+            if not legacy_key:
+                continue
+            configured = str(source.get(legacy_key) or "").strip()
+            if configured:
+                values[agent_cli] = configured
+        return values
 
     def _set_agent_config_dir_setting(
         self,


### PR DESCRIPTION
## Status
- Completed: failing tests fixed on the current branch with scoped code + test harness adjustments.

## Summary
- Added legacy fallback for per-agent config dir and interactive command settings when plugin-driven maps are missing.
- Corrected Copilot non-help interactive default command to `--add-dir /home/midori-ai/workspace`.
- Stabilized polling startup tests by using `QApplication` and preventing unnecessary poll-cycle execution in an assertion-only test.

## Validation
- `uv run pytest` -> `16 passed, 2 skipped`
- `uv run ruff check .` -> passed
- `uv run basedpyright` -> pre-existing repo-wide errors remain (outside this task scope)

## Commits
- `[FIX] Restore legacy config fallback and copilot interactive default`
- `[TEST] Stabilize polling startup tests with QApplication`

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
