### PR TITLE
Fix interactive PR no-prompt behavior and metadata path diagnostics

### DIFF
--- a/agents_runner/environments/model.py
+++ b/agents_runner/environments/model.py
@@ -74,6 +74,13 @@ GH_TASK_BRANCH_NAMING_STYLES = (
 )
 GH_TASK_BRANCH_CUSTOM_TEMPLATE_DEFAULT = "{task_id}"
 
+INTERACTIVE_PR_NO_PROMPT_MODE_AUTO_CREATE = "auto_create_pr"
+INTERACTIVE_PR_NO_PROMPT_MODE_MANUAL_REVIEW = "manual_via_review_menu"
+INTERACTIVE_PR_NO_PROMPT_MODES = (
+    INTERACTIVE_PR_NO_PROMPT_MODE_AUTO_CREATE,
+    INTERACTIVE_PR_NO_PROMPT_MODE_MANUAL_REVIEW,
+)
+
 
 def normalize_workspace_type(value: str) -> str:
     """Normalize workspace type to canonical values."""
@@ -122,6 +129,14 @@ def normalize_gh_task_branch_custom_template(value: str) -> str:
     """Normalize custom task-branch template text."""
     normalized = str(value or "").strip()
     return normalized or GH_TASK_BRANCH_CUSTOM_TEMPLATE_DEFAULT
+
+
+def normalize_interactive_pr_no_prompt_mode(value: str) -> str:
+    """Normalize interactive PR behavior when the prompt is disabled."""
+    normalized = str(value or "").strip().lower()
+    if normalized in INTERACTIVE_PR_NO_PROMPT_MODES:
+        return normalized
+    return INTERACTIVE_PR_NO_PROMPT_MODE_AUTO_CREATE
 
 
 @dataclass
@@ -191,6 +206,7 @@ class Environment:
     agentsnova_auto_reactions_mode: str = AGENTSNOVA_AUTO_MODE_INHERIT
     agentsnova_marker_comment_mode: str = AGENTSNOVA_MARKER_COMMENT_MODE_INHERIT
     interactive_pr_prompt_enabled: bool = True
+    interactive_pr_no_prompt_mode: str = INTERACTIVE_PR_NO_PROMPT_MODE_AUTO_CREATE
     setup_agents_missing_prompt_enabled: bool = False
     interactive_pull_before_run_enabled: bool = True
     gh_branch_work_mode: str = GH_BRANCH_WORK_MODE_TASK_BRANCH

--- a/agents_runner/environments/serialize.py
+++ b/agents_runner/environments/serialize.py
@@ -11,6 +11,7 @@ from .model import Environment
 from .model import GH_TASK_BRANCH_CUSTOM_TEMPLATE_DEFAULT
 from .model import normalize_workspace_type
 from .model import normalize_agentsnova_auto_mode
+from .model import normalize_interactive_pr_no_prompt_mode
 from .model import normalize_agentsnova_marker_comment_mode
 from .model import normalize_gh_branch_work_mode
 from .model import normalize_gh_task_branch_custom_template
@@ -297,6 +298,9 @@ def environment_from_payload(payload: dict[str, Any]) -> Environment | None:
     interactive_pr_prompt_enabled = bool(
         payload.get("interactive_pr_prompt_enabled", True)
     )
+    interactive_pr_no_prompt_mode = normalize_interactive_pr_no_prompt_mode(
+        payload.get("interactive_pr_no_prompt_mode", "auto_create_pr")
+    )
     setup_agents_missing_prompt_enabled = bool(
         payload.get("setup_agents_missing_prompt_enabled", False)
     )
@@ -514,6 +518,7 @@ def environment_from_payload(payload: dict[str, Any]) -> Environment | None:
         agentsnova_auto_reactions_mode=agentsnova_auto_reactions_mode,
         agentsnova_marker_comment_mode=agentsnova_marker_comment_mode,
         interactive_pr_prompt_enabled=interactive_pr_prompt_enabled,
+        interactive_pr_no_prompt_mode=interactive_pr_no_prompt_mode,
         setup_agents_missing_prompt_enabled=setup_agents_missing_prompt_enabled,
         interactive_pull_before_run_enabled=interactive_pull_before_run_enabled,
         gh_branch_work_mode=gh_branch_work_mode,
