### PR TITLE
Fix setup-agents prompt for repo-root container-only setup

### DIFF
--- a/agents_runner/setup_agents.py
+++ b/agents_runner/setup_agents.py
@@ -149,9 +149,9 @@ def _missing_instruction() -> str:
         "Repository bootstrap is missing. Create `.agents/setup-agents.sh`, "
         "make it executable, and commit it. `setup-agents.sh` is always executed "
         "from the repository root. The script must only prepare/setup the agent "
-        "container so it is ready for use, with no unrelated repository setup. "
+        "container so it is ready for use; do not perform repository setup. "
         "Environment is PixelArch: package installs must use `yay -Syu` only; "
-        "never `pacman`; never `yay -S`."
+        "never `pacman`; never plain `yay -S`."
     )
 
 

--- a/agents_runner/setup_agents.py
+++ b/agents_runner/setup_agents.py
@@ -145,7 +145,14 @@ def _write_script(path: Path, text: str, *, executable: bool) -> bool:
 
 
 def _missing_instruction() -> str:
-    return "Repository bootstrap is missing. Create `.agents/setup-agents.sh`, make it executable, add your setup steps, then commit the file to the repository."
+    return (
+        "Repository bootstrap is missing. Create `.agents/setup-agents.sh`, "
+        "make it executable, and commit it. `setup-agents.sh` is always executed "
+        "from the repository root. The script must only prepare/setup the agent "
+        "container so it is ready for use, with no unrelated repository setup. "
+        "Environment is PixelArch: package installs must use `yay -Syu` only; "
+        "never `pacman`; never `yay -S`."
+    )
 
 
 def _setup_agents_metadata_root() -> Path:


### PR DESCRIPTION
## Summary
- clarified setup-agents prompt so `setup-agents.sh` is always run from repository root
- constrained script purpose to agent container setup only (no repository setup)
- made goal explicit: get the container ready for agent use
- enforced PixelArch package guidance in prompt: use `yay -Syu` only; never `pacman`; never plain `yay -S`

## Validation
- performed multiple independent sub-agent review passes between edits
- applied one additional wording-tightening edit from review feedback
- completed control-folder and audit/root-file cleanup checks

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
