### PR TITLE
[FIX] Probe-first agent install gating for PixelArch runs

### DIFF
--- a/agents_runner/agent_install.py
+++ b/agents_runner/agent_install.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import shlex
+import subprocess
+import threading
+import time
 
 from dataclasses import dataclass
 
@@ -20,6 +23,10 @@ _DEBUG_AGENT_COMMANDS = {
     "/usr/bin/bash",
 }
 
+_PROBE_CACHE_LOCK = threading.Lock()
+_PROBE_CACHE: dict[tuple[str, str, tuple[str, ...], str], bool] = {}
+_PROBE_IMAGE_IDENTITY_BY_REF: dict[str, str] = {}
+
 
 @dataclass(frozen=True)
 class AgentInstallPlan:
@@ -33,6 +40,135 @@ class AgentInstallPlan:
 def _safe_phase_suffix(value: str) -> str:
     safe = "".join(ch for ch in str(value or "").strip().lower() if ch.isalnum())
     return safe or "agent"
+
+
+def _safe_probe_token(value: str, *, fallback: str) -> str:
+    token = "".join(
+        ch
+        for ch in str(value or "").strip().lower()
+        if ch.isalnum() or ch in {"-", "_"}
+    )
+    return token or fallback
+
+
+def _resolve_image_identity(image: str) -> str:
+    image_ref = str(image or "").strip()
+    if not image_ref:
+        return "unknown"
+    try:
+        completed = subprocess.run(
+            [
+                "docker",
+                "image",
+                "inspect",
+                image_ref,
+                "--format",
+                "{{.Id}}",
+            ],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=20.0,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return f"ref:{image_ref}"
+    if completed.returncode != 0:
+        return f"ref:{image_ref}"
+    identity = str(completed.stdout or "").strip()
+    if identity.startswith("sha256:"):
+        identity = identity[7:]
+    return identity or f"ref:{image_ref}"
+
+
+def _build_probe_container_name(*, task_token: str, agent_cli: str) -> str:
+    task = _safe_probe_token(task_token, fallback="task")
+    cli = _safe_probe_token(agent_cli, fallback="agent")
+    suffix = _safe_probe_token(str(time.time_ns()), fallback="0")
+    name = f"agents-runner-probe-{task}-{cli}-{suffix}"
+    return name[:63].rstrip("-")
+
+
+def probe_agent_executable_in_image(
+    *,
+    image: str,
+    agent_cli: str,
+    platform_args: list[str] | tuple[str, ...] | None = None,
+    task_token: str = "task",
+    timeout_s: float = 45.0,
+) -> bool:
+    image_ref = str(image or "").strip()
+    cli = str(agent_cli or "").strip().lower()
+    if not image_ref or not cli:
+        return False
+    if cli in _DEBUG_AGENT_COMMANDS:
+        return True
+
+    normalized_platform = tuple(
+        part for part in (str(part).strip() for part in (platform_args or [])) if part
+    )
+    image_identity = _resolve_image_identity(image_ref)
+    cache_key = (image_ref, image_identity, normalized_platform, cli)
+
+    with _PROBE_CACHE_LOCK:
+        previous_identity = _PROBE_IMAGE_IDENTITY_BY_REF.get(image_ref)
+        if previous_identity and previous_identity != image_identity:
+            stale_keys = [
+                key
+                for key in _PROBE_CACHE.keys()
+                if key[0] == image_ref and key[1] != image_identity
+            ]
+            for stale in stale_keys:
+                _PROBE_CACHE.pop(stale, None)
+        _PROBE_IMAGE_IDENTITY_BY_REF[image_ref] = image_identity
+        cached = _PROBE_CACHE.get(cache_key)
+        if cached is not None:
+            return cached
+
+    quoted_cli = shlex.quote(cli)
+    probe_command = f"command -v {quoted_cli} >/dev/null 2>&1"
+    container_name = _build_probe_container_name(task_token=task_token, agent_cli=cli)
+    probe_args = [
+        "docker",
+        "run",
+        "--rm",
+        "--name",
+        container_name,
+        *list(normalized_platform),
+        image_ref,
+        "/bin/bash",
+        "-lc",
+        probe_command,
+    ]
+    try:
+        completed = subprocess.run(
+            probe_args,
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=max(1.0, float(timeout_s)),
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"agent probe timed out for {cli} in image {image_ref}"
+        ) from exc
+    except OSError as exc:
+        raise RuntimeError(f"agent probe failed to execute docker: {exc}") from exc
+
+    if completed.returncode == 0:
+        available = True
+    elif completed.returncode == 1:
+        available = False
+    else:
+        stderr = str(completed.stderr or "").strip()
+        stdout = str(completed.stdout or "").strip()
+        detail = stderr or stdout or f"docker run probe exited {completed.returncode}"
+        raise RuntimeError(
+            f"agent probe failed for {cli} in image {image_ref}: {detail}"
+        )
+
+    with _PROBE_CACHE_LOCK:
+        _PROBE_CACHE[cache_key] = available
+    return available
 
 
 def build_agent_install_script(

--- a/agents_runner/docker/agent_worker_setup.py
+++ b/agents_runner/docker/agent_worker_setup.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Callable, Any
 
 from agents_runner.prompt_sanitizer import sanitize_prompt
+from agents_runner.agent_install import probe_agent_executable_in_image
 from agents_runner.agent_install import resolve_agent_install_plan
 from agents_runner.agent_cli import (
     additional_config_mounts,
@@ -147,12 +148,35 @@ class WorkerSetup:
                 setup_agents_prompt_instruction = missing_setup_agents_instruction(
                     launch_mode=self._config.launch_mode
                 )
+        self.pull_image_if_needed(
+            platform_config.forced_platform, platform_config.platform_args
+        )
+
+        agent_probe_available: bool | None = None
         install_plan = None
         if not self._config.custom_command_argv:
-            install_plan = resolve_agent_install_plan(
+            agent_probe_available = probe_agent_executable_in_image(
+                image=self._config.image,
                 agent_cli=platform_config.agent_cli,
-                include_internal=False,
+                platform_args=platform_config.platform_args,
+                task_token=self._config.task_id or "task",
             )
+            self._on_log(
+                format_log(
+                    "install",
+                    "probe",
+                    "INFO",
+                    (
+                        f"image probe ({self._config.image}) agent={platform_config.agent_cli}: "
+                        f"{'available' if agent_probe_available else 'missing'}"
+                    ),
+                )
+            )
+            if not agent_probe_available:
+                install_plan = resolve_agent_install_plan(
+                    agent_cli=platform_config.agent_cli,
+                    include_internal=False,
+                )
         install_script = (
             str(install_plan.script_content or "").strip() if install_plan else ""
         )
@@ -164,12 +188,10 @@ class WorkerSetup:
             install_script=install_script,
             setup_agents_script=setup_agents_script,
         )
-        self.pull_image_if_needed(
-            platform_config.forced_platform, platform_config.platform_args
-        )
         caching_config = self._setup_caching(
             install_script=install_script,
             install_phase_name=install_phase_name,
+            skip_system_preflight=agent_probe_available is True,
         )
 
         # Assemble final prompt
@@ -531,6 +553,7 @@ class WorkerSetup:
         *,
         install_script: str = "",
         install_phase_name: str = "",
+        skip_system_preflight: bool = False,
     ) -> _CachingConfig:
         """Setup desktop and environment caching."""
         runtime_image = self._config.image
@@ -549,6 +572,16 @@ class WorkerSetup:
                 system_preflight_script = ""
 
         system_preflight_enabled = bool(system_preflight_script.strip())
+        if skip_system_preflight and system_preflight_enabled:
+            system_preflight_enabled = False
+            self._on_log(
+                format_log(
+                    "phase",
+                    "cache",
+                    "INFO",
+                    "system preflight skipped: agent executable is already available in pulled image",
+                )
+            )
         install_preflight_cached = False
         system_preflight_cached = False
         settings_preflight_cached = False

--- a/agents_runner/ui/interactive_prep_worker.py
+++ b/agents_runner/ui/interactive_prep_worker.py
@@ -9,6 +9,7 @@ from PySide6.QtCore import QObject
 from PySide6.QtCore import Signal
 from PySide6.QtCore import Slot
 
+from agents_runner.agent_install import probe_agent_executable_in_image
 from agents_runner.agent_install import resolve_agent_install_plan
 from agents_runner.docker.agent_worker_prompt import PromptAssembler
 from agents_runner.docker.process import has_image
@@ -217,8 +218,29 @@ class InteractivePrepWorker(QObject):
     def _resolve_runtime_image_for_launch(
         self, *, cmd_parts: list[str]
     ) -> dict[str, object]:
-        install_plan = None
+        agent_probe_available: bool | None = None
         if cmd_parts:
+            agent_probe_available = probe_agent_executable_in_image(
+                image=self._image,
+                agent_cli=str(cmd_parts[0]),
+                platform_args=docker_platform_args_for_pixelarch(),
+                task_token=self._task_id or "task",
+            )
+            self.log.emit(
+                self._task_id,
+                format_log(
+                    "install",
+                    "probe",
+                    "INFO",
+                    (
+                        f"image probe ({self._image}) agent={str(cmd_parts[0])}: "
+                        f"{'available' if agent_probe_available else 'missing'}"
+                    ),
+                ),
+            )
+
+        install_plan = None
+        if cmd_parts and agent_probe_available is not True:
             install_plan = resolve_agent_install_plan(
                 agent_cli=str(cmd_parts[0]),
                 include_internal=False,
@@ -240,6 +262,17 @@ class InteractivePrepWorker(QObject):
         desktop_cache_enabled = bool(
             self._cache_desktop_build and self._desktop_enabled
         )
+        if agent_probe_available is True and cache_system_enabled:
+            cache_system_enabled = False
+            self.log.emit(
+                self._task_id,
+                format_log(
+                    "phase",
+                    "cache",
+                    "INFO",
+                    "system preflight cache skipped: agent executable is already available in pulled image",
+                ),
+            )
 
         def on_phase_log(line: str) -> None:
             self.log.emit(self._task_id, str(line or ""))
@@ -268,6 +301,8 @@ class InteractivePrepWorker(QObject):
             "resolved_extra_preflight_script": result.desktop_preflight_script,
             "install_preflight_script": install_preflight_script,
             "install_phase_name": install_phase_name,
+            "agent_probe_available": agent_probe_available,
+            "skip_system_preflight": agent_probe_available is True,
         }
 
     def _append_full_prompt_github_context(
@@ -617,6 +652,12 @@ class InteractivePrepWorker(QObject):
                     ),
                     "install_phase_name": cache_resolution.get(
                         "install_phase_name", ""
+                    ),
+                    "agent_probe_available": cache_resolution.get(
+                        "agent_probe_available"
+                    ),
+                    "skip_system_preflight": bool(
+                        cache_resolution.get("skip_system_preflight", False)
                     ),
                     "setup_agents_script": setup_agents_script,
                 },

--- a/agents_runner/ui/main_window_tasks_interactive.py
+++ b/agents_runner/ui/main_window_tasks_interactive.py
@@ -633,6 +633,15 @@ class MainWindowTasksInteractiveMixin:
             payload.get("install_preflight_script") or ""
         )
         resolved_install_phase_name = str(payload.get("install_phase_name") or "")
