### PR TITLE
[FEATURE] Add global and per-environment GPU runtime controls

### DIFF
--- a/agents_runner/docker/agent_worker_container.py
+++ b/agents_runner/docker/agent_worker_container.py
@@ -844,9 +844,11 @@ class ContainerExecutor:
         command_clause: str,
     ) -> list[str]:
         """Build complete Docker run command arguments."""
+        gpu_args = ["--gpus", "all"] if bool(self._config.gpu_enabled) else []
         return [
             "run",
             *platform_args,
+            *gpu_args,
             "-d",
             "-t",
             "--name",

--- a/agents_runner/docker/config.py
+++ b/agents_runner/docker/config.py
@@ -21,6 +21,7 @@ class DockerRunnerConfig:
     cache_system_preflight_enabled: bool = False
     cache_settings_preflight_enabled: bool = False
     cache_ide_preflight_enabled: bool = False
+    gpu_enabled: bool = False
     setup_agents_missing_prompt_enabled: bool = False
     environment_id: str = ""
     workspace_type: str = "none"

--- a/agents_runner/environments/__init__.py
+++ b/agents_runner/environments/__init__.py
@@ -6,10 +6,14 @@ from agents_runner.environments.model import SYSTEM_ENV_NAME
 from agents_runner.environments.model import WORKSPACE_CLONED
 from agents_runner.environments.model import WORKSPACE_MOUNTED
 from agents_runner.environments.model import WORKSPACE_NONE
+from agents_runner.environments.model import GPU_OVERRIDE_MODE_DISABLED
+from agents_runner.environments.model import GPU_OVERRIDE_MODE_ENABLED
+from agents_runner.environments.model import GPU_OVERRIDE_MODE_INHERIT
 from agents_runner.environments.model import Environment
 from agents_runner.environments.github_repo import GitHubRepoContext
 from agents_runner.environments.github_repo import resolve_environment_github_repo
 from agents_runner.environments.model import PromptConfig
+from agents_runner.environments.model import normalize_gpu_override_mode
 from agents_runner.environments.model import normalize_workspace_type
 from agents_runner.environments.parse import parse_env_vars_text
 from agents_runner.environments.parse import parse_mounts_text
@@ -30,6 +34,9 @@ __all__ = [
     "WORKSPACE_CLONED",
     "WORKSPACE_MOUNTED",
     "WORKSPACE_NONE",
+    "GPU_OVERRIDE_MODE_DISABLED",
+    "GPU_OVERRIDE_MODE_ENABLED",
+    "GPU_OVERRIDE_MODE_INHERIT",
     "Environment",
     "GitHubRepoContext",
     "PromptConfig",
@@ -39,6 +46,7 @@ __all__ = [
     "load_environments",
     "managed_repo_checkout_path",
     "managed_repos_dir",
+    "normalize_gpu_override_mode",
     "normalize_workspace_type",
     "parse_env_vars_text",
     "parse_mounts_text",

--- a/agents_runner/environments/model.py
+++ b/agents_runner/environments/model.py
@@ -81,6 +81,15 @@ INTERACTIVE_PR_NO_PROMPT_MODES = (
     INTERACTIVE_PR_NO_PROMPT_MODE_MANUAL_REVIEW,
 )
 
+GPU_OVERRIDE_MODE_INHERIT = "inherit"
+GPU_OVERRIDE_MODE_ENABLED = "enabled"
+GPU_OVERRIDE_MODE_DISABLED = "disabled"
+GPU_OVERRIDE_MODES = (
+    GPU_OVERRIDE_MODE_INHERIT,
+    GPU_OVERRIDE_MODE_ENABLED,
+    GPU_OVERRIDE_MODE_DISABLED,
+)
+
 
 def normalize_workspace_type(value: str) -> str:
     """Normalize workspace type to canonical values."""
@@ -139,6 +148,14 @@ def normalize_interactive_pr_no_prompt_mode(value: str) -> str:
     return INTERACTIVE_PR_NO_PROMPT_MODE_AUTO_CREATE
 
 
+def normalize_gpu_override_mode(value: str) -> str:
+    """Normalize environment-level GPU override mode values."""
+    normalized = str(value or "").strip().lower()
+    if normalized in GPU_OVERRIDE_MODES:
+        return normalized
+    return GPU_OVERRIDE_MODE_INHERIT
+
+
 @dataclass
 class PromptConfig:
     enabled: bool = False
@@ -177,6 +194,7 @@ class Environment:
     agent_cli_args: str = ""
     max_agents_running: int = -1
     headless_desktop_enabled: bool = False
+    gpu_override_mode: str = GPU_OVERRIDE_MODE_INHERIT
     ide_system_override: str = ""
     cache_desktop_build: bool = False
     container_caching_enabled: bool = False

--- a/agents_runner/environments/serialize.py
+++ b/agents_runner/environments/serialize.py
@@ -11,6 +11,7 @@ from .model import Environment
 from .model import GH_TASK_BRANCH_CUSTOM_TEMPLATE_DEFAULT
 from .model import normalize_workspace_type
 from .model import normalize_agentsnova_auto_mode
+from .model import normalize_gpu_override_mode
 from .model import normalize_interactive_pr_no_prompt_mode
 from .model import normalize_agentsnova_marker_comment_mode
 from .model import normalize_gh_branch_work_mode
@@ -224,6 +225,9 @@ def environment_from_payload(payload: dict[str, Any]) -> Environment | None:
         max_agents_running = -1
 
     headless_desktop_enabled = bool(payload.get("headless_desktop_enabled", False))
+    gpu_override_mode = normalize_gpu_override_mode(
+        payload.get("gpu_override_mode", "inherit")
+    )
     ide_system_override_raw = str(payload.get("ide_system_override") or "").strip()
     ide_system_override = (
         normalize_ide_system_name(ide_system_override_raw)
@@ -489,6 +493,7 @@ def environment_from_payload(payload: dict[str, Any]) -> Environment | None:
         agent_cli_args=agent_cli_args,
         max_agents_running=max_agents_running,
         headless_desktop_enabled=headless_desktop_enabled,
+        gpu_override_mode=gpu_override_mode,
         ide_system_override=ide_system_override,
         cache_desktop_build=cache_desktop_build,
         container_caching_enabled=container_caching_enabled,
@@ -578,6 +583,9 @@ def serialize_environment(env: Environment) -> dict[str, Any]:
         "max_agents_running": int(env.max_agents_running),
         "headless_desktop_enabled": bool(
             getattr(env, "headless_desktop_enabled", False)
+        ),
+        "gpu_override_mode": normalize_gpu_override_mode(
+            str(getattr(env, "gpu_override_mode", "inherit") or "inherit")
         ),
         "ide_system_override": (
             normalize_ide_system_name(

--- a/agents_runner/execution/supervisor.py
+++ b/agents_runner/execution/supervisor.py
@@ -545,6 +545,7 @@ class TaskSupervisor:
             cache_system_preflight_enabled=self._config.cache_system_preflight_enabled,
             cache_settings_preflight_enabled=self._config.cache_settings_preflight_enabled,
             cache_ide_preflight_enabled=self._config.cache_ide_preflight_enabled,
+            gpu_enabled=self._config.gpu_enabled,
             setup_agents_missing_prompt_enabled=(
                 self._config.setup_agents_missing_prompt_enabled
             ),

--- a/agents_runner/persistence.py
+++ b/agents_runner/persistence.py
@@ -527,6 +527,7 @@ def _deserialize_runner_config(payload: dict[str, Any], *, task_id: str) -> Any:
             cache_ide_preflight_enabled=bool(
                 payload.get("cache_ide_preflight_enabled") or False
             ),
+            gpu_enabled=bool(payload.get("gpu_enabled") or False),
             setup_agents_missing_prompt_enabled=bool(
                 payload.get("setup_agents_missing_prompt_enabled") or False
             ),

--- a/agents_runner/ui/main_window.py
+++ b/agents_runner/ui/main_window.py
@@ -106,6 +106,7 @@ class MainWindow(
             "max_agents_running": -1,
             "append_pixelarch_context": False,
             "headless_desktop_enabled": False,
+            "gpu_enabled": False,
             "auto_navigate_on_run_agent_start": False,
             "auto_navigate_on_run_interactive_start": False,
             "ui_theme": "auto",

--- a/agents_runner/ui/main_window_persistence.py
+++ b/agents_runner/ui/main_window_persistence.py
@@ -171,6 +171,7 @@ class MainWindowPersistenceMixin:
         self._settings_data.setdefault("ide_novnc_auto_open_enabled", True)
         self._settings_data.setdefault("ide_novnc_auto_open_mode", "viewing_only")
         self._settings_data.setdefault("headless_desktop_enabled", False)
+        self._settings_data.setdefault("gpu_enabled", False)
         self._settings_data.setdefault("auto_navigate_on_run_agent_start", False)
         self._settings_data.setdefault("auto_navigate_on_run_interactive_start", False)
         self._settings_data.setdefault("spellcheck_enabled", True)
@@ -227,6 +228,9 @@ class MainWindowPersistenceMixin:
             .lower()
             == "always"
             else "viewing_only"
+        )
+        self._settings_data["gpu_enabled"] = bool(
+            self._settings_data.get("gpu_enabled") or False
         )
         try:
             from agents_runner.ui.graphics import normalize_ui_theme_name

--- a/agents_runner/ui/main_window_preflight.py
+++ b/agents_runner/ui/main_window_preflight.py
@@ -101,6 +101,7 @@ class MainWindowPreflightMixin:
         )
         env_headless_desktop = bool(getattr(env, "headless_desktop_enabled", False))
         headless_desktop_enabled = bool(force_headless_desktop or env_headless_desktop)
+        gpu_enabled = self._effective_gpu_enabled(env=env, settings=self._settings_data)
         desktop_cache_enabled = bool(getattr(env, "cache_desktop_build", False))
         desktop_cache_enabled = desktop_cache_enabled and headless_desktop_enabled
         smoke_command = f'echo "preflight smoke: {env.name or env.env_id}"; sleep 10'
@@ -131,6 +132,7 @@ class MainWindowPreflightMixin:
             cache_ide_preflight_enabled=bool(
                 getattr(env, "cache_ide_preflight_enabled", False)
             ),
+            gpu_enabled=gpu_enabled,
             env_vars=dict(env.env_vars) if env else {},
             extra_mounts=self._get_extra_mounts_with_cache(env),
             custom_command_argv=["sh", "-c", smoke_command],

--- a/agents_runner/ui/main_window_settings.py
+++ b/agents_runner/ui/main_window_settings.py
@@ -20,6 +20,7 @@ from agents_runner.ide_systems import normalize_ide_system_name
 from agents_runner.ui.radio import RadioController
 from agents_runner.ui.utils import looks_like_agent_help_command
 from agents_runner.environments import Environment
+from agents_runner.environments.model import normalize_gpu_override_mode
 from agents_runner.gh.automation_policy import normalize_default_marker_comment_mode
 
 logger = logging.getLogger(__name__)
@@ -152,6 +153,7 @@ class MainWindowSettingsMixin:
         merged["headless_desktop_enabled"] = bool(
             merged.get("headless_desktop_enabled") or False
         )
+        merged["gpu_enabled"] = bool(merged.get("gpu_enabled") or False)
         merged["popup_theme_animation_enabled"] = bool(
             merged.get("popup_theme_animation_enabled", True)
         )
@@ -588,6 +590,25 @@ class MainWindowSettingsMixin:
             == "always"
             else "viewing_only"
         )
+
+    def _effective_gpu_enabled(
+        self,
+        *,
+        env: Environment | None,
+        settings: dict[str, object] | None = None,
+    ) -> bool:
+        settings_data = settings or self._settings_data
+        global_enabled = bool(settings_data.get("gpu_enabled") or False)
+        if env is None:
+            return global_enabled
+        mode = normalize_gpu_override_mode(
+            str(getattr(env, "gpu_override_mode", "inherit") or "inherit")
+        )
+        if mode == "enabled":
+            return True
+        if mode == "disabled":
+            return False
+        return global_enabled
 
     def _resolve_override_config_dir(
         self,

--- a/agents_runner/ui/main_window_tasks_agent.py
+++ b/agents_runner/ui/main_window_tasks_agent.py
@@ -286,6 +286,7 @@ class MainWindowTasksAgentMixin:
             )
 
         headless_desktop_enabled = ide_display_target == IDE_DISPLAY_CONTAINER_DESKTOP
+        gpu_enabled = self._effective_gpu_enabled(env=env, settings=self._settings_data)
         desktop_cache_enabled = (
             bool(getattr(env, "cache_desktop_build", False)) if env else False
         )
@@ -400,6 +401,7 @@ class MainWindowTasksAgentMixin:
             cache_system_preflight_enabled=cache_system_preflight_enabled,
             cache_settings_preflight_enabled=cache_settings_preflight_enabled,
             cache_ide_preflight_enabled=cache_ide_preflight_enabled,
+            gpu_enabled=gpu_enabled,
             setup_agents_missing_prompt_enabled=bool(
                 env and getattr(env, "setup_agents_missing_prompt_enabled", False)
             ),
@@ -806,6 +808,7 @@ class MainWindowTasksAgentMixin:
             bool(getattr(env, "headless_desktop_enabled", False)) if env else False
         )
         headless_desktop_enabled = bool(force_headless_desktop or env_headless_desktop)
+        gpu_enabled = self._effective_gpu_enabled(env=env, settings=self._settings_data)
         desktop_cache_enabled = (
             bool(getattr(env, "cache_desktop_build", False)) if env else False
         )
@@ -1180,6 +1183,7 @@ class MainWindowTasksAgentMixin:
             cache_system_preflight_enabled=cache_system_preflight_enabled,
             cache_settings_preflight_enabled=cache_settings_preflight_enabled,
             cache_ide_preflight_enabled=cache_ide_preflight_enabled,
+            gpu_enabled=gpu_enabled,
             setup_agents_missing_prompt_enabled=bool(
                 env and getattr(env, "setup_agents_missing_prompt_enabled", False)
             ),

--- a/agents_runner/ui/main_window_tasks_interactive.py
+++ b/agents_runner/ui/main_window_tasks_interactive.py
@@ -86,6 +86,7 @@ class MainWindowTasksInteractiveMixin:
             )
             return
         env = self._environments.get(env_id)
+        gpu_enabled = self._effective_gpu_enabled(env=env, settings=self._settings_data)
 
         task_id = uuid4().hex[:10]
         task_token = f"interactive-{task_id}"
@@ -422,6 +423,7 @@ class MainWindowTasksInteractiveMixin:
             "prep_id": prep_id,
             "shell_mode": shell_mode,
             "shell": shell,
+            "gpu_enabled": gpu_enabled,
         }
         prep_bridge = InteractivePrepBridge(
             on_stage=self._on_interactive_prep_stage,
@@ -712,6 +714,7 @@ class MainWindowTasksInteractiveMixin:
                 else None,
                 shell_mode=bool(context.get("shell_mode")),
                 shell=str(context.get("shell") or "bash"),
+                gpu_enabled=bool(context.get("gpu_enabled") or False),
             )
         except Exception as exc:
             self._on_interactive_prep_failed(task_id, str(exc))
@@ -719,10 +722,18 @@ class MainWindowTasksInteractiveMixin:
 
         self._clear_interactive_prep_refs(task_id)
 
-    def _start_interactive_finish_watch(self, task_id: str, finish_path: str) -> None:
+    def _start_interactive_finish_watch(
+        self, task_id: str, finish_path: str, error_log_path: str | None = None
+    ) -> None:
         task_id = str(task_id or "").strip()
         finish_path = os.path.abspath(
             os.path.expanduser(str(finish_path or "").strip())
+        )
+        error_candidate = str(error_log_path or "").strip()
+        resolved_error_log_path = (
+            os.path.abspath(os.path.expanduser(error_candidate))
+            if error_candidate
+            else ""
         )
         if not task_id or not finish_path:
             return
@@ -751,6 +762,25 @@ class MainWindowTasksInteractiveMixin:
                     break
                 except Exception:
                     time.sleep(0.2)
+
+            if exit_code != 0 and resolved_error_log_path:
+                try:
+                    with open(resolved_error_log_path, "r", encoding="utf-8") as f:
+                        lines = [str(line or "").rstrip("\n") for line in f.readlines()]
+                    lines = [line for line in lines if line.strip()]
+                    if lines:
+                        tail = "\n".join(lines[-20:])
+                        self._on_task_log(
+                            task_id,
+                            format_log(
+                                "docker",
+                                "run",
+                                "ERROR",
+                                f"interactive launch error details:\n{tail}",
+                            ),
+                        )
+                except Exception:
+                    pass
 
             # Encrypt finish file as artifact before deleting
             try:
@@ -793,6 +823,13 @@ class MainWindowTasksInteractiveMixin:
                 logger.rprint(
                     f"[finish] Failed to delete finish file: {exc!r}", mode="warn"
                 )
+
+            if resolved_error_log_path:
+                try:
+                    if os.path.exists(resolved_error_log_path):
+                        os.unlink(resolved_error_log_path)
+                except Exception:
+                    pass
 
             self.interactive_finished.emit(task_id, int(exit_code))
 

--- a/agents_runner/ui/main_window_tasks_interactive_docker.py
+++ b/agents_runner/ui/main_window_tasks_interactive_docker.py
@@ -123,6 +123,7 @@ def launch_docker_terminal_task(
     desktop_preflight_script_override: str | None = None,
     shell_mode: bool = False,
     shell: str = "bash",
+    gpu_enabled: bool = False,
 ) -> None:
     """Construct Docker command, generate host shell script, and launch terminal.
 
@@ -173,6 +174,7 @@ def launch_docker_terminal_task(
         desktop_preflight_script_override: Optional precomputed desktop script
         shell_mode: If True, run shell instead of agent command
         shell: Shell to use when shell_mode is True (bash, sh, zsh, fish, tmux)
+        gpu_enabled: If True, request Docker GPU runtime (`--gpus all`)
     """
     # Apply desktop preflight script override if provided, before desktop detection
     desktop_preflight_script = str(extra_preflight_script or "")
@@ -536,6 +538,7 @@ def launch_docker_terminal_task(
             image=runtime_image,
             container_script=container_script,
             shell_mode=shell_mode,
+            gpu_enabled=gpu_enabled,
         )
 
         docker_cmd_for_log = _build_docker_command(
@@ -552,6 +555,7 @@ def launch_docker_terminal_task(
             image=runtime_image,
             container_script=container_script,
             shell_mode=shell_mode,
+            gpu_enabled=gpu_enabled,
         )
         main_window._on_task_log(
             task_id,
@@ -562,11 +566,14 @@ def launch_docker_terminal_task(
         finish_dir = os.path.dirname(main_window._state_path)
         os.makedirs(finish_dir, exist_ok=True)
         finish_path = os.path.join(finish_dir, f"interactive-finish-{task_id}.txt")
+        error_log_path = os.path.join(finish_dir, f"interactive-error-{task_id}.log")
         try:
             if os.path.exists(finish_path):
                 os.unlink(finish_path)
+            if os.path.exists(error_log_path):
+                os.unlink(error_log_path)
         except Exception:
-            # Best-effort cleanup: ignore errors while removing stale finish file.
+            # Best-effort cleanup: ignore errors while removing stale local files.
             pass
 
         # Build Rosetta warning snippet
@@ -592,6 +599,7 @@ def launch_docker_terminal_task(
             task_token=task_token,
             tmp_paths=tmp_paths,
             finish_path=finish_path,
+            error_log_path=error_log_path,
             gh_token_snippet="",
             rosetta_snippet=rosetta_snippet,
             docker_pull_cmd=docker_pull_cmd,
@@ -622,7 +630,9 @@ def launch_docker_terminal_task(
         main_window._schedule_save()
 
         # Start finish file watcher
-        main_window._start_interactive_finish_watch(task_id, finish_path)
+        main_window._start_interactive_finish_watch(
+            task_id, finish_path, error_log_path
+        )
 
         # Log launch
         main_window._on_task_log(
@@ -936,6 +946,7 @@ def _build_docker_command(
     image: str,
     container_script: str,
     shell_mode: bool = False,
+    gpu_enabled: bool = False,
 ) -> str:
     """Build complete Docker run command string.
 
@@ -953,15 +964,18 @@ def _build_docker_command(
         image: Docker image name
         container_script: Container script to execute
         shell_mode: If True, skip agent config dir mount (for "To Shell" feature)
+        gpu_enabled: If True, add `--gpus all` to docker run
 
     Returns:
         Complete Docker command string
     """
     docker_platform_args = docker_platform_args_for_pixelarch()
+    gpu_args = ["--gpus", "all"] if bool(gpu_enabled) else []
     docker_args: list[str] = [
         "docker",
         "run",
         *docker_platform_args,
+        *gpu_args,
         "-it",
         "--name",
         container_name,
@@ -998,6 +1012,7 @@ def _build_host_shell_script(
     task_token: str,
     tmp_paths: dict[str, str],
     finish_path: str,
+    error_log_path: str,
     gh_token_snippet: str,
     rosetta_snippet: str,
     docker_pull_cmd: str,
@@ -1010,6 +1025,7 @@ def _build_host_shell_script(
         task_token: Unique task token
         tmp_paths: Dict of temp file paths for cleanup
         finish_path: Path to finish file
+        error_log_path: Path to captured docker stderr text
         gh_token_snippet: GH token setup snippet
         rosetta_snippet: Rosetta warning snippet
         docker_pull_cmd: Docker pull command
@@ -1027,6 +1043,7 @@ def _build_host_shell_script(
         f"TMP_SETTINGS={shlex.quote(tmp_paths.get('settings', ''))}",
         f"TMP_SETUP_AGENTS={shlex.quote(tmp_paths.get('setup_agents', ''))}",
         f"FINISH_FILE={shlex.quote(finish_path)}",
+        f"ERROR_FILE={shlex.quote(error_log_path)}",
         'write_finish() { STATUS="${1:-0}"; printf "%s\\n" "$STATUS" >"$FINISH_FILE" 2>/dev/null || true; }',
         'cleanup() { docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true; '
         + 'if [ -n "$TMP_SYSTEM" ]; then rm -f -- "$TMP_SYSTEM" >/dev/null 2>&1 || true; fi; '
@@ -1046,7 +1063,8 @@ def _build_host_shell_script(
     host_script_parts.extend(
         [
             f'{docker_pull_cmd} || {{ STATUS=$?; echo "[host/docker][ERROR] docker pull failed (exit $STATUS)"; write_finish "$STATUS"; read -r -p "Press Enter to close..."; exit $STATUS; }}',
-            f'{docker_cmd}; STATUS=$?; if [ $STATUS -ne 0 ]; then echo "[host/docker][ERROR] container command failed (exit $STATUS)"; fi; write_finish "$STATUS"; if [ $STATUS -ne 0 ]; then read -r -p "Press Enter to close..."; fi; exit $STATUS',
+            ': > "$ERROR_FILE" 2>/dev/null || true',
+            f'{docker_cmd} 2> >(tee "$ERROR_FILE" >&2); STATUS=$?; if [ $STATUS -ne 0 ] && [ ! -s "$ERROR_FILE" ]; then echo "[host/docker][ERROR] container command failed (exit $STATUS)" | tee -a "$ERROR_FILE"; elif [ $STATUS -ne 0 ]; then echo "[host/docker][ERROR] container command failed (exit $STATUS)"; fi; write_finish "$STATUS"; if [ $STATUS -ne 0 ]; then read -r -p "Press Enter to close..."; fi; exit $STATUS',
         ]
     )
 

--- a/agents_runner/ui/pages/environments.py
+++ b/agents_runner/ui/pages/environments.py
@@ -24,6 +24,7 @@ from agents_runner.environments.model import (
     GH_TASK_BRANCH_CUSTOM_TEMPLATE_DEFAULT,
     INTERACTIVE_PR_NO_PROMPT_MODE_AUTO_CREATE,
     normalize_agentsnova_auto_mode,
+    normalize_gpu_override_mode,
     normalize_interactive_pr_no_prompt_mode,
     normalize_agentsnova_marker_comment_mode,
     normalize_gh_branch_work_mode,
@@ -358,6 +359,11 @@ class EnvironmentsPage(
                 self._name.setText("")
                 self._max_agents_running.setText("-1")
                 self._headless_desktop_enabled.setChecked(False)
+                gpu_mode_idx = self._gpu_override_mode.findData("inherit")
+                if gpu_mode_idx < 0:
+                    gpu_mode_idx = 0
+                if gpu_mode_idx >= 0:
+                    self._gpu_override_mode.setCurrentIndex(gpu_mode_idx)
                 self._ide_system_override.setCurrentIndex(0)
                 self._cache_desktop_build.setChecked(False)
                 self._cache_desktop_build.setEnabled(False)
@@ -462,6 +468,16 @@ class EnvironmentsPage(
             self._headless_desktop_enabled.setChecked(
                 bool(getattr(env, "headless_desktop_enabled", False))
             )
+            gpu_mode = normalize_gpu_override_mode(
+                getattr(env, "gpu_override_mode", "inherit")
+            )
+            gpu_mode_idx = self._gpu_override_mode.findData(gpu_mode)
+            if gpu_mode_idx < 0:
+                gpu_mode_idx = self._gpu_override_mode.findData("inherit")
+            if gpu_mode_idx < 0:
+                gpu_mode_idx = 0
+            if gpu_mode_idx >= 0:
+                self._gpu_override_mode.setCurrentIndex(gpu_mode_idx)
             ide_system_override = str(getattr(env, "ide_system_override", "") or "")
             ide_system_idx = self._ide_system_override.findData(ide_system_override)
             if ide_system_idx < 0:

--- a/agents_runner/ui/pages/environments_actions.py
+++ b/agents_runner/ui/pages/environments_actions.py
@@ -14,6 +14,7 @@ from agents_runner.environments import load_environments
 from agents_runner.environments import save_environment
 from agents_runner.environments.model import (
     normalize_agentsnova_auto_mode,
+    normalize_gpu_override_mode,
     normalize_interactive_pr_no_prompt_mode,
     normalize_agentsnova_marker_comment_mode,
     normalize_gh_branch_work_mode,
@@ -133,6 +134,9 @@ class EnvironmentsPageActionsMixin:
                 normalize_gh_task_branch_custom_template(
                     self._gh_task_branch_custom_template.text()
                 )
+            ),
+            "gpu_override_mode": normalize_gpu_override_mode(
+                str(self._gpu_override_mode.currentData() or "inherit")
             ),
         }
 

--- a/agents_runner/ui/pages/environments_form.py
+++ b/agents_runner/ui/pages/environments_form.py
@@ -148,6 +148,13 @@ class EnvironmentsFormMixin:
         self._headless_desktop_enabled.stateChanged.connect(
             self._on_headless_desktop_toggled
         )
+        self._gpu_override_mode = QComboBox()
+        self._gpu_override_mode.addItem("Inherit global setting", "inherit")
+        self._gpu_override_mode.addItem("Enabled", "enabled")
+        self._gpu_override_mode.addItem("Disabled", "disabled")
+        self._gpu_override_mode.setToolTip(
+            "Override the global GPU runtime setting for this environment."
+        )
         self._ide_system_override = QComboBox()
         self._ide_system_override.addItem("Inherit setting default", "")
         for ide_name in available_ide_system_names():
@@ -421,8 +428,9 @@ class EnvironmentsFormMixin:
         add_grid_row(grid, 1, QLabel("Color"), self._color)
         add_grid_row(grid, 3, QLabel("Max agents running"), max_agents_row)
         add_grid_row(grid, 4, self._headless_desktop_label, self._headless_desktop_row)
-        add_grid_row(grid, 5, QLabel("IDE override"), self._ide_system_override)
-        add_grid_row(grid, 6, QLabel("Cross agents"), cross_agents_row)
+        add_grid_row(grid, 5, QLabel("GPU runtime"), self._gpu_override_mode)
+        add_grid_row(grid, 6, QLabel("IDE override"), self._ide_system_override)
+        add_grid_row(grid, 7, QLabel("Cross agents"), cross_agents_row)
 
         general_body.addLayout(grid)
         general_body.addStretch(1)

--- a/agents_runner/ui/pages/environments_navigation.py
+++ b/agents_runner/ui/pages/environments_navigation.py
@@ -22,6 +22,7 @@ class EnvironmentsNavigationMixin:
         for combo in (
             self._color,
             self._workspace_type_combo,
+            self._gpu_override_mode,
             self._ide_system_override,
             self._agentsnova_trusted_mode,
             self._agentsnova_auto_review_mode,

--- a/agents_runner/ui/pages/settings.py
+++ b/agents_runner/ui/pages/settings.py
@@ -161,6 +161,7 @@ class SettingsPage(QWidget, SettingsFormMixin):
             self._agentsnova_auto_reactions_enabled,
             self._github_polling_enabled,
             self._headless_desktop_enabled,
+            self._gpu_enabled,
             self._popup_theme_animation_enabled,
             self._auto_navigate_on_run_agent_start,
             self._auto_navigate_on_run_interactive_start,

--- a/agents_runner/ui/pages/settings_form.py
+++ b/agents_runner/ui/pages/settings_form.py
@@ -196,6 +196,11 @@ class SettingsFormMixin:
         self._headless_desktop_enabled.setToolTip(
             "When enabled, this overrides per-environment headless desktop settings."
         )
+        self._gpu_enabled = QCheckBox("Enabled")
+        self._gpu_enabled.setToolTip(
+            "When enabled, task containers request GPU runtime access (`--gpus all`) "
+            "for Agent, Interactive, and IDE runs."
+        )
         self._auto_navigate_on_run_agent_start = QCheckBox("Enabled")
         self._auto_navigate_on_run_agent_start.setToolTip(
             "When enabled, starting a Run Agent task switches to the Home dashboard."
@@ -553,25 +558,31 @@ class SettingsFormMixin:
         add_grid_row(
             ide_grid,
             2,
+            QLabel("Enable GPU"),
+            self._gpu_enabled,
+        )
+        add_grid_row(
+            ide_grid,
+            3,
             QLabel("Navigate Home on Run Agent start"),
             self._auto_navigate_on_run_agent_start,
         )
         add_grid_row(
             ide_grid,
-            3,
+            4,
             QLabel("Navigate Home on Run Interactive start"),
             self._auto_navigate_on_run_interactive_start,
         )
         add_grid_row(
             ide_grid,
-            4,
+            5,
             QLabel("Mount host cache"),
             self._mount_host_cache,
         )
-        add_grid_row(ide_grid, 5, QLabel("Default IDE"), self._ide_system_default)
+        add_grid_row(ide_grid, 6, QLabel("Default IDE"), self._ide_system_default)
         add_grid_row(
             ide_grid,
-            6,
+            7,
             QLabel("Run IDE auto-open mode"),
             self._ide_novnc_auto_open_mode,
         )
@@ -990,6 +1001,7 @@ class SettingsFormMixin:
             self._headless_desktop_enabled.setChecked(
                 bool(settings.get("headless_desktop_enabled") or False)
             )
+            self._gpu_enabled.setChecked(bool(settings.get("gpu_enabled") or False))
             self._auto_navigate_on_run_agent_start.setChecked(
                 bool(settings.get("auto_navigate_on_run_agent_start") or False)
             )
@@ -1213,6 +1225,7 @@ class SettingsFormMixin:
             "headless_desktop_enabled": bool(
                 self._headless_desktop_enabled.isChecked()
             ),
+            "gpu_enabled": bool(self._gpu_enabled.isChecked()),
             "auto_navigate_on_run_agent_start": bool(
                 self._auto_navigate_on_run_agent_start.isChecked()
             ),


### PR DESCRIPTION
## Summary
- added a global **Enable GPU** setting in desktop settings
- added per-environment **GPU runtime** override with tri-state behavior:
  - inherit global setting
  - enabled
  - disabled
- wired effective GPU resolution into all launch paths:
  - Run Agent
  - Run Interactive
  - Run IDE
  - Preflight containers

## Runtime behavior
- when effective GPU is enabled, Docker run commands now include `--gpus all`
- worker/supervisor config now persists `gpu_enabled` so resumed tasks keep behavior
- interactive Docker launch now captures stderr to a task-scoped error log and surfaces tail lines into task logs on failure

## Compatibility and safety
- defaults remain GPU disabled globally
- environment payloads normalize unknown GPU override values to `inherit`
- existing IDE app launch args that include `--disable-gpu` were preserved

## Verification
- formatted/linted with Ruff (`uv run ruff format .`, `uv run ruff check .`)
- syntax-checked touched Python modules via `uv run python -m py_compile ...`
- basedpyright reports repository-wide baseline issues in these modules; no new GPU-specific type break was identified from local diff review
- in-container smoke test on 2026-03-16 verified GPU visibility via `nvidia-smi` (exit 0), reporting:
  - NVIDIA GeForce RTX 4060 Ti
  - driver 580.142
  - CUDA 13.0

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