@@ -638,6 +643,9 @@ def serialize_environment(env: Environment) -> dict[str, Any]:
         ),
         "interactive_pr_prompt_enabled": bool(
             getattr(env, "interactive_pr_prompt_enabled", True)
+        ),
+        "interactive_pr_no_prompt_mode": normalize_interactive_pr_no_prompt_mode(
+            getattr(env, "interactive_pr_no_prompt_mode", "auto_create_pr")
         ),
         "setup_agents_missing_prompt_enabled": bool(
             getattr(env, "setup_agents_missing_prompt_enabled", False)

--- a/agents_runner/ui/dialogs/new_environment_wizard.py
+++ b/agents_runner/ui/dialogs/new_environment_wizard.py
@@ -32,6 +32,7 @@ from agents_runner.environments import (
     WORKSPACE_MOUNTED,
 )
 from agents_runner.environments.model import GH_TASK_BRANCH_CUSTOM_TEMPLATE_DEFAULT
+from agents_runner.environments.model import INTERACTIVE_PR_NO_PROMPT_MODE_AUTO_CREATE
 from agents_runner.gh.git_ops import parse_github_url
 from agents_runner.terminal_apps import detect_terminal_options, launch_in_terminal
 from agents_runner.ui.dialogs.themed_dialog import ThemedDialog
@@ -503,6 +504,7 @@ read
             agentsnova_auto_reactions_mode="inherit",
             agentsnova_marker_comment_mode="inherit",
             interactive_pr_prompt_enabled=True,
+            interactive_pr_no_prompt_mode=INTERACTIVE_PR_NO_PROMPT_MODE_AUTO_CREATE,
             setup_agents_missing_prompt_enabled=False,
             interactive_pull_before_run_enabled=True,
             gh_branch_work_mode="task_branch",

--- a/agents_runner/ui/main_window_tasks_interactive_finalize.py
+++ b/agents_runner/ui/main_window_tasks_interactive_finalize.py
@@ -13,12 +13,15 @@ from PySide6.QtWidgets import QMessageBox
 from agents_runner.agent_display import format_agent_markdown_link
 from agents_runner.agent_display import get_agent_display_name
 from agents_runner.environments import WORKSPACE_CLONED
+from agents_runner.environments.model import INTERACTIVE_PR_NO_PROMPT_MODE_MANUAL_REVIEW
+from agents_runner.environments.model import normalize_interactive_pr_no_prompt_mode
 from agents_runner.environments.cleanup import cleanup_task_workspace
 from agents_runner.gh_management import commit_push_and_pr
 from agents_runner.gh_management import GhManagementError
 from agents_runner.log_format import format_log
 from agents_runner.pr_metadata import load_pr_metadata
 from agents_runner.pr_metadata import normalize_pr_title
+from agents_runner.pr_metadata import pr_metadata_host_path
 from agents_runner.ui.task_git_metadata import derive_task_git_metadata
 from agents_runner.ui.utils import stain_color
 
@@ -85,8 +88,8 @@ class MainWindowTasksInteractiveFinalizeMixin:
         # Collect staged artifacts and emit UUIDs back through host_artifacts.
         self._start_artifact_finalization(task)
 
-        # Interactive tasks handle PR creation immediately via user dialog, then mark finalization done
-        # This is different from agent tasks which queue finalization work for background processing
+        # Interactive tasks can create PRs immediately based on environment settings,
+        # then mark finalization done. Agent tasks still finalize in background workers.
         if (
             task.status == "done"
             and task.workspace_type == WORKSPACE_CLONED
@@ -95,26 +98,19 @@ class MainWindowTasksInteractiveFinalizeMixin:
             and str(task.gh_branch or "").strip()
             != str(task.gh_base_branch or "").strip()
             and not task.gh_pr_url
-            and bool(
-                getattr(env, "interactive_pr_prompt_enabled", True) if env else True
-            )
         ):
             base = str(task.gh_base_branch or "").strip()
             base_display = base or "auto"
-            message = f"Interactive run finished.\n\nCreate a PR from {task.gh_branch} -> {base_display}?"
-            if (
-                QMessageBox.question(self, "Create pull request?", message)
-                == QMessageBox.StandardButton.Yes
-            ):
-                self.host_log.emit(
-                    task_id,
-                    format_log(
-                        "host",
-                        "interactive",
-                        "INFO",
-                        f"Task {task_id}: creating PR after interactive run (branch={task.gh_branch}, base={base_display})",
-                    ),
-                )
+            prompt_enabled = bool(
+                getattr(env, "interactive_pr_prompt_enabled", True) if env else True
+            )
+            no_prompt_mode = normalize_interactive_pr_no_prompt_mode(
+                getattr(env, "interactive_pr_no_prompt_mode", "auto_create_pr")
+                if env
+                else "auto_create_pr"
+            )
+
+            def _queue_interactive_pr_creation() -> None:
                 threading.Thread(
                     target=self._finalize_gh_management_worker,
                     args=(
@@ -131,6 +127,46 @@ class MainWindowTasksInteractiveFinalizeMixin:
                     ),
                     daemon=True,
                 ).start()
+
+            if prompt_enabled:
+                message = (
+                    "Interactive run finished.\n\n"
+                    f"Create a PR from {task.gh_branch} -> {base_display}?"
+                )
+                if (
+                    QMessageBox.question(self, "Create pull request?", message)
+                    == QMessageBox.StandardButton.Yes
+                ):
+                    self.host_log.emit(
+                        task_id,
+                        format_log(
+                            "host",
+                            "interactive",
+                            "INFO",
+                            f"Task {task_id}: creating PR after interactive run (branch={task.gh_branch}, base={base_display})",
+                        ),
+                    )
+                    _queue_interactive_pr_creation()
+                else:
+                    self.host_log.emit(
+                        task_id,
+                        format_log(
+                            "host",
+                            "interactive",
+                            "INFO",
+                            f"Task {task_id}: PR creation declined by user",
+                        ),
+                    )
+            elif no_prompt_mode == INTERACTIVE_PR_NO_PROMPT_MODE_MANUAL_REVIEW:
+                self.host_log.emit(
+                    task_id,
+                    format_log(
+                        "host",
+                        "interactive",
+                        "INFO",
+                        "Interactive PR prompt disabled and mode=manual; use Review -> Create PR to open the PR.",
+                    ),
+                )
             else:
                 self.host_log.emit(
                     task_id,
@@ -138,11 +174,12 @@ class MainWindowTasksInteractiveFinalizeMixin:
                         "host",
                         "interactive",
                         "INFO",
-                        f"Task {task_id}: PR creation declined by user",
+                        f"Interactive PR prompt disabled and mode=auto-create; creating PR ({task.gh_branch} -> {base_display}).",
                     ),
                 )
