### PR TITLE
[FIX] Rebuild interactive commands from plugins

### DIFF
--- a/agents_runner/agent_systems/copilot/plugin.py
+++ b/agents_runner/agent_systems/copilot/plugin.py
@@ -17,6 +17,16 @@ from agents_runner.agent_systems.interactive_command import move_flag_value_to_e
 
 
 CONTAINER_HOME = Path("/home/midori-ai")
+WORKSPACE_DIR = "/home/midori-ai/workspace"
+
+
+def _has_yolo_permissions(parts: list[str]) -> bool:
+    if "--yolo" in parts or "--allow-all" in parts:
+        return True
+    return all(
+        flag in parts
+        for flag in ("--allow-all-tools", "--allow-all-paths", "--allow-all-urls")
+    )
 
 
 class CopilotAgentSystemPlugin:
@@ -37,8 +47,7 @@ class CopilotAgentSystemPlugin:
 
         argv = [
             "copilot",
-            "--allow-all-tools",
-            "--allow-all-paths",
+            "--yolo",
             "--add-dir",
             str(context.workspace_container),
             *list(context.extra_cli_args),
@@ -83,7 +92,7 @@ class CopilotAgentSystemPlugin:
         return ["copilot", "--version"]
 
     def default_interactive_command(self) -> str:
-        return "--allow-all-tools --allow-all-paths --add-dir /home/midori-ai/workspace"
+        return f"--yolo --add-dir {WORKSPACE_DIR}"
 
     def sanitize_interactive_command_parts(self, *, cmd_parts: list[str]) -> list[str]:
         return list(cmd_parts)
@@ -103,13 +112,11 @@ class CopilotAgentSystemPlugin:
             parts.extend(agent_cli_args)
 
         if "--add-dir" not in parts:
-            parts[1:1] = ["--add-dir", "/home/midori-ai/workspace"]
+            parts[1:1] = ["--add-dir", WORKSPACE_DIR]
 
         if is_help_launch:
-            if "--allow-all-tools" not in parts:
-                parts[1:1] = ["--allow-all-tools"]
-            if "--allow-all-paths" not in parts:
-                parts[1:1] = ["--allow-all-paths"]
+            if not _has_yolo_permissions(parts):
+                parts[1:1] = ["--yolo"]
             if help_repos_dir not in parts:
                 parts[1:1] = ["--add-dir", help_repos_dir]
 

--- a/agents_runner/prompts/templates/agentcli/copilot.md
+++ b/agents_runner/prompts/templates/agentcli/copilot.md
@@ -14,9 +14,10 @@ This section is appended because Copilot CLI is selected and available for this 
 **How Agents Runner runs it**
 - Command:
   ```
-  copilot --allow-all-tools --allow-all-paths --add-dir <WORKDIR> [extra_args] -p <PROMPT>
+  copilot --yolo --add-dir <WORKDIR> [extra_args] -p <PROMPT>
   ```
-- Access: all tools + all paths allowed; `<WORKDIR>` is included (default `~/workspace`)
+- Access: all tools + all paths + all URLs allowed; `<WORKDIR>` is included (default `~/workspace`)
+- Note: `--yolo` is broader than the older tools+paths-only setup because it also auto-approves URL access
 - Timeout: if the main agent is invoking Copilot for long tasks (especially as Router/Orchestrator), the main agent must bypass automatic command timeouts by setting a very high timeout (8+ hours). Some runtimes (including Codex) apply an automatic timeout to command runs.
 
 **MCP servers**

--- a/agents_runner/ui/main_window.py
+++ b/agents_runner/ui/main_window.py
@@ -20,7 +20,6 @@ from PySide6.QtWidgets import QWidget
 
 from agents_runner.agent_cli import default_host_config_dir
 from agents_runner.agent_systems import available_agent_system_names
-from agents_runner.agent_systems import get_agent_system
 from agents_runner.environments import Environment
 from agents_runner.ide_systems import IDE_DISPLAY_CONTAINER_DESKTOP
 from agents_runner.ide_systems import get_default_ide_system_name
@@ -93,19 +92,10 @@ class MainWindow(
         self.resize(1280, 720)
 
         agent_config_dirs: dict[str, str] = {}
-        agent_interactive_commands: dict[str, str] = {}
         for agent_cli in available_agent_system_names(include_internal=False):
             agent_config_dirs[agent_cli] = os.path.expanduser(
                 default_host_config_dir(agent_cli)
             )
-            interactive_default = ""
-            try:
-                interactive_default = str(
-                    get_agent_system(agent_cli).default_interactive_command() or ""
-                ).strip()
-            except Exception:
-                pass
-            agent_interactive_commands[agent_cli] = interactive_default
 
         self._settings_data: dict[str, object] = {
             "use": "codex",
@@ -120,7 +110,6 @@ class MainWindow(
             "ide_display_target_default": IDE_DISPLAY_CONTAINER_DESKTOP,
             "ide_novnc_auto_open_enabled": True,
             "ide_novnc_auto_open_mode": "viewing_only",
-            "agent_interactive_commands": dict(agent_interactive_commands),
             "window_w": 1280,
             "window_h": 720,
             "max_agents_running": -1,

--- a/agents_runner/ui/main_window_persistence.py
+++ b/agents_runner/ui/main_window_persistence.py
@@ -159,9 +159,6 @@ class MainWindowPersistenceMixin:
         self._settings_data["agent_config_dirs"] = self._get_agent_config_dirs_map(
             self._settings_data
         )
-        self._settings_data["agent_interactive_commands"] = (
-            self._get_agent_interactive_commands_map(self._settings_data)
-        )
         for key in self._REMOVED_LEGACY_SETTINGS_KEYS:
             self._settings_data.pop(key, None)
         self._settings_data.setdefault(

--- a/agents_runner/ui/main_window_settings.py
+++ b/agents_runner/ui/main_window_settings.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import os
-import shlex
 
 from typing import Any
 
@@ -27,12 +26,12 @@ logger = logging.getLogger(__name__)
 
 class MainWindowSettingsMixin:
     _AGENT_CONFIG_DIRS_KEY = "agent_config_dirs"
-    _AGENT_INTERACTIVE_COMMANDS_KEY = "agent_interactive_commands"
     _REMOVED_LEGACY_SETTINGS_KEYS = (
         "host_codex_dir",
         "host_claude_dir",
         "host_copilot_dir",
         "host_gemini_dir",
+        "agent_interactive_commands",
         "interactive_command",
         "interactive_command_claude",
         "interactive_command_copilot",
@@ -77,33 +76,12 @@ class MainWindowSettingsMixin:
             normalized[agent_cli] = configured
         return normalized
 
-    def _normalized_agent_interactive_commands_map(self, raw: object) -> dict[str, str]:
-        values = self._coerce_agent_map(raw)
-        normalized: dict[str, str] = {}
-        for agent_cli in available_agents(include_internal=False):
-            configured = str(values.get(agent_cli) or "").strip()
-            if not configured:
-                configured = self._plugin_default_interactive_command(agent_cli)
-            normalized[agent_cli] = self._sanitize_interactive_command_value(
-                agent_cli=agent_cli,
-                raw=configured,
-            )
-        return normalized
-
     def _get_agent_config_dirs_map(
         self, settings: dict[str, object] | None = None
     ) -> dict[str, str]:
         source = settings if settings is not None else self._settings_data
         return self._normalized_agent_config_dirs_map(
             source.get(self._AGENT_CONFIG_DIRS_KEY)
-        )
-
-    def _get_agent_interactive_commands_map(
-        self, settings: dict[str, object] | None = None
-    ) -> dict[str, str]:
-        source = settings if settings is not None else self._settings_data
-        return self._normalized_agent_interactive_commands_map(
-            source.get(self._AGENT_INTERACTIVE_COMMANDS_KEY)
         )
 
     def _set_agent_config_dir_setting(
@@ -121,25 +99,6 @@ class MainWindowSettingsMixin:
         normalized = self._get_agent_config_dirs_map(settings)
         normalized[agent_cli] = os.path.expanduser(str(config_dir or "").strip())
         settings[self._AGENT_CONFIG_DIRS_KEY] = normalized
-
-    def _set_agent_interactive_command_setting(
-        self,
-        *,
-        settings: dict[str, object],
-        agent_cli: str,
-        command: str,
-    ) -> None:
-        agent_cli = str(agent_cli or "").strip().lower()
-        if not agent_cli or agent_cli not in set(
-            available_agents(include_internal=False)
-        ):
-            return
-        normalized = self._get_agent_interactive_commands_map(settings)
-        normalized[agent_cli] = self._sanitize_interactive_command_value(
-            agent_cli=agent_cli,
-            raw=command,
-        )
-        settings[self._AGENT_INTERACTIVE_COMMANDS_KEY] = normalized
 
     def _apply_settings(self, settings: dict[str, Any]) -> None:
         previous_radio_enabled = bool(self._settings_data.get("radio_enabled") or False)
@@ -177,11 +136,6 @@ class MainWindowSettingsMixin:
             if str(merged.get("ide_novnc_auto_open_mode") or "").strip().lower()
             == "always"
             else "viewing_only"
-        )
-        merged[self._AGENT_INTERACTIVE_COMMANDS_KEY] = (
-            self._normalized_agent_interactive_commands_map(
-                merged.get(self._AGENT_INTERACTIVE_COMMANDS_KEY)
-            )
         )
         for key in self._REMOVED_LEGACY_SETTINGS_KEYS:
             merged.pop(key, None)
@@ -325,40 +279,7 @@ class MainWindowSettingsMixin:
             available_agents(include_internal=False)
         ):
             return ""
-        commands = self._get_agent_interactive_commands_map(self._settings_data)
-        configured = str(commands.get(agent_cli) or "").strip()
-        if configured:
-            return configured
         return self._plugin_default_interactive_command(agent_cli)
-
-    def _sanitize_interactive_command_value(
-        self, *, agent_cli: str, raw: object
-    ) -> str:
-        agent_cli = str(agent_cli or "").strip().lower()
-        if agent_cli not in set(available_agents(include_internal=False)):
-            agent_cli = ""
-        value = str(raw or "").strip()
-        if not value:
-            return ""
-
-        try:
-            cmd_parts = shlex.split(value)
-        except ValueError:
-            cmd_parts = []
-        if cmd_parts and cmd_parts[0] in set(available_agents(include_internal=False)):
-            head = cmd_parts.pop(0)
-            try:
-                cmd_parts = get_agent_system(head).sanitize_interactive_command_parts(
-                    cmd_parts=cmd_parts
-                )
-            except Exception:
-                pass
-            value = " ".join(shlex.quote(part) for part in cmd_parts)
-
-        if looks_like_agent_help_command(value):
-            return self._plugin_default_interactive_command(agent_cli)
-
-        return value
 
     @staticmethod
     def _is_agent_help_interactive_launch(prompt: str, command: str) -> bool:


### PR DESCRIPTION
## Summary
- stop persisting interactive base commands in state.toml
- rebuild interactive defaults from the active agent plugin on each launch
- switch Copilot launches and help mode to real --yolo behavior
- keep environment and per-agent CLI flags layered on top of plugin defaults

## Verification
- uv run ruff check agents_runner/ui/main_window_settings.py agents_runner/ui/main_window_persistence.py agents_runner/ui/main_window.py agents_runner/agent_systems/copilot/plugin.py
- uv run pytest agents_runner/tests/test_interactive_agent_override.py -q
- runtime probe with temporary state.toml confirming stale agent_interactive_commands is ignored and dropped on save
- command-builder probe confirming Copilot plugin default still merges --model gpt-5.2 and help-repo args

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
