### PR TITLE
[FIX] Harden GitHub repo parsing and clone validation

### DIFF
--- a/agents_runner/environments/github_repo.py
+++ b/agents_runner/environments/github_repo.py
@@ -1,6 +1,4 @@
 from __future__ import annotations
-
-import re
 from dataclasses import dataclass
 
 from agents_runner.environments.git_operations import get_git_info
@@ -27,12 +25,6 @@ def _parse_cloned_target(target: str) -> tuple[str | None, str | None]:
     value = str(target or "").strip()
     if not value:
         return (None, None)
-
-    shorthand = re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", value)
-    if shorthand:
-        owner, repo = value.split("/", 1)
-        return (owner.strip(), repo.strip())
-
     return parse_github_url(value)
 
 

--- a/agents_runner/environments/preflight_snapshot.py
+++ b/agents_runner/environments/preflight_snapshot.py
@@ -6,6 +6,7 @@ import os
 
 from cryptography.fernet import Fernet
 from cryptography.fernet import InvalidToken
+from agents_runner.gh.git_ops import normalize_github_repo_slug
 
 from .model import WORKSPACE_CLONED
 from .model import WORKSPACE_MOUNTED
@@ -32,17 +33,10 @@ def _normalize_repo_identity(target: str) -> str:
     text = str(target or "").strip()
     if not text:
         return ""