+        agent_probe_available_override: bool | None = None
+        if (
+            "agent_probe_available" in payload
+            and payload.get("agent_probe_available") is not None
+        ):
+            agent_probe_available_override = bool(payload.get("agent_probe_available"))
+        skip_system_preflight_override = bool(
+            payload.get("skip_system_preflight", False)
+        )
 
         try:
             launch_docker_terminal_task(
@@ -688,6 +697,8 @@ class MainWindowTasksInteractiveMixin:
                 )
                 if has_runtime_cache_overrides
                 else None,
+                agent_probe_available_override=agent_probe_available_override,
+                skip_system_preflight_override=skip_system_preflight_override,
                 desktop_preflight_script_override=resolved_extra_preflight_script
                 if has_runtime_cache_overrides
                 else None,

--- a/agents_runner/ui/main_window_tasks_interactive_docker.py
+++ b/agents_runner/ui/main_window_tasks_interactive_docker.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from PySide6.QtWidgets import QMessageBox
 
+from agents_runner.agent_install import probe_agent_executable_in_image
 from agents_runner.agent_install import resolve_agent_install_plan
 from agents_runner.agent_cli import agent_requires_github_token
 from agents_runner.agent_cli import available_agents
@@ -117,6 +118,8 @@ def launch_docker_terminal_task(
     desktop_preflight_cached_override: bool | None = None,
     settings_preflight_cached_override: bool | None = None,
     install_preflight_cached_override: bool | None = None,
+    agent_probe_available_override: bool | None = None,
+    skip_system_preflight_override: bool = False,
     desktop_preflight_script_override: str | None = None,
 ) -> None:
     """Construct Docker command, generate host shell script, and launch terminal.
@@ -163,6 +166,8 @@ def launch_docker_terminal_task(
         desktop_preflight_cached_override: Optional precomputed desktop cache status
         settings_preflight_cached_override: Optional precomputed settings cache status
         install_preflight_cached_override: Optional precomputed install cache status
+        agent_probe_available_override: Optional precomputed image probe status
+        skip_system_preflight_override: Optional precomputed system-preflight skip
         desktop_preflight_script_override: Optional precomputed desktop script
     """
     # Apply desktop preflight script override if provided, before desktop detection
