### PR TITLE
Fix auto-start gating, selection sync, env preview source, and setup...

### DIFF
--- a/agents_runner/docker/agent_worker_container.py
+++ b/agents_runner/docker/agent_worker_container.py
@@ -473,8 +473,15 @@ class ContainerExecutor:
         return (
             f"PREFLIGHT_SETUP_AGENTS={shlex.quote(container_path)}; "
             f"{shell_log_statement('env', 'setup', 'INFO', 'setup-agents: running')}; "
+            "set +e; "
             '/bin/bash "${PREFLIGHT_SETUP_AGENTS}"; '
-            f"{shell_log_statement('env', 'setup', 'INFO', 'setup-agents: done')}; ",
+            "SETUP_AGENTS_EXIT=$?; "
+            "set -e; "
+            'if [ "$SETUP_AGENTS_EXIT" -ne 0 ]; then '
+            'echo "[env/setup][ERROR] setup-agents failed (exit ${SETUP_AGENTS_EXIT}); continuing startup"; '
+            "else "
+            f"{shell_log_statement('env', 'setup', 'INFO', 'setup-agents: done')}; "
+            "fi; ",
             ["-v", f"{tmp_path}:{container_path}:ro"],
         )
 

--- a/agents_runner/environments/model.py
+++ b/agents_runner/environments/model.py
@@ -85,6 +85,9 @@ class Environment:
     cache_system_preflight_enabled: bool = False
     cache_settings_preflight_enabled: bool = False
     cache_ide_preflight_enabled: bool = False
+    preflight_identity_token: str = ""
+    setup_agents_preflight_snapshot_ciphertext: str = ""
+    setup_agents_preflight_snapshot_sha256: str = ""
     ide_safe_mode_by_system: dict[str, bool] = field(default_factory=dict)
     env_vars: dict[str, str] = field(default_factory=dict)
     extra_mounts: list[str] = field(default_factory=list)

--- a/agents_runner/environments/preflight_snapshot.py
+++ b/agents_runner/environments/preflight_snapshot.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+
+from cryptography.fernet import Fernet
+from cryptography.fernet import InvalidToken
+
+from .model import WORKSPACE_CLONED
+from .model import WORKSPACE_MOUNTED
+from .model import WORKSPACE_NONE
+
+
+def normalize_setup_agents_script_text(text: str) -> str:
+    normalized = str(text or "").replace("\r\n", "\n").replace("\r", "\n")
+    if normalized and not normalized.endswith("\n"):
+        normalized += "\n"
+    return normalized
+
+
+def normalize_setup_agents_snapshot_hash(value: object) -> str:
+    token = str(value or "").strip().lower()
+    if len(token) != 64:
+        return ""
+    if any(ch not in "0123456789abcdef" for ch in token):
+        return ""
+    return token
+
+
+def _normalize_repo_identity(target: str) -> str:
+    text = str(target or "").strip()
+    if not text:
+        return ""
+    if text.startswith("git@github.com:"):
+        text = text.removeprefix("git@github.com:").strip()
+    elif "github.com/" in text:
+        text = text.split("github.com/", 1)[-1].strip()
+    text = text.split("#", 1)[0].split("?", 1)[0].strip().strip("/")
+    if text.endswith(".git"):
+        text = text[: -len(".git")].strip().strip("/")
+    parts = [part for part in text.split("/") if part]
+    if len(parts) >= 2:
+        return f"{parts[-2].lower()}/{parts[-1].lower()}"
+    return text.lower()
+
+
+def _workspace_identity_baseline(
+    *,
+    workspace_type: str,
+    workspace_target: str,
+    host_workdir: str,
+) -> str:
+    normalized_type = str(workspace_type or WORKSPACE_NONE).strip().lower()
+    target = str(workspace_target or "").strip()
+    legacy_workdir = str(host_workdir or "").strip()
+
+    if normalized_type == WORKSPACE_MOUNTED:
+        identity = os.path.abspath(os.path.expanduser(target)) if target else ""
+    elif normalized_type == WORKSPACE_CLONED:
+        identity = _normalize_repo_identity(target)
+    else:
+        identity = (
+            os.path.abspath(os.path.expanduser(legacy_workdir))
+            if legacy_workdir
+            else ""
+        )
+    return f"{normalized_type}\0{identity}"
+
+
+def build_preflight_identity_token(
+    *,
+    env_id: str,
+    workspace_type: str,
+    workspace_target: str,
+    host_workdir: str,
+) -> str:
+    hasher = hashlib.sha256()
+    hasher.update(str(env_id or "").encode("utf-8"))
+    hasher.update(b"\0")
+    baseline = _workspace_identity_baseline(
+        workspace_type=workspace_type,
+        workspace_target=workspace_target,
+        host_workdir=host_workdir,
+    )
+    hasher.update(baseline.encode("utf-8"))
+    return hasher.hexdigest()
+
+
+def derive_setup_agents_snapshot_key(*, env_id: str, identity_token: str) -> bytes:
+    hasher = hashlib.sha256()
+    hasher.update(str(env_id or "").encode("utf-8"))
+    hasher.update(b"\0")
+    hasher.update(str(identity_token or "").encode("utf-8"))
+    key_material = hasher.digest()
+    return base64.urlsafe_b64encode(key_material)
+
+
+def setup_agents_snapshot_hash(plaintext: str) -> str:
+    normalized = normalize_setup_agents_script_text(plaintext)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def encrypt_setup_agents_snapshot(
+    *,
+    env_id: str,
+    identity_token: str,
+    plaintext: str,
+) -> tuple[str, str]:
+    normalized = normalize_setup_agents_script_text(plaintext)
+    key = derive_setup_agents_snapshot_key(
+        env_id=env_id,
+        identity_token=identity_token,
+    )
+    ciphertext = Fernet(key).encrypt(normalized.encode("utf-8")).decode("utf-8")
+    return ciphertext, setup_agents_snapshot_hash(normalized)
+
+
+def decrypt_setup_agents_snapshot(
+    *,
+    env_id: str,
+    identity_token: str,
+    ciphertext: str,
+    expected_hash: str = "",
+) -> str | None:
+    env = str(env_id or "").strip()
+    token = str(identity_token or "").strip()
+    payload = str(ciphertext or "").strip()
+    if not env or not token or not payload:
+        return None
+    key = derive_setup_agents_snapshot_key(env_id=env, identity_token=token)
+    try:
+        plaintext = Fernet(key).decrypt(payload.encode("utf-8")).decode("utf-8")
+    except (InvalidToken, UnicodeDecodeError, ValueError):
+        return None
+
+    normalized = normalize_setup_agents_script_text(plaintext)
+    expected = normalize_setup_agents_snapshot_hash(expected_hash)
+    if expected and setup_agents_snapshot_hash(normalized) != expected:
+        return None
+    return normalized

--- a/agents_runner/environments/serialize.py
+++ b/agents_runner/environments/serialize.py
@@ -12,6 +12,8 @@ from .model import normalize_workspace_type
 from .model import PromptConfig
 from .model import AgentSelection
 from .model import AgentInstance
+from .preflight_snapshot import build_preflight_identity_token
+from .preflight_snapshot import normalize_setup_agents_snapshot_hash
 from .prompt_storage import save_prompt_to_file
 from .prompt_storage import load_prompt_from_file
 from .prompt_storage import delete_prompt_file