-    if text.startswith("git@github.com:"):
-        text = text.removeprefix("git@github.com:").strip()
-    elif "github.com/" in text:
-        text = text.split("github.com/", 1)[-1].strip()
-    text = text.split("#", 1)[0].split("?", 1)[0].strip().strip("/")
-    if text.endswith(".git"):
-        text = text[: -len(".git")].strip().strip("/")
-    parts = [part for part in text.split("/") if part]
-    if len(parts) >= 2:
-        return f"{parts[-2].lower()}/{parts[-1].lower()}"
-    return text.lower()
+    slug = normalize_github_repo_slug(text)
+    if slug:
+        return slug
+    return text.split("#", 1)[0].split("?", 1)[0].strip().rstrip("/").lower()
 
 
 def _workspace_identity_baseline(

--- a/agents_runner/gh/git_ops.py
+++ b/agents_runner/gh/git_ops.py
@@ -1,6 +1,27 @@
 import os
+import re
+from urllib.parse import urlsplit
 
 from .process import expand_dir, run_gh
+
+_GITHUB_REPO_PART_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+def _parse_github_repo_path(path: str) -> tuple[str | None, str | None]:
+    candidate = str(path or "").strip().strip("/")
+    if not candidate:
+        return None, None
+    if candidate.endswith(".git"):
+        candidate = candidate[: -len(".git")].strip().strip("/")
+    parts = [part.strip() for part in candidate.split("/") if part.strip()]
+    if len(parts) != 2:
+        return None, None
+    owner, repo = parts
+    if not _GITHUB_REPO_PART_PATTERN.fullmatch(owner):
+        return None, None
+    if not _GITHUB_REPO_PART_PATTERN.fullmatch(repo):
+        return None, None
+    return owner, repo
 
 
 def is_git_repo(path: str, *, timeout_s: float = 8.0) -> bool:
@@ -99,13 +120,10 @@ def git_list_remote_heads(repo: str) -> list[str]:
     if not repo:
         return []
     url = repo
-    if (
-        "://" not in url
-        and not url.startswith("git@")
-        and "/" in url
-        and " " not in url
-    ):
-        url = f"https://github.com/{url}.git"
+    if "://" not in url and not url.startswith("git@"):
+        owner, repo_name = parse_github_url(url)
+        if owner and repo_name:
+            url = f"https://github.com/{owner}/{repo_name}.git"
     proc = run_gh(["git", "ls-remote", "--heads", url], timeout_s=20.0)
     if proc.returncode != 0:
         return []
@@ -159,40 +177,45 @@ def git_remote_url(
 
 
 def parse_github_url(url: str) -> tuple[str | None, str | None]:
-    """Parse owner and repo name from GitHub URL.
+    """Parse owner and repo name from GitHub references.
 
     Supports multiple URL formats:
+        - owner/repo
         - https://github.com/owner/repo
         - https://github.com/owner/repo.git
         - git@github.com:owner/repo.git
         - ssh://git@github.com/owner/repo
 
     Returns (owner, repo_name) tuple, or (None, None) if parsing fails.
+    Only exact GitHub hosts are accepted for URL forms, and paths must be
+    exactly two segments (`owner/repo`) after an optional terminal `.git`.
     """
-    import re
-
-    url = (url or "").strip()
-    if not url:
+    text = (url or "").strip()
+    if not text or " " in text:
         return None, None
 
-    # HTTPS pattern: https://github.com/owner/repo or https://github.com/owner/repo.git
-    https_match = re.search(r"github\.com[:/]([^/]+)/([^/\.]+)", url)
-    if https_match:
-        owner = https_match.group(1).strip()
-        repo = https_match.group(2).strip()
-        # Remove .git suffix if present
-        if repo.endswith(".git"):
-            repo = repo[:-4]
-        return owner if owner else None, repo if repo else None
+    if "://" not in text and not text.startswith("git@"):
+        return _parse_github_repo_path(text)
 
-    # SSH pattern: git@github.com:owner/repo.git
-    ssh_match = re.search(r"github\.com:([^/]+)/([^/\.]+)", url)
-    if ssh_match:
-        owner = ssh_match.group(1).strip()
-        repo = ssh_match.group(2).strip()
-        # Remove .git suffix if present
-        if repo.endswith(".git"):
-            repo = repo[:-4]
-        return owner if owner else None, repo if repo else None
+    if text.startswith("git@"):
+        prefix = "git@github.com:"
+        if not text.startswith(prefix):
+            return None, None
+        path = text[len(prefix) :].split("#", 1)[0].split("?", 1)[0]
+        return _parse_github_repo_path(path)
 
-    return None, None
+    parsed = urlsplit(text)
+    if parsed.scheme not in {"http", "https", "ssh"}:
+        return None, None
+    if (parsed.hostname or "").lower() != "github.com":
+        return None, None
+    if parsed.scheme == "ssh" and (parsed.username or "") != "git":
+        return None, None
+    return _parse_github_repo_path(parsed.path)
+
+
+def normalize_github_repo_slug(value: str) -> str:
+    owner, repo = parse_github_url(value)
+    if not owner or not repo:
+        return ""
+    return f"{owner.lower()}/{repo.lower()}"

--- a/agents_runner/gh/repo_clone.py
+++ b/agents_runner/gh/repo_clone.py
@@ -4,32 +4,8 @@ import time
 
 from .errors import GhManagementError
 from .gh_cli import is_gh_available
-from .git_ops import is_git_repo
+from .git_ops import is_git_repo, normalize_github_repo_slug
 from .process import expand_dir, is_empty_dir, require_ok, run_gh
-
-
-def _normalize_repo_slug(value: str) -> str:
-    value = (value or "").strip()
-    if not value:
-        return ""
-
-    text = value
-    if text.startswith("git@github.com:"):
-        text = text.removeprefix("git@github.com:").strip()
-    elif "github.com/" in text:
-        text = text.split("github.com/", 1)[-1].strip()
-    elif "://" not in text and "/" in text and " " not in text:
-        text = text
-    else:
-        return ""
-
-    text = text.split("#", 1)[0].split("?", 1)[0].strip().strip("/")
-    if text.endswith(".git"):
-        text = text[: -len(".git")].strip().strip("/")
-    parts = [p for p in text.split("/") if p]
-    if len(parts) < 2:
-        return ""
-    return f"{parts[-2].lower()}/{parts[-1].lower()}"
 
 
 def _read_origin_url(dest_dir: str) -> str:
@@ -100,21 +76,24 @@ def ensure_github_clone(
     os.makedirs(parent, exist_ok=True)
     if os.path.exists(dest_dir):
         if is_git_repo(dest_dir):
-            desired = _normalize_repo_slug(repo)
-            existing = _normalize_repo_slug(_read_origin_url(dest_dir))
-            if desired and existing and desired != existing:
+            origin_url = _read_origin_url(dest_dir)
+            desired = normalize_github_repo_slug(repo)
+            existing = normalize_github_repo_slug(origin_url)
+            if desired != existing and (desired or existing):
+                desired_label = desired or repo
+                existing_label = existing or origin_url
                 if recreate_if_needed and os.path.isdir(dest_dir):
                     backup_dir = f"{dest_dir}.bak-{time.time_ns()}"
                     try:
                         os.replace(dest_dir, backup_dir)
                     except OSError as exc:
                         raise GhManagementError(
-                            f"destination contains a different repo ({existing}), expected {desired}: {dest_dir}\n"
+                            f"destination contains a different repo ({existing_label}), expected {desired_label}: {dest_dir}\n"
                             f"failed to move it aside to {backup_dir}: {exc}"
                         ) from exc
                 else:
                     raise GhManagementError(
-                        f"destination contains a different repo ({existing}), expected {desired}: {dest_dir}\n"
+                        f"destination contains a different repo ({existing_label}), expected {desired_label}: {dest_dir}\n"
                         "delete it (or pick a different workspace) and try again"
                     )
             return

--- a/agents_runner/setup_agents.py
+++ b/agents_runner/setup_agents.py
@@ -13,7 +13,7 @@ from agents_runner.environments.preflight_snapshot import (
     decrypt_setup_agents_snapshot,
     encrypt_setup_agents_snapshot,
 )
-from agents_runner.gh.git_ops import git_repo_root
+from agents_runner.gh.git_ops import git_repo_root, normalize_github_repo_slug
 from agents_runner.log_format import format_log
 
 SETUP_AGENTS_PRIMARY_RELATIVE_PATH = ".agents/setup-agents.sh"
@@ -56,29 +56,8 @@ def _safe_segment(value: str, fallback: str = "default") -> str:
     return safe or fallback
 
 
-def _normalize_repo_slug(value: str) -> str:
-    text = str(value or "").strip()
-    if not text:
-        return ""
-    if text.startswith("git@github.com:"):
-        text = text.removeprefix("git@github.com:").strip()
-    elif "github.com/" in text:
-        text = text.split("github.com/", 1)[-1].strip()
-    elif "://" not in text and "/" in text and " " not in text:
-        text = text
-    else:
-        return ""
-    text = text.split("#", 1)[0].split("?", 1)[0].strip().strip("/")
-    if text.endswith(".git"):
-        text = text[: -len(".git")].strip().strip("/")
-    parts = [part for part in text.split("/") if part]
-    if len(parts) < 2:
-        return ""
-    return f"{parts[-2].lower()}/{parts[-1].lower()}"
-
-
 def _repo_key(*, repo_root: Path, gh_repo: str | None) -> str:
-    slug = _normalize_repo_slug(str(gh_repo or ""))
+    slug = normalize_github_repo_slug(str(gh_repo or ""))
     if slug:
         return slug.replace("/", "__")
     digest = hashlib.sha1(str(repo_root).encode("utf-8")).hexdigest()[:12]

--- a/agents_runner/tests/test_github_repo_parsing.py
+++ b/agents_runner/tests/test_github_repo_parsing.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agents_runner.environments.model import WORKSPACE_CLONED
+from agents_runner.environments.preflight_snapshot import build_preflight_identity_token
+from agents_runner.gh import repo_clone
+from agents_runner.gh.errors import GhManagementError
+from agents_runner.gh.git_ops import normalize_github_repo_slug, parse_github_url
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("Owner/Repo", ("Owner", "Repo")),
+        ("owner/repo.name", ("owner", "repo.name")),
+        ("https://github.com/Owner/Repo", ("Owner", "Repo")),
+        ("https://github.com/owner/repo.name.git", ("owner", "repo.name")),
+        ("git@github.com:Owner/Repo.git", ("Owner", "Repo")),
+        ("ssh://git@github.com/owner/repo.name", ("owner", "repo.name")),
+        ("ssh://git@github.com:22/owner/repo", ("owner", "repo")),
+    ],
+)
+def test_parse_github_url_accepts_supported_formats(
+    value: str, expected: tuple[str, str]
+) -> None:
+    assert parse_github_url(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://example.com/github.com/owner/repo",
+        "https://github.com/owner/repo/tree/main",
+        "https://www.github.com/owner/repo",
+        "ssh://github.com/owner/repo",
+        "owner/repo/extra",
+        "owner only/repo",
+    ],
+)
+def test_parse_github_url_rejects_embedded_hosts_and_extra_segments(
+    value: str,
+) -> None:
+    assert parse_github_url(value) == (None, None)
+
+
+def test_normalize_github_repo_slug_lowercases_and_preserves_dotted_repo_names() -> (
+    None
+):
+    assert normalize_github_repo_slug("https://github.com/Owner/Repo.Name.git") == (
+        "owner/repo.name"
+    )
+
+
+def test_build_preflight_identity_token_distinguishes_github_lookalikes() -> None:
+    real = build_preflight_identity_token(
+        env_id="env-1",
+        workspace_type=WORKSPACE_CLONED,
+        workspace_target="https://github.com/Owner/Repo.git",
+        host_workdir="",
+    )
+    lookalike = build_preflight_identity_token(
+        env_id="env-1",
+        workspace_type=WORKSPACE_CLONED,
+        workspace_target="https://example.com/github.com/Owner/Repo.git",
+        host_workdir="",
+    )
+
+    assert real != lookalike
+
+
+def test_build_preflight_identity_token_keeps_non_github_targets_distinct() -> None:
+    first = build_preflight_identity_token(
+        env_id="env-1",
+        workspace_type=WORKSPACE_CLONED,
+        workspace_target="https://gitlab.com/example/repo-a.git",
+        host_workdir="",
+    )
+    second = build_preflight_identity_token(
+        env_id="env-1",
+        workspace_type=WORKSPACE_CLONED,
+        workspace_target="https://gitlab.com/example/repo-b.git",
+        host_workdir="",
+    )
+
+    assert first != second
+
+
+def test_ensure_github_clone_accepts_equivalent_existing_repo(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def _is_git_repo(_path: str, *, timeout_s: float = 8.0) -> bool:
+        _ = timeout_s
+        return True
+
+    def _read_origin_url(_dest_dir: str) -> str:
+        return "git@github.com:owner/repo.name.git"
+
+    dest = tmp_path / "repo"
+    dest.mkdir()
+    monkeypatch.setattr(repo_clone, "is_git_repo", _is_git_repo)
+    monkeypatch.setattr(repo_clone, "_read_origin_url", _read_origin_url)
+
+    repo_clone.ensure_github_clone(
+        "https://github.com/Owner/Repo.Name.git",
+        str(dest),
+    )
+
+
+def test_ensure_github_clone_rejects_invalid_ref_against_existing_repo(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def _is_git_repo(_path: str, *, timeout_s: float = 8.0) -> bool:
+        _ = timeout_s
+        return True
+
+    def _read_origin_url(_dest_dir: str) -> str:
+        return "https://github.com/owner/repo.git"
+
+    dest = tmp_path / "repo"
+    dest.mkdir()
+    monkeypatch.setattr(repo_clone, "is_git_repo", _is_git_repo)
+    monkeypatch.setattr(repo_clone, "_read_origin_url", _read_origin_url)
+
+    with pytest.raises(
+        GhManagementError, match="destination contains a different repo"
+    ):
+        repo_clone.ensure_github_clone(
+            "https://example.com/github.com/owner/repo",
+            str(dest),
+        )

--- a/agents_runner/ui/dialogs/new_environment_wizard.py
+++ b/agents_runner/ui/dialogs/new_environment_wizard.py
@@ -31,6 +31,7 @@ from agents_runner.environments import (
     WORKSPACE_CLONED,
     WORKSPACE_MOUNTED,
 )
+from agents_runner.gh.git_ops import parse_github_url
 from agents_runner.terminal_apps import detect_terminal_options, launch_in_terminal
 from agents_runner.ui.dialogs.themed_dialog import ThemedDialog
 from agents_runner.ui.graphics import EnvironmentTintOverlay
@@ -321,12 +322,13 @@ class NewEnvironmentWizard(ThemedDialog):
     def _expand_repo_url(self, url: str) -> str:
         """Convert GitHub shorthand (owner/repo) to full URL."""
         url = url.strip()
-        # Check if it's already a full URL
+        if not url:
+            return ""
         if url.startswith(("https://", "http://", "git@", "ssh://")):
             return url
-        # Check if it matches GitHub shorthand pattern (owner/repo)
-        if re.match(r"^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$", url):
-            return f"https://github.com/{url}.git"
+        owner, repo = parse_github_url(url)
+        if owner and repo:
+            return f"https://github.com/{owner}/{repo}.git"
         return url
 
     def _validate_clone(self) -> None:
@@ -341,16 +343,12 @@ class NewEnvironmentWizard(ThemedDialog):
             self._clone_validation.setStyleSheet("color: #f44336; font-size: 11px;")
             self._update_next_button()
             return
-        # Accept GitHub shorthand (owner/repo) or full URLs
-        shorthand_pattern = r"^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$"
-        url_pattern = r"^(https?://|git@|ssh://)"
-        if re.match(shorthand_pattern, url) or re.match(url_pattern, url):
+        owner, repo = parse_github_url(url)
+        if owner and repo:
             self._clone_validation.setText("✓ Valid format")
             self._clone_validation.setStyleSheet("color: #4caf50; font-size: 11px;")
         else:
-            self._clone_validation.setText(
-                "✗ Use owner/repo or valid URL (https://, git@, ssh://)"
-            )
+            self._clone_validation.setText("✗ Use owner/repo or a valid GitHub URL")
             self._clone_validation.setStyleSheet("color: #f44336; font-size: 11px;")
         self._update_next_button()
 
@@ -385,10 +383,8 @@ class NewEnvironmentWizard(ThemedDialog):
             url = self._clone_input.text().strip()
             if not url or " " in url:
                 return False
-            # Accept GitHub shorthand (owner/repo) or full URLs
-            shorthand_pattern = r"^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$"
-            url_pattern = r"^(https?://|git@|ssh://)"
-            return bool(re.match(shorthand_pattern, url) or re.match(url_pattern, url))
+            owner, repo = parse_github_url(url)
+            return bool(owner and repo)
 
     def _on_next(self) -> None:
         if self._source_combo.currentIndex() == 1 and not self._clone_test_passed:
@@ -489,9 +485,9 @@ read
         else:
             gh_target = self._expand_repo_url(self._clone_input.text().strip())
             workspace_type = WORKSPACE_CLONED
-        color = str(
-            getattr(self, "_color_combo", None).currentData() or self._suggested_color
-        )
+        color_combo = getattr(self, "_color_combo", None)
+        color_value = color_combo.currentData() if color_combo is not None else None
+        color = str(color_value or self._suggested_color)
         env = Environment(
             env_id=env_id,
             name=name,


### PR DESCRIPTION
## Summary
- harden shared GitHub repo parsing to reject embedded-host lookalikes and extra path segments
- route setup-agent, preflight, clone-mismatch, and cloned repo context parsing through the shared logic
- align new environment clone validation with the stricter parser and add focused regression tests

## Validation
- `uv run pytest agents_runner/tests/test_github_repo_parsing.py`
- `uv run ruff check agents_runner/gh/git_ops.py agents_runner/setup_agents.py agents_runner/environments/preflight_snapshot.py agents_runner/environments/github_repo.py agents_runner/gh/repo_clone.py agents_runner/ui/dialogs/new_environment_wizard.py agents_runner/tests/test_github_repo_parsing.py`
- `uv run basedpyright agents_runner/gh/git_ops.py agents_runner/setup_agents.py agents_runner/environments/preflight_snapshot.py agents_runner/environments/github_repo.py agents_runner/gh/repo_clone.py agents_runner/ui/dialogs/new_environment_wizard.py agents_runner/tests/test_github_repo_parsing.py`

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