@@ -222,6 +227,7 @@ def launch_docker_terminal_task(
     def on_phase_log(line: str) -> None:
         main_window._on_task_log(task_id, line)
 
+    resolved_probe_available = agent_probe_available_override
     if use_precomputed_cache:
         runtime_image = str(runtime_image_override or image)
         install_preflight_cached = bool(install_preflight_cached_override)
@@ -229,7 +235,40 @@ def launch_docker_terminal_task(
         desktop_preflight_cached = bool(desktop_preflight_cached_override)
         settings_preflight_cached = bool(settings_preflight_cached_override)
     else:
-        if not resolved_install_preflight_script and cmd_parts:
+        if resolved_probe_available is None and cmd_parts and skip_image_pull:
+            resolved_probe_available = probe_agent_executable_in_image(
+                image=runtime_image,
+                agent_cli=str(cmd_parts[0]),
+                platform_args=docker_platform_args_for_pixelarch(),
+                task_token=task_token or task_id or "task",
+            )
+            on_phase_log(
+                format_log(
+                    "install",
+                    "probe",
+                    "INFO",
+                    (
+                        f"image probe ({runtime_image}) agent={str(cmd_parts[0])}: "
+                        f"{'available' if resolved_probe_available else 'missing'}"
+                    ),
+                )
+            )
+        if resolved_probe_available is True and cache_system_enabled:
+            cache_system_enabled = False
+            on_phase_log(
+                format_log(
+                    "phase",
+                    "cache",
+                    "INFO",
+                    "system preflight cache skipped: agent executable is already available in pulled image",
+                )
+            )
+
+        if (
+            not resolved_install_preflight_script
+            and cmd_parts
+            and resolved_probe_available is not True
+        ):
             install_plan = resolve_agent_install_plan(
                 agent_cli=str(cmd_parts[0]),
                 include_internal=False,
@@ -318,13 +357,28 @@ def launch_docker_terminal_task(
 
     run_interactive_mode = task.is_interactive_run()
     skip_system_preflight = bool(system_preflight_cached and not run_interactive_mode)
-    if run_interactive_mode and system_preflight_cached:
+    if skip_system_preflight_override or resolved_probe_available is True:
+        skip_system_preflight = True
+    if (
+        run_interactive_mode
+        and system_preflight_cached
+        and not (skip_system_preflight_override or resolved_probe_available is True)
+    ):
         on_phase_log(
             format_log(
                 "phase",
                 "cache",
                 "INFO",
                 "interactive run requires runtime system preflight; skipping cache-only shortcut",
+            )
+        )
+    if skip_system_preflight and resolved_probe_available is True:
+        on_phase_log(
+            format_log(
+                "phase",
+                "cache",
+                "INFO",
+                "system preflight skipped: probe confirmed agent executable in pulled image",
             )
         )
 


### PR DESCRIPTION
## Summary
- Added a probe-first agent availability check in the PixelArch image path using `docker run --rm --name agents-runner-probe-... /bin/bash -lc 'command -v <agent>'`.
- Added in-memory probe result caching keyed by image identity + platform args + agent CLI.
- Integrated probe gating into non-interactive worker setup and interactive prep/launch paths.
- If probe reports agent available, install preflight is skipped; if missing, existing install fallback is used.
- Aligned system-preflight behavior so it is skipped when probe confirms the agent executable is already present.

## Validation
- `sudo docker run --rm --name agents-runner-probe-manual-copilot lunamidori5/pixelarch:emerald /bin/bash -lc 'command -v copilot >/dev/null 2>&1'` → available.
- `sudo docker run --rm --name agents-runner-probe-manual-missing lunamidori5/pixelarch:emerald /bin/bash -lc 'command -v __definitely_missing_agent__ >/dev/null 2>&1'` → missing.
- `uv run ruff check` on changed files → pass.
- `python -m py_compile` on changed files → pass.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [Github Copilot](https://github.com/github/copilot-cli)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