@@ -309,6 +311,23 @@ def environment_from_payload(payload: dict[str, Any]) -> Environment | None:
     # Normalize using the new function
     workspace_type = normalize_workspace_type(workspace_type)
 
+    preflight_identity_token = str(
+        payload.get("preflight_identity_token") or ""
+    ).strip()
+    if not preflight_identity_token:
+        preflight_identity_token = build_preflight_identity_token(
+            env_id=env_id,
+            workspace_type=workspace_type,
+            workspace_target=workspace_target,
+            host_workdir=host_workdir,
+        )
+    setup_agents_preflight_snapshot_ciphertext = str(
+        payload.get("setup_agents_preflight_snapshot_ciphertext") or ""
+    ).strip()
+    setup_agents_preflight_snapshot_sha256 = normalize_setup_agents_snapshot_hash(
+        payload.get("setup_agents_preflight_snapshot_sha256")
+    )
+
     try:
         midoriai_template_likelihood = float(
             payload.get("midoriai_template_likelihood", 0.0)
@@ -498,6 +517,9 @@ def environment_from_payload(payload: dict[str, Any]) -> Environment | None:
         cache_system_preflight_enabled=cache_system_preflight_enabled,
         cache_settings_preflight_enabled=cache_settings_preflight_enabled,
         cache_ide_preflight_enabled=cache_ide_preflight_enabled,
+        preflight_identity_token=preflight_identity_token,
+        setup_agents_preflight_snapshot_ciphertext=setup_agents_preflight_snapshot_ciphertext,
+        setup_agents_preflight_snapshot_sha256=setup_agents_preflight_snapshot_sha256,
         ide_safe_mode_by_system=ide_safe_mode_by_system,
         env_vars={str(k): str(v) for k, v in env_vars.items() if str(k).strip()},
         extra_mounts=[str(item) for item in extra_mounts if str(item).strip()],
@@ -572,13 +594,31 @@ def serialize_environment(env: Environment) -> dict[str, Any]:
     validated_allowlist = _validate_cross_agent_allowlist(
         env.cross_agent_allowlist, agents_list_for_validation
     )
+    workspace_type = normalize_workspace_type(getattr(env, "workspace_type", "none"))
+    workspace_target = str(getattr(env, "workspace_target", "") or "").strip()
+    host_workdir = str(getattr(env, "host_workdir", "") or "").strip()
+    preflight_identity_token = str(getattr(env, "preflight_identity_token", "") or "")
+    preflight_identity_token = preflight_identity_token.strip()
+    if not preflight_identity_token:
+        preflight_identity_token = build_preflight_identity_token(
+            env_id=str(getattr(env, "env_id", "") or ""),
+            workspace_type=workspace_type,
+            workspace_target=workspace_target,
+            host_workdir=host_workdir,
+        )
+    setup_agents_preflight_snapshot_ciphertext = str(
+        getattr(env, "setup_agents_preflight_snapshot_ciphertext", "") or ""
+    ).strip()
+    setup_agents_preflight_snapshot_sha256 = normalize_setup_agents_snapshot_hash(
+        getattr(env, "setup_agents_preflight_snapshot_sha256", "")
+    )
 
     return {
         "version": ENVIRONMENT_VERSION,
         "env_id": env.env_id,
         "name": env.name,
         "color": env.normalized_color(),
-        "host_workdir": env.host_workdir,
+        "host_workdir": host_workdir,
         "agent_cli_args": env.agent_cli_args,
         "max_agents_running": int(env.max_agents_running),
         "headless_desktop_enabled": bool(
@@ -604,6 +644,9 @@ def serialize_environment(env: Environment) -> dict[str, Any]:
         "cache_ide_preflight_enabled": bool(
             getattr(env, "cache_ide_preflight_enabled", False)
         ),
+        "preflight_identity_token": preflight_identity_token,
+        "setup_agents_preflight_snapshot_ciphertext": setup_agents_preflight_snapshot_ciphertext,
+        "setup_agents_preflight_snapshot_sha256": setup_agents_preflight_snapshot_sha256,
         "ide_safe_mode_by_system": _normalize_ide_safe_mode_map(
             getattr(env, "ide_safe_mode_by_system", {})
         ),
@@ -623,8 +666,8 @@ def serialize_environment(env: Environment) -> dict[str, Any]:
             getattr(env, "ports_advanced_acknowledged", False)
         ),
         "gh_management_locked": bool(env.gh_management_locked),
-        "workspace_type": env.workspace_type,
-        "workspace_target": str(env.workspace_target or "").strip(),
+        "workspace_type": workspace_type,
+        "workspace_target": workspace_target,
         "gh_last_base_branch": str(
             getattr(env, "gh_last_base_branch", "") or ""
         ).strip(),

--- a/agents_runner/gh/work_items.py
+++ b/agents_runner/gh/work_items.py
@@ -44,6 +44,9 @@ _TRANSIENT_GH_ERROR_MARKERS = (
     "context deadline exceeded",
 )
 
+_GITHUB_API_PER_PAGE_MAX = 100
+_REACTION_SCAN_LIMIT = 1000
+
 
 @dataclass(frozen=True)
 class GitHubReactionSummary:
@@ -330,6 +333,90 @@ def _repo_full_name(repo_owner: str, repo_name: str) -> str:
     return f"{owner}/{name}"
 
 
+def _with_api_pagination(path: str, *, page: int, per_page: int) -> str:
+    delimiter = "&" if "?" in path else "?"
+    return f"{path}{delimiter}per_page={max(1, int(per_page))}&page={max(1, int(page))}"
+
+
+def _list_api_rows_paginated(
+    path: str,
+    *,
+    limit: int,
+    keep_latest: bool = False,
+    timeout_s: float = 45.0,
+    retry_on_transient: bool = True,
+) -> list[object]:
+    safe_limit = max(1, int(limit))
+    per_page = min(_GITHUB_API_PER_PAGE_MAX, safe_limit)
+    rows: list[object] = []
+    page = 1
+
+    while True:
+        data = run_gh_gh_json_read(
+            [
+                "api",
+                _with_api_pagination(path, page=page, per_page=per_page),
+                "-H",
+                "Accept: application/vnd.github+json",
+            ],
+            timeout_s=timeout_s,
+            retry_on_transient=retry_on_transient,
+        )
+        page_rows = _as_object_list(data) or []
+        if not page_rows:
+            break
+        rows.extend(page_rows)
+        if keep_latest and len(rows) > safe_limit:
+            rows = rows[-safe_limit:]
+        if not keep_latest and len(rows) >= safe_limit:
+            break
+        if len(page_rows) < per_page:
+            break
+        page += 1
+
+    if keep_latest:
+        return rows
+    return rows[:safe_limit]
+
+
+def _has_actor_reaction_on_endpoint(
+    repo_owner: str,
+    repo_name: str,
+    *,
+    endpoint: str,
+    reaction: str,
+    actor_login: str,
+    limit: int = _REACTION_SCAN_LIMIT,
+    retry_on_transient: bool = True,
+) -> bool:
+    repo = _repo_full_name(repo_owner, repo_name)
+    content_value = _safe_text(reaction).lower()
+    if content_value not in {"+1", "-1", "eyes", "rocket", "hooray"}:
+        raise GhManagementError(f"unsupported reaction: {content_value}")
+    actor = _safe_text(actor_login).lower()
+    if not actor:
+        raise GhManagementError("missing actor login for reaction check")
+
+    rows = _list_api_rows_paginated(
+        f"repos/{repo}/{endpoint}",
+        limit=limit,
+        timeout_s=45.0,
+        retry_on_transient=retry_on_transient,
+    )
+    for row in rows:
+        row_dict = _as_object_dict(row)
+        if row_dict is None:
+            continue
+        content = _safe_text(row_dict.get("content")).lower()
+        if content != content_value:
+            continue
+        user_dict = _as_object_dict(row_dict.get("user"))
+        user_login = _safe_text(user_dict.get("login") if user_dict else "").lower()
+        if user_login == actor:
+            return True
+    return False
+
+
 def list_open_pull_requests(
     repo_owner: str,
     repo_name: str,
@@ -407,21 +494,17 @@ def list_issue_comments(
     *,
     issue_number: int,
     limit: int = 100,
+    newest_first: bool = False,
     retry_on_transient: bool = True,
 ) -> list[GitHubComment]:
     repo = _repo_full_name(repo_owner, repo_name)
-    data = run_gh_gh_json_read(
-        [
-            "api",
-            f"repos/{repo}/issues/{int(issue_number)}/comments?per_page={max(1, int(limit))}",
-            "-H",
-            "Accept: application/vnd.github+json",
-        ],
+    rows = _list_api_rows_paginated(
+        f"repos/{repo}/issues/{int(issue_number)}/comments",
+        limit=limit,
+        keep_latest=newest_first,
         timeout_s=45.0,
         retry_on_transient=retry_on_transient,
     )
-
-    rows = _as_object_list(data) or []
     comments: list[GitHubComment] = []
     for row in rows:
         row_dict = _as_object_dict(row)
@@ -457,24 +540,17 @@ def list_pull_request_review_comments(
     *,
     pull_number: int,
     limit: int = 100,
+    newest_first: bool = False,
     retry_on_transient: bool = True,
 ) -> list[GitHubComment]:
     repo = _repo_full_name(repo_owner, repo_name)
-    data = run_gh_gh_json_read(
-        [
-            "api",
-            (
-                f"repos/{repo}/pulls/{int(pull_number)}/comments?"
-                f"per_page={max(1, int(limit))}"
-            ),
-            "-H",
-            "Accept: application/vnd.github+json",
-        ],
+    rows = _list_api_rows_paginated(
+        f"repos/{repo}/pulls/{int(pull_number)}/comments",
+        limit=limit,
+        keep_latest=newest_first,
         timeout_s=45.0,
         retry_on_transient=retry_on_transient,
     )
-
-    rows = _as_object_list(data) or []
     comments: list[GitHubComment] = []
     for row in rows:
         row_dict = _as_object_dict(row)
@@ -510,24 +586,17 @@ def list_pull_request_reviews(
     *,
     pull_number: int,
     limit: int = 100,
+    newest_first: bool = False,
     retry_on_transient: bool = True,
 ) -> list[GitHubReview]:
     repo = _repo_full_name(repo_owner, repo_name)
-    data = run_gh_gh_json_read(
-        [
-            "api",
-            (
-                f"repos/{repo}/pulls/{int(pull_number)}/reviews?"
-                f"per_page={max(1, int(limit))}"
-            ),
-            "-H",
-            "Accept: application/vnd.github+json",
-        ],
+    rows = _list_api_rows_paginated(
+        f"repos/{repo}/pulls/{int(pull_number)}/reviews",
+        limit=limit,
+        keep_latest=newest_first,
         timeout_s=45.0,
         retry_on_transient=retry_on_transient,
     )
-
-    rows = _as_object_list(data) or []
     reviews: list[GitHubReview] = []
     for row in rows:
         row_dict = _as_object_dict(row)
@@ -829,6 +898,34 @@ def add_pull_request_review_comment_reaction(
     )
 
 
+def add_pull_request_review_reaction(
+    repo_owner: str,
+    repo_name: str,
+    *,
+    pull_number: int,
+    review_id: int,
+    reaction: str,
+) -> None:
+    repo = _repo_full_name(repo_owner, repo_name)
+    reaction_value = _safe_text(reaction)
+    if reaction_value not in {"+1", "-1", "eyes", "rocket", "hooray"}:
+        raise GhManagementError(f"unsupported reaction: {reaction_value}")
+
+    run_gh_gh_json(
+        [
+            "api",
+            "--method",
+            "POST",
+            f"repos/{repo}/pulls/{int(pull_number)}/reviews/{int(review_id)}/reactions",
+            "-H",
+            "Accept: application/vnd.github+json",
+            "-f",
+            f"content={reaction_value}",
+        ],
+        timeout_s=30.0,
+    )
+
+
 def add_issue_reaction(
     repo_owner: str,
     repo_name: str,
@@ -853,6 +950,91 @@ def add_issue_reaction(
             f"content={reaction_value}",
         ],
         timeout_s=30.0,
+    )
+
+
+def has_actor_issue_reaction(
+    repo_owner: str,
+    repo_name: str,
+    *,
+    issue_number: int,
+    reaction: str,
+    actor_login: str,
+    limit: int = _REACTION_SCAN_LIMIT,
+    retry_on_transient: bool = True,
+) -> bool:
+    return _has_actor_reaction_on_endpoint(
+        repo_owner,
+        repo_name,
+        endpoint=f"issues/{int(issue_number)}/reactions",
+        reaction=reaction,
+        actor_login=actor_login,
+        limit=limit,
+        retry_on_transient=retry_on_transient,
+    )
+
+
+def has_actor_issue_comment_reaction(
+    repo_owner: str,
+    repo_name: str,
+    *,
+    comment_id: int,
+    reaction: str,
+    actor_login: str,
+    limit: int = _REACTION_SCAN_LIMIT,
+    retry_on_transient: bool = True,
+) -> bool:
+    return _has_actor_reaction_on_endpoint(
+        repo_owner,
+        repo_name,
+        endpoint=f"issues/comments/{int(comment_id)}/reactions",
+        reaction=reaction,
+        actor_login=actor_login,
+        limit=limit,
+        retry_on_transient=retry_on_transient,
+    )
+
+
+def has_actor_pull_request_review_comment_reaction(
+    repo_owner: str,
+    repo_name: str,
+    *,
+    comment_id: int,
+    reaction: str,
+    actor_login: str,
+    limit: int = _REACTION_SCAN_LIMIT,
+    retry_on_transient: bool = True,
+) -> bool:
+    return _has_actor_reaction_on_endpoint(
+        repo_owner,
+        repo_name,
+        endpoint=f"pulls/comments/{int(comment_id)}/reactions",
+        reaction=reaction,
+        actor_login=actor_login,
+        limit=limit,
+        retry_on_transient=retry_on_transient,
+    )
+
+
+def has_actor_pull_request_review_reaction(
+    repo_owner: str,
+    repo_name: str,
+    *,
+    pull_number: int,
+    review_id: int,
+    reaction: str,
+    actor_login: str,
+    limit: int = _REACTION_SCAN_LIMIT,
+    retry_on_transient: bool = True,
+) -> bool:
+    return _has_actor_reaction_on_endpoint(
+        repo_owner,
+        repo_name,
+        endpoint=f"pulls/{int(pull_number)}/reviews/{int(review_id)}/reactions",
+        reaction=reaction,
+        actor_login=actor_login,
+        limit=limit,
+        retry_on_transient=retry_on_transient,
     )
 
 

--- a/agents_runner/ui/main_window_settings.py
+++ b/agents_runner/ui/main_window_settings.py
@@ -486,6 +486,62 @@ class MainWindowSettingsMixin:
 
         return agent_cli, config_dir, agent_id
 
+    def _commit_round_robin_selection(
+        self,
+        *,
+        env: Environment | None,
+        selected_agent_id: str,
+    ) -> None:
+        if (
+            env is None
+            or not env.agent_selection
+            or not getattr(env.agent_selection, "agents", None)
+        ):
+            return
+
+        mode = (
+            str(getattr(env.agent_selection, "selection_mode", "") or "round-robin")
+            .strip()
+            .lower()
+        )
+        if mode != "round-robin":
+            return
+
+        agents = list(env.agent_selection.agents or [])
+        if not agents:
+            return
+
+        env_id = str(getattr(env, "env_id", "") or "").strip()
+        if not env_id:
+            return
+
+        if not hasattr(self, "_agent_selection_round_robin_cursor"):
+            self._agent_selection_round_robin_cursor = {}
+        cursor_map = getattr(self, "_agent_selection_round_robin_cursor", {})
+
+        selected_id = str(selected_agent_id or "").strip()
+        selected_idx: int | None = None
+        if selected_id:
+            selected_lower = selected_id.lower()
+            for idx, inst in enumerate(agents):
+                inst_id = str(getattr(inst, "agent_id", "") or "").strip()
+                if inst_id == selected_id or inst_id.lower() == selected_lower:
+                    selected_idx = idx
+                    break
+
+        if selected_idx is None:
+            cursor = int(cursor_map.get(env_id, 0))
+            selected_idx = cursor % len(agents)
+
+        cursor_map[env_id] = selected_idx + 1
+
+    def _refresh_new_task_agent_info(self) -> None:
+        if not hasattr(self, "_new_task"):
+            return
+        env = self._environments.get(self._active_environment_id())
+        current_agent, next_agent = self._get_next_agent_info(env=env)
+        self._new_task.set_agent_info(agent=current_agent, next_agent=next_agent)
+
     def _effective_agent_and_config(
         self,
         *,

--- a/agents_runner/ui/main_window_task_events.py
+++ b/agents_runner/ui/main_window_task_events.py
@@ -299,6 +299,7 @@ class MainWindowTaskEventsMixin:
             self._dashboard.upsert_task(task, stain=stain, spinner_color=spinner)
             self._details.update_task(task)
             self._schedule_save()
+            self._refresh_new_task_agent_info()
 
             # SYNCHRONIZATION: Set finalization_state to "pending" BEFORE calling _queue_task_finalization().
             # This atomic state transition ensures recovery_tick sees the state change and avoids
@@ -441,6 +442,7 @@ class MainWindowTaskEventsMixin:
         self._dashboard_log_refresh_s.pop(task_id, None)
         self._interactive_watch.pop(task_id, None)
         self._schedule_save()
+        self._refresh_new_task_agent_info()
 
         if self._details.isVisible() and self._details.current_task_id() == task_id:
             self._show_dashboard()
@@ -880,6 +882,7 @@ class MainWindowTaskEventsMixin:
                 ),
             )
             self._try_start_queued_tasks()
+            self._refresh_new_task_agent_info()
 
             if (task.finalization_state or "").lower().strip() == "done":
                 self.host_log.emit(

--- a/agents_runner/ui/main_window_tasks_agent.py
+++ b/agents_runner/ui/main_window_tasks_agent.py
@@ -491,6 +491,12 @@ class MainWindowTasksAgentMixin:
         # Get effective agent and config dir (environment agent_selection overrides settings)
         agent_instance_id = ""
         selected_cli_flags = ""
+        uses_environment_agent_selection = bool(
+            not override
+            and env
+            and env.agent_selection
+            and getattr(env.agent_selection, "agents", None)
+        )
         if override:
             agent_cli = override.get("agent_cli", "")
             auto_config_dir = self._resolve_override_config_dir(
@@ -507,7 +513,7 @@ class MainWindowTasksAgentMixin:
                 self._select_agent_instance_for_env(
                     env=env,
                     settings=self._settings_data,
-                    advance_round_robin=True,
+                    advance_round_robin=False,
                 )
             )
         else:
@@ -720,6 +726,23 @@ class MainWindowTasksAgentMixin:
                         cli_flags=str(getattr(inst, "cli_flags", "") or "").strip(),
                     )
                 )
+            if (
+                selection_mode.strip().lower() in {"round-robin", "least-used"}
+                and agent_instance_id
+            ):
+                selected_lower = agent_instance_id.lower()
+                selected_index: int | None = None
+                for idx, inst in enumerate(resolved_agents):
+                    inst_id = str(getattr(inst, "agent_id", "") or "").strip()
+                    if (
+                        inst_id == agent_instance_id
+                        or inst_id.lower() == selected_lower
+                    ):
+                        selected_index = idx
+                        break
+                if selected_index is not None and selected_index > 0:
+                    selected_inst = resolved_agents.pop(selected_index)
+                    resolved_agents.insert(0, selected_inst)
             resolved_agent_selection = AgentSelection(
                 agents=resolved_agents,
                 selection_mode=selection_mode,
@@ -753,6 +776,11 @@ class MainWindowTasksAgentMixin:
             except ValueError as exc:
                 QMessageBox.warning(self, "Invalid agent CLI flags", str(exc))
                 return
+        if uses_environment_agent_selection:
+            self._commit_round_robin_selection(
+                env=env,
+                selected_agent_id=agent_instance_id,
+            )
 
         settings_preflight_script: str | None = None
         if (
@@ -1148,6 +1176,7 @@ class MainWindowTasksAgentMixin:
             self._dashboard.upsert_task(task, stain=stain, spinner_color=spinner)
             self._schedule_save()
 
+        self._refresh_new_task_agent_info()
         self._maybe_auto_navigate_on_task_start(interactive=False)
         self._new_task.reset_for_new_run()
         return task_id

--- a/agents_runner/ui/main_window_tasks_interactive.py
+++ b/agents_runner/ui/main_window_tasks_interactive.py
@@ -230,6 +230,12 @@ class MainWindowTasksInteractiveMixin:
             prompt = ""
         else:
             override = self._coerce_agent_override(agent_override)
+            uses_environment_agent_selection = bool(
+                not override
+                and env
+                and env.agent_selection
+                and getattr(env.agent_selection, "agents", None)
+            )
 
             if (
                 not override
@@ -292,7 +298,7 @@ class MainWindowTasksInteractiveMixin:
                     self._select_agent_instance_for_env(
                         env=env,
                         settings=self._settings_data,
-                        advance_round_robin=True,
+                        advance_round_robin=False,
                     )
                 )
             else:
@@ -346,6 +352,11 @@ class MainWindowTasksInteractiveMixin:
                     workspace_type=workspace_type,
                     env=env,
                     task_id=task_id,
+                )
+            if uses_environment_agent_selection:
+                self._commit_round_robin_selection(
+                    env=env,
+                    selected_agent_id=agent_instance_id,
                 )
 
         image = PIXELARCH_EMERALD_IMAGE
@@ -402,6 +413,7 @@ class MainWindowTasksInteractiveMixin:
         stain = env.color if env else None
         spinner = stain_color(env.color) if env else None
         self._dashboard.upsert_task(task, stain=stain, spinner_color=spinner)
+        self._refresh_new_task_agent_info()
         self._schedule_save()
 
         if env:
@@ -642,6 +654,7 @@ class MainWindowTasksInteractiveMixin:
             format_log("ui", "prep", "ERROR", task.error),
         )
         self._refresh_interactive_prep_task_card(task)
+        self._refresh_new_task_agent_info()
         self._clear_interactive_prep_refs(task_id)
 
     def _on_interactive_prep_succeeded(

--- a/agents_runner/ui/main_window_tasks_interactive_docker.py
+++ b/agents_runner/ui/main_window_tasks_interactive_docker.py
@@ -684,6 +684,7 @@ def _prepare_preflight_scripts(
             skip: bool,
             env_var: str,
             to_desktop_start: bool = False,
+            continue_on_error: bool = False,
         ) -> None:
             nonlocal preflight_clause, desktop_start_clause
             if skip:
@@ -691,6 +692,24 @@ def _prepare_preflight_scripts(
             stripped = str(script or "").strip()
             if not stripped:
                 return
+
+            run_clause = (
+                "set +e; "
+                f'/bin/bash "${{{env_var}}}"; '
+                "PHASE_EXIT=$?; "
+                "set -e; "
+                'if [ "$PHASE_EXIT" -ne 0 ]; then '
+                f'echo "[docker/preflight][ERROR] {label}: failed (exit $PHASE_EXIT); continuing startup"; '
+                "else "
+                f"{shell_log_statement('docker', 'preflight', 'INFO', f'{label}: done')}; "
+                "fi; "
+                if continue_on_error
+                else (
+                    f'/bin/bash "${{{env_var}}}"; '
+                    f"{shell_log_statement('docker', 'preflight', 'INFO', f'{label}: done')}; "
+                )
+            )
+
             matched = next(
                 (
                     name
@@ -703,8 +722,7 @@ def _prepare_preflight_scripts(
                 clause = (
                     f'{env_var}="${{PREFLIGHTS_DIR}}/{matched}"; '
                     f"{shell_log_statement('docker', 'preflight', 'INFO', f'{label}: running')}; "
-                    f'/bin/bash "${{{env_var}}}"; '
-                    f"{shell_log_statement('docker', 'preflight', 'INFO', f'{label}: done')}; "
+                    f"{run_clause}"
                 )
                 if to_desktop_start:
                     desktop_start_clause += clause
@@ -717,8 +735,7 @@ def _prepare_preflight_scripts(
             clause = (
                 f"{env_var}={shlex.quote(container_path)}; "
                 f"{shell_log_statement('docker', 'preflight', 'INFO', f'{label}: running')}; "
-                f'/bin/bash "${{{env_var}}}"; '
-                f"{shell_log_statement('docker', 'preflight', 'INFO', f'{label}: done')}; "
+                f"{run_clause}"
             )
             if to_desktop_start:
                 desktop_start_clause += clause
@@ -756,6 +773,7 @@ def _prepare_preflight_scripts(
             tmp_key="setup_agents",
             skip=skip_setup_agents,
             env_var="PREFLIGHT_SETUP_AGENTS",
+            continue_on_error=True,
         )
         _append_optional_phase(
             label="desktop-start",
@@ -887,8 +905,8 @@ def _build_host_shell_script(
 
     host_script_parts.extend(
         [
-            f'{docker_pull_cmd} || {{ STATUS=$?; {shell_log_statement("host", "docker", "ERROR", "docker pull failed (exit $STATUS)")}; write_finish "$STATUS"; read -r -p "Press Enter to close..."; exit $STATUS; }}',
-            f'{docker_cmd}; STATUS=$?; if [ $STATUS -ne 0 ]; then {shell_log_statement("host", "docker", "ERROR", "container command failed (exit $STATUS)")}; fi; write_finish "$STATUS"; if [ $STATUS -ne 0 ]; then read -r -p "Press Enter to close..."; fi; exit $STATUS',
+            f'{docker_pull_cmd} || {{ STATUS=$?; echo "[host/docker][ERROR] docker pull failed (exit $STATUS)"; write_finish "$STATUS"; read -r -p "Press Enter to close..."; exit $STATUS; }}',
+            f'{docker_cmd}; STATUS=$?; if [ $STATUS -ne 0 ]; then echo "[host/docker][ERROR] container command failed (exit $STATUS)"; fi; write_finish "$STATUS"; if [ $STATUS -ne 0 ]; then read -r -p "Press Enter to close..."; fi; exit $STATUS',
         ]
     )
 

--- a/agents_runner/ui/main_window_tasks_interactive_finalize.py
+++ b/agents_runner/ui/main_window_tasks_interactive_finalize.py
@@ -75,6 +75,7 @@ class MainWindowTasksInteractiveFinalizeMixin:
         self._dashboard.upsert_task(task, stain=stain, spinner_color=spinner)
         self._details.update_task(task)
         self._schedule_save()
+        self._refresh_new_task_agent_info()
         QApplication.beep()
         self._on_task_log(
             task_id,

--- a/agents_runner/ui/pages/environments.py
+++ b/agents_runner/ui/pages/environments.py
@@ -19,6 +19,15 @@ from agents_runner.environments import Environment
 from agents_runner.environments import WORKSPACE_CLONED
 from agents_runner.environments import WORKSPACE_MOUNTED
 from agents_runner.environments import WORKSPACE_NONE
+from agents_runner.environments import managed_repo_checkout_path
+from agents_runner.environments import save_environment
+from agents_runner.environments.preflight_snapshot import (
+    build_preflight_identity_token,
+    decrypt_setup_agents_snapshot,
+    encrypt_setup_agents_snapshot,
+    normalize_setup_agents_snapshot_hash,
+    setup_agents_snapshot_hash,
+)
 from agents_runner.gh_management import is_gh_available
 from agents_runner.persistence import default_state_path
 from agents_runner.setup_agents import resolve_setup_agents_preview
@@ -518,6 +527,92 @@ class EnvironmentsPage(
             return os.path.relpath(candidate, root)
         return candidate
 
+    @staticmethod
+    def _setup_agents_preview_workdir(env: Environment) -> str:
+        workspace_type = str(getattr(env, "workspace_type", "") or "")
+        if workspace_type == WORKSPACE_MOUNTED:
+            candidate = str(getattr(env, "workspace_target", "") or "").strip()
+        elif workspace_type == WORKSPACE_CLONED:
+            candidate = managed_repo_checkout_path(
+                env.env_id, data_dir=os.path.dirname(default_state_path())
+            )
+        else:
+            candidate = str(getattr(env, "host_workdir", "") or "").strip()
+        candidate = os.path.expanduser(candidate) if candidate else ""
+        return candidate or os.getcwd()
+
+    @staticmethod
+    def _load_direct_setup_agents_script(path: str | None) -> str | None:
+        script_path = str(path or "").strip()
+        if not script_path:
+            return None
+        try:
+            with open(script_path, "r", encoding="utf-8") as handle:
+                return handle.read()
+        except Exception:
+            return None
+
+    @staticmethod
+    def _ensure_preflight_identity_token(env: Environment) -> tuple[str, bool]:
+        token = str(getattr(env, "preflight_identity_token", "") or "").strip()
+        if token:
+            return token, False
+        token = build_preflight_identity_token(
+            env_id=str(getattr(env, "env_id", "") or ""),
+            workspace_type=str(getattr(env, "workspace_type", "") or ""),
+            workspace_target=str(getattr(env, "workspace_target", "") or ""),
+            host_workdir=str(getattr(env, "host_workdir", "") or ""),
+        )
+        env.preflight_identity_token = token
+        return token, True
+
+    @staticmethod
+    def _persist_environment(env: Environment) -> None:
+        try:
+            save_environment(env)
+        except Exception:
+            pass
+
+    def _snapshot_setup_agents_script(self, env: Environment, script: str) -> None:
+        plaintext_hash = setup_agents_snapshot_hash(script)
+        stored_hash = normalize_setup_agents_snapshot_hash(
+            getattr(env, "setup_agents_preflight_snapshot_sha256", "")
+        )
+        stored_ciphertext = str(
+            getattr(env, "setup_agents_preflight_snapshot_ciphertext", "") or ""
+        ).strip()
+        identity_token, token_created = self._ensure_preflight_identity_token(env)
+
+        if plaintext_hash == stored_hash and stored_ciphertext:
+            if token_created:
+                self._persist_environment(env)
+            return
+
+        ciphertext, normalized_hash = encrypt_setup_agents_snapshot(
+            env_id=env.env_id,
+            identity_token=identity_token,
+            plaintext=script,
+        )
+        env.setup_agents_preflight_snapshot_ciphertext = ciphertext
+        env.setup_agents_preflight_snapshot_sha256 = normalized_hash
+        self._persist_environment(env)
+
+    def _load_encrypted_setup_agents_snapshot(self, env: Environment) -> str | None:
+        identity_token, token_created = self._ensure_preflight_identity_token(env)
+        snapshot = decrypt_setup_agents_snapshot(
+            env_id=env.env_id,
+            identity_token=identity_token,
+            ciphertext=str(
+                getattr(env, "setup_agents_preflight_snapshot_ciphertext", "") or ""
+            ),
+            expected_hash=str(
+                getattr(env, "setup_agents_preflight_snapshot_sha256", "") or ""
+            ),
+        )
+        if token_created:
+            self._persist_environment(env)
+        return snapshot
+
     def _refresh_setup_agents_preview(self, env: Environment | None) -> None:
         if env is None:
             self._setup_agents_preview.setPlainText("")
@@ -528,17 +623,14 @@ class EnvironmentsPage(
             return
 
         workspace_type = str(getattr(env, "workspace_type", "") or "")
-        if workspace_type == WORKSPACE_MOUNTED:
-            host_workdir = str(getattr(env, "workspace_target", "") or "").strip()
-        else:
-            host_workdir = str(self._settings_data.get("host_workdir") or "").strip()
-        host_workdir = os.path.expanduser(host_workdir) if host_workdir else os.getcwd()
+        host_workdir = self._setup_agents_preview_workdir(env)
 
         gh_repo: str | None = None
         if workspace_type == WORKSPACE_CLONED:
             candidate = str(getattr(env, "workspace_target", "") or "").strip()
             gh_repo = candidate or None
 
+        preview = None
         try:
             preview = resolve_setup_agents_preview(
                 host_workdir=host_workdir,
@@ -547,26 +639,32 @@ class EnvironmentsPage(
                 data_dir=os.path.dirname(default_state_path()),
             )
         except Exception:
-            self._setup_agents_preview.setPlainText("")
-            self._setup_agents_preview.setToolTip(
-                "Create in repo: .agents/setup-agents.sh"
-            )
-            self._setup_agents_preview_highlighter.set_language("bash")
-            return
+            preview = None
 
-        repo_edit_path = self._path_label(
-            repo_root=preview.repo_root,
-            path=preview.preferred_repo_script_path,
-        )
+        repo_edit_path = ".agents/setup-agents.sh"
+        if preview is not None:
+            repo_edit_path = self._path_label(
+                repo_root=preview.repo_root,
+                path=preview.preferred_repo_script_path,
+            )
         if not repo_edit_path:
             repo_edit_path = ".agents/setup-agents.sh"
-        if preview.repo_script_path:
+
+        direct_script = self._load_direct_setup_agents_script(
+            preview.repo_script_path if preview is not None else None
+        )
+        if direct_script is not None:
+            preview_text = direct_script
             tooltip = f"Edit in repo: {repo_edit_path}"
+            self._snapshot_setup_agents_script(env, direct_script)
         else:
-            tooltip = f"Create in repo: {repo_edit_path}"
+            preview_text = str(self._load_encrypted_setup_agents_snapshot(env) or "")
+            if preview_text:
+                tooltip = f"Create in repo: {repo_edit_path} (showing saved snapshot)"
+            else:
+                tooltip = f"Create in repo: {repo_edit_path}"
         self._setup_agents_preview.setToolTip(tooltip)
 
-        preview_text = str(preview.setup_script or "")
         self._setup_agents_preview.setPlainText(preview_text)
         if preview_text.strip():
             self._setup_agents_preview_highlighter.set_language(

--- a/agents_runner/ui/pages/github_work_coordinator.py
+++ b/agents_runner/ui/pages/github_work_coordinator.py
@@ -15,12 +15,17 @@ from PySide6.QtCore import Signal
 from agents_runner.environments import Environment
 from agents_runner.environments import GitHubRepoContext
 from agents_runner.environments import resolve_environment_github_repo
-from agents_runner.gh.work_items import AUTO_REVIEW_MARKER_TOKEN
 from agents_runner.gh.work_items import GitHubComment
 from agents_runner.gh.work_items import GitHubWorkItem
 from agents_runner.gh.work_items import add_issue_comment_reaction
 from agents_runner.gh.work_items import add_issue_reaction
 from agents_runner.gh.work_items import add_pull_request_review_comment_reaction
+from agents_runner.gh.work_items import add_pull_request_review_reaction
+from agents_runner.gh.work_items import get_authenticated_github_login
+from agents_runner.gh.work_items import has_actor_issue_comment_reaction
+from agents_runner.gh.work_items import has_actor_issue_reaction
+from agents_runner.gh.work_items import has_actor_pull_request_review_comment_reaction
+from agents_runner.gh.work_items import has_actor_pull_request_review_reaction
 from agents_runner.gh.work_items import list_issue_comments
 from agents_runner.gh.work_items import list_open_issues
 from agents_runner.gh.work_items import list_open_pull_requests
@@ -56,6 +61,7 @@ class GitHubWorkCoordinator(QObject):
     _cycle_finished = Signal()
 
     _CACHE_TTL_S = 45.0
+    _AUTO_REVIEW_THREAD_SCAN_LIMIT = 300
 
     def __init__(self, parent: QObject | None = None) -> None:
         super().__init__(parent)
@@ -563,7 +569,16 @@ class GitHubWorkCoordinator(QObject):
         )
         if not trusted_users:
             return []
-
+        bot_login = get_authenticated_github_login()
+        if not bot_login:
+            logger.rprint(
+                (
+                    "[github-auto-review] skipped auto-start scan: failed to resolve "
+                    "authenticated GitHub login for eyes gating."
+                ),
+                mode="warn",
+            )
+            return []
         auto_reactions_enabled = bool(
             self._settings.get("agentsnova_auto_reactions_enabled", True)
         )
@@ -588,19 +603,15 @@ class GitHubWorkCoordinator(QObject):
                 repo_owner,
                 repo_name,
                 issue_number=item.number,
-                limit=100,
+                limit=self._AUTO_REVIEW_THREAD_SCAN_LIMIT,
+                newest_first=True,
             )
-            (
-                marker_created_at_s,
-                marker_comment_id,
-            ) = self._latest_marker_checkpoint(comments)
             candidates: list[dict[str, object]] = []
 
             def _add_comment_candidate(
                 comment: GitHubComment,
                 *,
                 source: str,
-                allow_id_compare: bool,
             ) -> None:
                 if not self._is_trusted_comment_author(comment, trusted_users):
                     return
@@ -608,14 +619,6 @@ class GitHubWorkCoordinator(QObject):
                     return
                 mention_created_at = str(comment.created_at or "")
                 mention_created_at_s = self._parse_iso_timestamp_s(mention_created_at)
-                mention_comment_id = comment.comment_id if allow_id_compare else 0
-                if not self._is_mention_newer_than_marker(
-                    mention_created_at_s=mention_created_at_s,
-                    mention_comment_id=mention_comment_id,
-                    marker_created_at_s=marker_created_at_s,
-                    marker_comment_id=marker_comment_id,
-                ):
-                    return
                 mention_key = f"{source}:{comment.comment_id}"
                 candidates.append(
                     {
@@ -628,6 +631,7 @@ class GitHubWorkCoordinator(QObject):
                         "created_at_s": mention_created_at_s or 0.0,
                         "sort_id": comment.comment_id,
                         "comment": comment,
+                        "anchor_id": comment.comment_id,
                     }
                 )
 
@@ -635,7 +639,6 @@ class GitHubWorkCoordinator(QObject):
                 _add_comment_candidate(
                     comment,
                     source="issue_comment",
-                    allow_id_compare=True,
                 )
 
             if item.item_type == "pr":
@@ -643,20 +646,21 @@ class GitHubWorkCoordinator(QObject):
                     repo_owner,
                     repo_name,
                     pull_number=item.number,
-                    limit=100,
+                    limit=self._AUTO_REVIEW_THREAD_SCAN_LIMIT,
+                    newest_first=True,
                 )
                 for comment in review_comments:
                     _add_comment_candidate(
                         comment,
                         source="review_comment",
-                        allow_id_compare=False,
                     )
 
                 review_bodies = list_pull_request_reviews(
                     repo_owner,
                     repo_name,
                     pull_number=item.number,
-                    limit=100,
+                    limit=self._AUTO_REVIEW_THREAD_SCAN_LIMIT,
+                    newest_first=True,
                 )
                 for review in review_bodies:
                     author = str(review.author or "").strip().lower()
@@ -668,13 +672,6 @@ class GitHubWorkCoordinator(QObject):
                     mention_created_at_s = self._parse_iso_timestamp_s(
                         mention_created_at
                     )
-                    if not self._is_mention_newer_than_marker(
-                        mention_created_at_s=mention_created_at_s,
-                        mention_comment_id=0,
-                        marker_created_at_s=marker_created_at_s,
-                        marker_comment_id=marker_comment_id,
-                    ):
-                        continue
                     mention_key = f"review_body:{review.review_id}"
                     candidates.append(
                         {
@@ -686,6 +683,7 @@ class GitHubWorkCoordinator(QObject):
                             "mention_url": str(review.url or ""),
                             "created_at_s": mention_created_at_s or 0.0,
                             "sort_id": review.review_id,
+                            "anchor_id": review.review_id,
                         }
                     )
 
@@ -702,27 +700,22 @@ class GitHubWorkCoordinator(QObject):
                     mention_created_at_s = self._parse_iso_timestamp_s(
                         mention_created_at
                     )
-                    if self._is_mention_newer_than_marker(
-                        mention_created_at_s=mention_created_at_s,
-                        mention_comment_id=0,
-                        marker_created_at_s=marker_created_at_s,
-                        marker_comment_id=marker_comment_id,
-                    ):
-                        source = "pr_body" if item.item_type == "pr" else "issue_body"
-                        mention_key = f"{source}:{item_key}"
-                        mention_author = str(getattr(item, "author", "") or "")
-                        candidates.append(
-                            {
-                                "source": source,
-                                "mention_key": mention_key,
-                                "mention_text": str(mention_text or ""),
-                                "mention_author": mention_author,
-                                "mention_created_at": mention_created_at,
-                                "mention_url": str(item.url or ""),
-                                "created_at_s": mention_created_at_s or 0.0,
-                                "sort_id": item.number,
-                            }
-                        )
+                    source = "pr_body" if item.item_type == "pr" else "issue_body"
+                    mention_key = f"{source}:{item_key}"
+                    mention_author = str(getattr(item, "author", "") or "")
+                    candidates.append(
+                        {
+                            "source": source,
+                            "mention_key": mention_key,
+                            "mention_text": str(mention_text or ""),
+                            "mention_author": mention_author,
+                            "mention_created_at": mention_created_at,
+                            "mention_url": str(item.url or ""),
+                            "created_at_s": mention_created_at_s or 0.0,
+                            "sort_id": item.number,
+                            "anchor_id": item.number,
+                        }
+                    )
 
             if not candidates:
                 continue
@@ -744,46 +737,47 @@ class GitHubWorkCoordinator(QObject):
                     continue
 
                 source = str(candidate.get("source") or "").strip().lower()
-                comment = candidate.get("comment")
+                try:
+                    bot_has_eyes = self._anchor_has_bot_eyes(
+                        repo_owner=repo_owner,
+                        repo_name=repo_name,
+                        item_number=item.number,
+                        source=source,
+                        anchor_id=candidate.get("anchor_id"),
+                        bot_login=bot_login,
+                    )
+                except Exception as exc:
+                    logger.rprint(
+                        (
+                            "[github-auto-review] skipped auto-start: failed to read "
+                            f"eyes reaction on {repo_owner}/{repo_name} "
+                            f"{item.item_type} #{item.number} ({source}): {exc}"
+                        ),
+                        mode="warn",
+                    )
+                    continue
+                if bot_has_eyes:
+                    continue
+
                 if auto_reactions_enabled:
-                    if (
-                        source == "issue_comment"
-                        and isinstance(comment, GitHubComment)
-                        and self._can_apply_reaction(comment=comment)
-                    ):
-                        try:
-                            add_issue_comment_reaction(
-                                repo_owner,
-                                repo_name,
-                                comment_id=comment.comment_id,
-                                reaction="eyes",
-                            )
-                        except Exception:
-                            pass
-                    if (
-                        source == "review_comment"
-                        and isinstance(comment, GitHubComment)
-                        and self._can_apply_reaction(comment=comment)
-                    ):
-                        try:
-                            add_pull_request_review_comment_reaction(
-                                repo_owner,
-                                repo_name,
-                                comment_id=comment.comment_id,
-                                reaction="eyes",
-                            )
-                        except Exception:
-                            pass
-                    if source in {"pr_body", "issue_body"}:
-                        try:
-                            add_issue_reaction(
-                                repo_owner,
-                                repo_name,
-                                issue_number=item.number,
-                                reaction="eyes",
-                            )
-                        except Exception:
-                            pass
+                    try:
+                        self._add_anchor_eyes_reaction(
+                            repo_owner=repo_owner,
+                            repo_name=repo_name,
+                            item_number=item.number,
+                            source=source,
+                            anchor_id=candidate.get("anchor_id"),
+                        )
+                    except Exception as exc:
+                        logger.rprint(
+                            (
+                                "[github-auto-review] skipped auto-start: failed to add "
+                                f"eyes reaction on {repo_owner}/{repo_name} "
+                                f"{item.item_type} #{item.number} ({source}): {exc}"
+                            ),
+                            mode="warn",
+                        )
+                        continue
 
                 results.append(
                     {
@@ -812,79 +806,120 @@ class GitHubWorkCoordinator(QObject):
 
         return results
 
-    @classmethod
-    def _latest_marker_checkpoint(
-        cls, comments: list[GitHubComment]
-    ) -> tuple[float | None, int]:
-        marker_created_at_s: float | None = None
-        marker_comment_id = 0
-
-        for comment in comments:
-            body = str(comment.body or "")
-            if AUTO_REVIEW_MARKER_TOKEN not in body:
-                continue
-
-            comment_created_at_s = cls._parse_iso_timestamp_s(comment.created_at)
-            try:
-                comment_id = max(0, int(comment.comment_id))
-            except Exception:
-                comment_id = 0
-
-            if marker_created_at_s is None and comment_created_at_s is None:
-                if comment_id > marker_comment_id:
-                    marker_comment_id = comment_id
-                continue
-
-            if marker_created_at_s is None and comment_created_at_s is not None:
-                marker_created_at_s = comment_created_at_s
-                marker_comment_id = comment_id
-                continue
-
-            if marker_created_at_s is not None and comment_created_at_s is None:
-                continue
-
-            if comment_created_at_s is None:
-                continue
-
-            current_marker_created_at_s = marker_created_at_s
-            if current_marker_created_at_s is None:
-                continue
-
-            if comment_created_at_s > current_marker_created_at_s or (
-                comment_created_at_s == current_marker_created_at_s
-                and comment_id > marker_comment_id
-            ):
-                marker_created_at_s = comment_created_at_s
-                marker_comment_id = comment_id
-
-        return marker_created_at_s, marker_comment_id
-
     @staticmethod
-    def _is_mention_newer_than_marker(
+    def _safe_positive_int(value: object) -> int:
+        try:
+            parsed = int(value or 0)
+        except Exception:
+            return 0
+        return parsed if parsed > 0 else 0
+
+    def _anchor_has_bot_eyes(
+        self,
         *,
-        mention_created_at_s: float | None,
-        mention_comment_id: int,
-        marker_created_at_s: float | None,
-        marker_comment_id: int,
+        repo_owner: str,
+        repo_name: str,
+        item_number: int,
+        source: str,
+        anchor_id: object,
+        bot_login: str,
     ) -> bool:
-        if marker_created_at_s is None and marker_comment_id <= 0:
-            return True
+        if source == "issue_comment":
+            comment_id = self._safe_positive_int(anchor_id)
+            if comment_id <= 0:
+                raise ValueError("invalid issue comment anchor id")
+            return has_actor_issue_comment_reaction(
+                repo_owner,
+                repo_name,
+                comment_id=comment_id,
+                reaction="eyes",
+                actor_login=bot_login,
+            )
+        if source == "review_comment":
+            comment_id = self._safe_positive_int(anchor_id)
+            if comment_id <= 0:
+                raise ValueError("invalid review comment anchor id")
+            return has_actor_pull_request_review_comment_reaction(
+                repo_owner,
+                repo_name,
+                comment_id=comment_id,
+                reaction="eyes",
+                actor_login=bot_login,
+            )
+        if source == "review_body":
+            review_id = self._safe_positive_int(anchor_id)
+            if review_id <= 0:
+                raise ValueError("invalid review anchor id")
+            return has_actor_pull_request_review_reaction(
+                repo_owner,
+                repo_name,
+                pull_number=item_number,
+                review_id=review_id,
+                reaction="eyes",
+                actor_login=bot_login,
+            )
+        if source in {"pr_body", "issue_body"}:
+            return has_actor_issue_reaction(
+                repo_owner,
+                repo_name,
+                issue_number=item_number,
+                reaction="eyes",
+                actor_login=bot_login,
+            )
+        raise ValueError(f"unsupported mention source: {source}")
 
-        if marker_created_at_s is None:
-            if mention_comment_id > 0:
-                return mention_comment_id > marker_comment_id
-            return True
-
-        if mention_created_at_s is None:
-            return True
-
-        if mention_created_at_s > marker_created_at_s:
-            return True
-        if mention_created_at_s < marker_created_at_s:
-            return False
-        if mention_comment_id > 0 and marker_comment_id > 0:
-            return mention_comment_id > marker_comment_id
-        return False
+    def _add_anchor_eyes_reaction(
+        self,
+        *,
+        repo_owner: str,
+        repo_name: str,
+        item_number: int,
+        source: str,
+        anchor_id: object,
+    ) -> None:
+        if source == "issue_comment":
+            comment_id = self._safe_positive_int(anchor_id)
+            if comment_id <= 0:
+                raise ValueError("invalid issue comment anchor id")
+            add_issue_comment_reaction(
+                repo_owner,
+                repo_name,
+                comment_id=comment_id,
+                reaction="eyes",
+            )
+            return
+        if source == "review_comment":
+            comment_id = self._safe_positive_int(anchor_id)
+            if comment_id <= 0:
+                raise ValueError("invalid review comment anchor id")
+            add_pull_request_review_comment_reaction(
+                repo_owner,
+                repo_name,
+                comment_id=comment_id,
+                reaction="eyes",
+            )
+            return
+        if source == "review_body":
+            review_id = self._safe_positive_int(anchor_id)
+            if review_id <= 0:
+                raise ValueError("invalid review anchor id")
+            add_pull_request_review_reaction(
+                repo_owner,
+                repo_name,
+                pull_number=item_number,
+                review_id=review_id,
+                reaction="eyes",
+            )
+            return
+        if source in {"pr_body", "issue_body"}:
+            add_issue_reaction(
+                repo_owner,
+                repo_name,
+                issue_number=item_number,
+                reaction="eyes",
+            )
+            return
+        raise ValueError(f"unsupported mention source: {source}")
 
     @staticmethod
     def _parse_iso_timestamp_s(value: object) -> float | None:
@@ -915,10 +950,6 @@ class GitHubWorkCoordinator(QObject):
     ) -> bool:
         author = str(getattr(item, "author", "") or "").strip().lower()
         return bool(author and author in trusted_users)
-
-    @staticmethod
-    def _can_apply_reaction(*, comment: GitHubComment) -> bool:
-        return comment.reactions.eyes <= 0
 
     @staticmethod
     def _normalize_item_type(value: object) -> str:


### PR DESCRIPTION
## Summary
- Fix auto-start safety for GitHub issues/PRs by gating scheduling on bot `eyes` reaction presence at the exact mention anchor.
- Fix round-robin/least-used behavior across both Normal and Interactive routes by deferring RR commit until launch commit-time and refreshing New Task pick info on lifecycle events.
- Fix environment preflight preview source to selected environment context and add encrypted same-env setup-agents snapshot fallback in env settings.
- Make `setup-agents` preflight non-blocking during startup in both non-interactive and interactive launch flows while keeping other preflight phases strict.

## Commits
- `[FIX] Make setup-agents preflight non-blocking at startup` (`1181e82`)
- `[FIX] Sync agent selection state across normal and interactive launches` (`5b8474d`)
- `[FIX] Bind preflight preview and encrypted snapshot to selected env` (`64d04d3`)
- `[FIX] Gate auto-start scheduling by anchor eyes reactions` (`ad1f745`)

## Validation
- `uv run ruff format` on touched files
- `uv run ruff check` on touched files
- `uv run python -m py_compile` on touched files
- `uv run basedpyright` on touched files (fails with pre-existing baseline strict typing errors in UI mixin modules; no new blocker surfaced from these changes)

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