+                _queue_interactive_pr_creation()
 
-        # Mark finalization done for interactive tasks (PR creation handled synchronously above)
+        # Mark finalization done for interactive tasks (PR handling selected above).
         self.host_log.emit(
             task_id,
             format_log(
@@ -155,6 +192,70 @@ class MainWindowTasksInteractiveFinalizeMixin:
         task.finalization_state = "done"
         task.finalization_error = ""
         self._schedule_save()
+
+    def _resolve_pr_metadata_path_for_finalize(
+        self,
+        *,
+        task_id: str,
+        provided_path: str | None,
+    ) -> str | None:
+        normalized_provided = os.path.abspath(
+            os.path.expanduser(str(provided_path or "").strip())
+        )
+        if normalized_provided:
+            if os.path.exists(normalized_provided):
+                return normalized_provided
+            self.host_log.emit(
+                task_id,
+                format_log(
+                    "gh",
+                    "pr",
+                    "WARN",
+                    f"configured PR metadata file is missing: {normalized_provided}",
+                ),
+            )
+
+        state_path = str(getattr(self, "_state_path", "") or "").strip()
+        if not state_path:
+            self.host_log.emit(
+                task_id,
+                format_log(
+                    "gh",
+                    "pr",
+                    "WARN",
+                    "state path unavailable; cannot resolve PR metadata fallback path",
+                ),
+            )
+            return None
+
+        fallback_path = os.path.abspath(
+            os.path.expanduser(
+                pr_metadata_host_path(os.path.dirname(state_path), task_id)
+            )
+        )
+        if os.path.exists(fallback_path):
+            if fallback_path != normalized_provided:
+                self.host_log.emit(
+                    task_id,
+                    format_log(
+                        "gh",
+                        "pr",
+                        "INFO",
+                        f"using fallback PR metadata file: {fallback_path}",
+                    ),
+                )
+            return fallback_path
+
+        self.host_log.emit(
+            task_id,
+            format_log(
+                "gh",
+                "pr",
+                "INFO",
+                f"no PR metadata file found (checked: {fallback_path}); using generated PR title/body defaults",
+            ),
+        )
+        return None
 
     def _finalize_gh_management_worker(
         self,
@@ -260,14 +361,42 @@ class MainWindowTasksInteractiveFinalizeMixin:
                 "Prompt:\n"
                 f"{(prompt_text or '').strip()}\n"
             )
+            provided_metadata_path = (
+                str(pr_metadata_path or "").strip()
+                or (
+                    str(getattr(task, "gh_pr_metadata_path", "") or "").strip()
+                    if task
+                    else ""
+                )
+                or None
+            )
+            resolved_pr_metadata_path = self._resolve_pr_metadata_path_for_finalize(
+                task_id=task_id,
+                provided_path=provided_metadata_path,
+            )
             metadata = (
-                load_pr_metadata(pr_metadata_path or "") if pr_metadata_path else None
+                load_pr_metadata(resolved_pr_metadata_path)
+                if resolved_pr_metadata_path
+                else None
             )
             if metadata is not None and (metadata.title or metadata.body):
                 self.host_log.emit(
                     task_id,
                     format_log(
-                        "gh", "pr", "INFO", f"using PR metadata from {pr_metadata_path}"
+                        "gh",
+                        "pr",
+                        "INFO",
+                        f"using PR metadata from {resolved_pr_metadata_path}",
+                    ),
+                )
+            elif resolved_pr_metadata_path:
+                self.host_log.emit(
+                    task_id,
+                    format_log(
+                        "gh",
+                        "pr",
+                        "INFO",
+                        f"PR metadata file is empty: {resolved_pr_metadata_path}; using generated defaults where needed",
                     ),
                 )
             title = (

--- a/agents_runner/ui/pages/environments.py
+++ b/agents_runner/ui/pages/environments.py
@@ -22,7 +22,9 @@ from agents_runner.environments import WORKSPACE_NONE
 from agents_runner.environments import managed_repo_checkout_path
 from agents_runner.environments.model import (
     GH_TASK_BRANCH_CUSTOM_TEMPLATE_DEFAULT,
+    INTERACTIVE_PR_NO_PROMPT_MODE_AUTO_CREATE,
     normalize_agentsnova_auto_mode,
+    normalize_interactive_pr_no_prompt_mode,
     normalize_agentsnova_marker_comment_mode,
     normalize_gh_branch_work_mode,
     normalize_gh_task_branch_custom_template,
@@ -182,6 +184,7 @@ class EnvironmentsPage(
         self._build_navigation(nav_layout)
         self._connect_autosave_signals()
         self._sync_github_branch_naming_controls()
+        self._sync_interactive_pr_controls()
 
         if self._pane_specs:
             first_key = self._pane_specs[0].key
@@ -297,6 +300,19 @@ class EnvironmentsPage(
         self._ports_tab.set_desktop_effective_enabled(self._effective_desktop_enabled())
         self._cache_desktop_build.setEnabled(self._effective_desktop_enabled())
 
+    def _sync_interactive_pr_controls(self) -> None:
+        show_no_prompt_mode = not bool(self._interactive_pr_prompt_enabled.isChecked())
+        no_prompt_mode_label = getattr(
+            self, "_interactive_pr_no_prompt_mode_label", None
+        )
+        if isinstance(no_prompt_mode_label, QWidget):
+            no_prompt_mode_label.setVisible(show_no_prompt_mode)
+        no_prompt_mode_row = getattr(self, "_interactive_pr_no_prompt_mode_row", None)
+        if isinstance(no_prompt_mode_row, QWidget):
+            no_prompt_mode_row.setVisible(show_no_prompt_mode)
+        self._interactive_pr_no_prompt_mode.setVisible(show_no_prompt_mode)
+        self._interactive_pr_no_prompt_mode.setEnabled(show_no_prompt_mode)
+
     def _sync_github_branch_naming_controls(self) -> None:
         workspace_type = str(self._workspace_type_combo.currentData() or "").strip()
         branch_work_mode = normalize_gh_branch_work_mode(
@@ -379,6 +395,15 @@ class EnvironmentsPage(
                         marker_comment_idx
                     )
                 self._interactive_pr_prompt_enabled.setChecked(True)
+                no_prompt_mode_idx = self._interactive_pr_no_prompt_mode.findData(
+                    INTERACTIVE_PR_NO_PROMPT_MODE_AUTO_CREATE
+                )
+                if no_prompt_mode_idx < 0:
+                    no_prompt_mode_idx = 0
+                if no_prompt_mode_idx >= 0:
+                    self._interactive_pr_no_prompt_mode.setCurrentIndex(
+                        no_prompt_mode_idx
+                    )
                 self._setup_agents_missing_prompt_enabled.setChecked(False)
                 self._interactive_pull_before_run_enabled.setChecked(True)
                 branch_work_idx = self._gh_branch_work_mode.findData("task_branch")
@@ -424,6 +449,7 @@ class EnvironmentsPage(
                 self._sync_github_branch_naming_controls()
                 self._sync_workspace_controls()
                 self._sync_headless_desktop_override_visibility()
+                self._sync_interactive_pr_controls()
                 return
 
             self._name.setText(env.name)
@@ -504,6 +530,18 @@ class EnvironmentsPage(
             self._interactive_pr_prompt_enabled.setChecked(
                 bool(getattr(env, "interactive_pr_prompt_enabled", True))
             )
+            interactive_pr_no_prompt_mode = normalize_interactive_pr_no_prompt_mode(
+                getattr(env, "interactive_pr_no_prompt_mode", "auto_create_pr")
+            )
+            interactive_pr_no_prompt_idx = self._interactive_pr_no_prompt_mode.findData(
+                interactive_pr_no_prompt_mode
+            )
+            if interactive_pr_no_prompt_idx < 0:
+                interactive_pr_no_prompt_idx = 0
+            if interactive_pr_no_prompt_idx >= 0:
+                self._interactive_pr_no_prompt_mode.setCurrentIndex(
+                    interactive_pr_no_prompt_idx
+                )
             self._setup_agents_missing_prompt_enabled.setChecked(
                 bool(getattr(env, "setup_agents_missing_prompt_enabled", False))
             )
@@ -589,6 +627,7 @@ class EnvironmentsPage(
             self._agents_tab.set_cross_agents_enabled(use_cross_agents)
             self._sync_github_branch_naming_controls()
             self._sync_headless_desktop_override_visibility()
+            self._sync_interactive_pr_controls()
         finally:
             self._suppress_autosave = False
 

--- a/agents_runner/ui/pages/environments_actions.py
+++ b/agents_runner/ui/pages/environments_actions.py
@@ -14,6 +14,7 @@ from agents_runner.environments import load_environments
 from agents_runner.environments import save_environment
 from agents_runner.environments.model import (
     normalize_agentsnova_auto_mode,
+    normalize_interactive_pr_no_prompt_mode,
     normalize_agentsnova_marker_comment_mode,
     normalize_gh_branch_work_mode,
     normalize_gh_task_branch_custom_template,
@@ -112,6 +113,9 @@ class EnvironmentsPageActionsMixin:
             ),
             "interactive_pr_prompt_enabled": bool(
                 self._interactive_pr_prompt_enabled.isChecked()
+            ),
+            "interactive_pr_no_prompt_mode": normalize_interactive_pr_no_prompt_mode(
+                self._interactive_pr_no_prompt_mode.currentData() or "auto_create_pr"
             ),
             "setup_agents_missing_prompt_enabled": bool(
                 self._setup_agents_missing_prompt_enabled.isChecked()

--- a/agents_runner/ui/pages/environments_form.py
+++ b/agents_runner/ui/pages/environments_form.py
@@ -26,6 +26,8 @@ from agents_runner.environments import WORKSPACE_MOUNTED
 from agents_runner.environments import WORKSPACE_NONE
 from agents_runner.environments.model import (
     GH_TASK_BRANCH_CUSTOM_TEMPLATE_DEFAULT,
+    INTERACTIVE_PR_NO_PROMPT_MODE_AUTO_CREATE,
+    INTERACTIVE_PR_NO_PROMPT_MODE_MANUAL_REVIEW,
 )
 from agents_runner.ide_systems import available_ide_system_names
 from agents_runner.ide_systems import get_ide_system
@@ -238,6 +240,23 @@ class EnvironmentsFormMixin:
         self._interactive_pr_prompt_enabled = QCheckBox("Show interactive PR prompt")
         self._interactive_pr_prompt_enabled.setToolTip(
             "When enabled, interactive GitHub work can keep showing the PR prompt for this environment."
+        )
+        self._interactive_pr_no_prompt_mode = QComboBox()
+        self._interactive_pr_no_prompt_mode.addItem(
+            "Auto-create PR after interactive run",
+            INTERACTIVE_PR_NO_PROMPT_MODE_AUTO_CREATE,
+        )
+        self._interactive_pr_no_prompt_mode.addItem(
+            "Manual only (Review -> Create PR)",
+            INTERACTIVE_PR_NO_PROMPT_MODE_MANUAL_REVIEW,
+        )
+        self._interactive_pr_no_prompt_mode.setToolTip(
+            "Used when 'Show interactive PR prompt' is disabled.\n"
+            "Manual mode means you can enter the task, then click Review -> Create PR yourself."
+        )
+        self._interactive_pr_no_prompt_mode.setVisible(False)
+        self._interactive_pr_prompt_enabled.toggled.connect(
+            self._sync_interactive_pr_controls
         )
         self._setup_agents_missing_prompt_enabled = QCheckBox(
             "Inject missing setup-agents prompt"
@@ -459,6 +478,10 @@ class EnvironmentsFormMixin:
         interactive_pr_prompt_row = self._create_stretch_row(
             github_config_page, self._interactive_pr_prompt_enabled
         )
+        self._interactive_pr_no_prompt_mode_label = QLabel("When prompt is disabled")
+        self._interactive_pr_no_prompt_mode_row = self._create_stretch_row(
+            github_config_page, self._interactive_pr_no_prompt_mode
+        )
         setup_agents_missing_prompt_row = self._create_stretch_row(
             github_config_page, self._setup_agents_missing_prompt_enabled
         )
@@ -483,24 +506,28 @@ class EnvironmentsFormMixin:
         github_grid.addWidget(self._github_polling_enabled_row, 1, 1, 1, 2)
         github_grid.addWidget(QLabel("Interactive PR prompt"), 2, 0)
         github_grid.addWidget(interactive_pr_prompt_row, 2, 1, 1, 2)
-        github_grid.addWidget(QLabel("Missing setup-agents prompt injection"), 3, 0)
-        github_grid.addWidget(setup_agents_missing_prompt_row, 3, 1, 1, 2)
-        github_grid.addWidget(QLabel("Interactive pull before run"), 4, 0)
-        github_grid.addWidget(interactive_pull_before_run_row, 4, 1, 1, 2)
-        github_grid.addWidget(QLabel("Trusted mode"), 5, 0)
-        github_grid.addWidget(trusted_mode_row, 5, 1, 1, 2)
-        github_grid.addWidget(QLabel("Auto review"), 6, 0)
-        github_grid.addWidget(auto_review_row, 6, 1, 1, 2)
-        github_grid.addWidget(QLabel("Auto reactions"), 7, 0)
-        github_grid.addWidget(auto_reactions_row, 7, 1, 1, 2)
-        github_grid.addWidget(QLabel("Marker comments"), 8, 0)
-        github_grid.addWidget(marker_comment_row, 8, 1, 1, 2)
-        github_grid.addWidget(QLabel("Branch workflow"), 9, 0)
-        github_grid.addWidget(branch_work_mode_row, 9, 1, 1, 2)
-        github_grid.addWidget(QLabel("Task branch naming"), 10, 0)
-        github_grid.addWidget(task_branch_naming_row, 10, 1, 1, 2)
-        github_grid.addWidget(self._gh_task_branch_custom_template_label, 11, 0)
-        github_grid.addWidget(self._gh_task_branch_custom_template_row, 11, 1, 1, 2)
+        github_grid.addWidget(self._interactive_pr_no_prompt_mode_label, 3, 0)
+        github_grid.addWidget(self._interactive_pr_no_prompt_mode_row, 3, 1, 1, 2)
+        github_grid.addWidget(QLabel("Missing setup-agents prompt injection"), 4, 0)
+        github_grid.addWidget(setup_agents_missing_prompt_row, 4, 1, 1, 2)
+        github_grid.addWidget(QLabel("Interactive pull before run"), 5, 0)
+        github_grid.addWidget(interactive_pull_before_run_row, 5, 1, 1, 2)
+        github_grid.addWidget(QLabel("Trusted mode"), 6, 0)
+        github_grid.addWidget(trusted_mode_row, 6, 1, 1, 2)
+        github_grid.addWidget(QLabel("Auto review"), 7, 0)
+        github_grid.addWidget(auto_review_row, 7, 1, 1, 2)
+        github_grid.addWidget(QLabel("Auto reactions"), 8, 0)
+        github_grid.addWidget(auto_reactions_row, 8, 1, 1, 2)
+        github_grid.addWidget(QLabel("Marker comments"), 9, 0)
+        github_grid.addWidget(marker_comment_row, 9, 1, 1, 2)
+        github_grid.addWidget(QLabel("Branch workflow"), 10, 0)
+        github_grid.addWidget(branch_work_mode_row, 10, 1, 1, 2)
+        github_grid.addWidget(QLabel("Task branch naming"), 11, 0)
+        github_grid.addWidget(task_branch_naming_row, 11, 1, 1, 2)
+        github_grid.addWidget(self._gh_task_branch_custom_template_label, 12, 0)
+        github_grid.addWidget(self._gh_task_branch_custom_template_row, 12, 1, 1, 2)
+        self._interactive_pr_no_prompt_mode_label.setVisible(False)
+        self._interactive_pr_no_prompt_mode_row.setVisible(False)
         self._gh_task_branch_custom_template_label.setVisible(False)
         self._gh_task_branch_custom_template_row.setVisible(False)
 

--- a/agents_runner/ui/pages/environments_navigation.py
+++ b/agents_runner/ui/pages/environments_navigation.py
@@ -27,6 +27,7 @@ class EnvironmentsNavigationMixin:
             self._agentsnova_auto_review_mode,
             self._agentsnova_auto_reactions_mode,
             self._agentsnova_marker_comment_mode,
+            self._interactive_pr_no_prompt_mode,
             self._gh_branch_work_mode,
             self._gh_task_branch_naming_style,
         ):


### PR DESCRIPTION
## Summary
- Add a new interactive environment setting for post-run PR behavior when "Show interactive PR prompt" is disabled.
- Add a conditional dropdown in the Environment GitHub Config section (visible only when prompt is disabled):
  - Auto-create PR after interactive run
  - Manual only (Review -> Create PR)
- Keep default behavior as auto-create and wire the setting through model/serialization/defaults/autosave.
- Update interactive finalization to honor prompt/manual/auto modes without changing non-interactive behavior.
- Harden PR metadata TOML lookup with explicit diagnostics and fallback to the task-scoped metadata file path.

## Verification
- `uv run ruff format ...` (changed files)
- `uv run ruff check ...` (changed files)
- `basedpyright` still reports pre-existing repository-wide issues outside this change.

Commit: 4bd255d

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [Github Copilot](https://github.com/github/copilot-cli)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
