### PR TITLE
[FEAT] Add PixelArch recommended preflight presets

### DIFF
--- a/agents_runner/preflight-scripts/clear_uv_cache.sh
+++ b/agents_runner/preflight-scripts/clear_uv_cache.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Demonstrates clearing the uv cache.
+uv cache clean --force

--- a/agents_runner/preflight-scripts/install_paru_with_yay_cleanup.sh
+++ b/agents_runner/preflight-scripts/install_paru_with_yay_cleanup.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 
 # Demonstrates a PixelArch install flow with yay.
-yay -Syu --noconfirm && yay -S --noconfirm --needed paru && yay -Yccc --noconfirm
+yay -Syu --noconfirm && yay -Syu --noconfirm --needed paru && yay -Yccc --noconfirm

--- a/agents_runner/preflight-scripts/install_paru_with_yay_cleanup.sh
+++ b/agents_runner/preflight-scripts/install_paru_with_yay_cleanup.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 
 # Demonstrates a PixelArch install flow with yay.
-yay -Syu --noconfirm && yay -Syu --noconfirm --needed paru && yay -Yccc --noconfirm
+yay -Syu --noconfirm --needed paru && yay -Yccc --noconfirm

--- a/agents_runner/preflight-scripts/install_paru_with_yay_cleanup.sh
+++ b/agents_runner/preflight-scripts/install_paru_with_yay_cleanup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Demonstrates a PixelArch install flow with yay.
+yay -Syu --noconfirm && yay -S --noconfirm --needed paru && yay -Yccc --noconfirm

--- a/agents_runner/preflight-scripts/reinstall_lolcat_with_yay_cleanup.sh
+++ b/agents_runner/preflight-scripts/reinstall_lolcat_with_yay_cleanup.sh
@@ -6,5 +6,5 @@ yay -Syu --noconfirm
 if yay -Q lolcat >/dev/null 2>&1; then
   yay -Rns --noconfirm lolcat
 fi
-yay -S --noconfirm --needed lolcat
+yay -Syu --noconfirm --needed lolcat
 yay -Yccc --noconfirm

--- a/agents_runner/preflight-scripts/reinstall_lolcat_with_yay_cleanup.sh
+++ b/agents_runner/preflight-scripts/reinstall_lolcat_with_yay_cleanup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Demonstrates a PixelArch uninstall + reinstall flow with yay.
+yay -Syu --noconfirm
+if yay -Q lolcat >/dev/null 2>&1; then
+  yay -Rns --noconfirm lolcat
+fi
+yay -S --noconfirm --needed lolcat
+yay -Yccc --noconfirm

--- a/agents_runner/preflight-scripts/reinstall_lolcat_with_yay_cleanup.sh
+++ b/agents_runner/preflight-scripts/reinstall_lolcat_with_yay_cleanup.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 # Demonstrates a PixelArch uninstall + reinstall flow with yay.
-yay -Syu --noconfirm
 if yay -Q lolcat >/dev/null 2>&1; then
   yay -Rns --noconfirm lolcat
 fi

--- a/agents_runner/preflight-scripts/remove_lolcat_with_yay_cleanup.sh
+++ b/agents_runner/preflight-scripts/remove_lolcat_with_yay_cleanup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Demonstrates a PixelArch remove flow with yay.
+yay -Syu --noconfirm
+if yay -Q lolcat >/dev/null 2>&1; then
+  yay -Rns --noconfirm lolcat
+else
+  echo "[settings-preflight] lolcat is not installed; nothing to remove"
+fi
+yay -Yccc --noconfirm

--- a/agents_runner/preflight-scripts/uv_install_all_python_versions_all_impls.sh
+++ b/agents_runner/preflight-scripts/uv_install_all_python_versions_all_impls.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Demonstrates installing every downloadable uv Python key for this platform.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "[settings-preflight] jq is required for this preset."
+  exit 1
+fi
+
+mapfile -t python_keys < <(
+  uv python list --only-downloads --all-versions --output-format json | jq -r '.[].key'
+)
+
+if [ "${#python_keys[@]}" -eq 0 ]; then
+  echo "[settings-preflight] No downloadable Python versions were returned by uv."
+  exit 0
+fi
+
+for key in "${python_keys[@]}"; do
+  echo "[settings-preflight] uv python install ${key}"
+  uv python install "${key}"
+done


### PR DESCRIPTION
## Summary
- add five new recommended preflight preset scripts under `agents_runner/preflight-scripts`
- keep implementation script-only with no UI/runtime Python changes
- include PixelArch yay examples and UV cache/all-versions examples for user guidance

## Added Presets
- `install_paru_with_yay_cleanup.sh`
- `remove_lolcat_with_yay_cleanup.sh`
- `reinstall_lolcat_with_yay_cleanup.sh`
- `clear_uv_cache.sh`
- `uv_install_all_python_versions_all_impls.sh`

## Notes
- install/reinstall presets now perform a single `yay -Syu --noconfirm --needed ...` pass (no duplicate full update)
- yay cleanup step remains `yay -Yccc --noconfirm` per request
- UV all-versions preset prints each install key on its own line before running install

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
