### PR TITLE
[FIX] Stabilize tests and targeted typing updates

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -31,4 +31,4 @@ jobs:
         run: uv sync --group ci
 
       - name: Tests
-        run: uv run pytest -q --maxfail=1
+        run: PYTHONOPTIMIZE= uv run pytest -q --maxfail=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,4 @@ jobs:
         run: uv run ruff check --select F .
 
       - name: Tests
-        run: uv run pytest -q
+        run: PYTHONOPTIMIZE= uv run pytest -q

--- a/agents_runner/artifacts.py
+++ b/agents_runner/artifacts.py
@@ -175,7 +175,7 @@ def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
 
 def encrypt_artifact(
     task_dict: dict[str, Any],
-    env_name: str,
+    env_name: str | None,
     source_path: str | Path,
     original_filename: str,
 ) -> str | None:
@@ -252,7 +252,7 @@ def encrypt_artifact(
 
 def decrypt_artifact(
     task_dict: dict[str, Any],
-    env_name: str,
+    env_name: str | None,
     artifact_uuid: str,
     dest_path: str | Path,
 ) -> bool:

--- a/agents_runner/tests/test_interactive_agent_override.py
+++ b/agents_runner/tests/test_interactive_agent_override.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from agents_runner.environments import Environment
 from agents_runner.environments import WORKSPACE_NONE
+from agents_runner.ui.main_window_environment import MainWindowEnvironmentMixin
 from agents_runner.terminal_apps import TerminalOption
 from agents_runner.ui.main_window_settings import MainWindowSettingsMixin
 from agents_runner.ui.main_window_tasks_interactive import (
@@ -97,7 +98,11 @@ class _DummyNewTask:
         return
 
 
-class _DummyMainWindow(MainWindowSettingsMixin, MainWindowTasksInteractiveMixin):
+class _DummyMainWindow(
+    MainWindowEnvironmentMixin,
+    MainWindowSettingsMixin,
+    MainWindowTasksInteractiveMixin,
+):
     def __init__(self, env: Environment, tmp_path: Path, workdir: Path) -> None:
         self._settings_data = {
             "use": "codex",


### PR DESCRIPTION
## Summary
- Align the interactive override test double with current MainWindow mixin composition by including MainWindowEnvironmentMixin.
- Fix two targeted basedpyright diagnostics in artifacts helpers by making env_name nullable where None handling already exists.
- Harden CI pytest execution against host -OO defaults by unsetting PYTHONOPTIMIZE in workflow test steps.

## Validation
- PYTHONOPTIMIZE= uv run pytest -q --maxfail=10 (PASS: 34 passed, 2 skipped)
- uv run ruff check . (PASS)
- PYTHONOPTIMIZE= uv run basedpyright (expected non-zero due baseline backlog; now 5495 errors, targeted artifacts.py diagnostics at ~204 and ~294 removed)

## Commit
- d3c1a4c6025c2287ee99a808e5dacd1ab716e1b8

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [Github Copilot](https://github.com/github/copilot-cli)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
