### PR TITLE
[FIX] Enforce runtime system preflight for Run Interactive

### DIFF
--- a/agents_runner/ui/main_window_tasks_interactive_docker.py
+++ b/agents_runner/ui/main_window_tasks_interactive_docker.py
@@ -282,6 +282,18 @@ def launch_docker_terminal_task(
                 )
             )
 
+    run_interactive_mode = task.is_interactive_run()
+    skip_system_preflight = bool(system_preflight_cached and not run_interactive_mode)
+    if run_interactive_mode and system_preflight_cached:
+        on_phase_log(
+            format_log(
+                "phase",
+                "cache",
+                "INFO",
+                "interactive run requires runtime system preflight; skipping cache-only shortcut",
+            )
+        )
+
     # Prepare preflight scripts and get mounts.
     # Desktop caching only pre-installs desktop dependencies into an image layer;
     # runtime desktop services still need to start for each container launch.
@@ -292,7 +304,7 @@ def launch_docker_terminal_task(
             desktop_preflight_script=desktop_preflight_script,
             settings_preflight_script=settings_preflight_script,
             setup_agents_script=setup_agents_script,
-            skip_system=system_preflight_cached,
+            skip_system=skip_system_preflight,
             skip_desktop=False,
             skip_settings=settings_preflight_cached,
         )


### PR DESCRIPTION
## Summary
- Ensure Run Interactive always executes `pixelarch_yay.sh` (`yay -Syu --noconfirm`) at runtime before `setup-agents`.
- Keep IDE interactive behavior unchanged.
- Keep non-interactive worker behavior unchanged.

## Validation
- `uv run ruff check .`
- `uv run pytest agents_runner/tests/test_interactive_agent_override.py -q`
- `uv run basedpyright` (baseline unchanged: existing type-check errors remain)

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [Github Copilot](https://github.com/github/copilot-cli)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
