### PR TITLE
[FEATURE] Add Qwen and OpenCode agent systems

### DIFF
--- a/.agents/planning/plan.md
+++ b/.agents/planning/plan.md
@@ -1,0 +1,311 @@
+# Build plan: Add Qwen and OpenCode agent systems
+
+## 1) Title and objective
+
+Objective: add two first-class agent systems, Qwen and OpenCode, across plugin discovery, Docker runtime planning, setup/login/status flows, UI selection surfaces, prompt templates, and themes, while keeping the work plugin-driven and reviewable.
+
+This document is planning only. It makes no implementation edits, adds no tests, and does not change `README.md`.
+
+## 2) Scope and non-goals
+
+### In scope
+
+- Add new plugin packages under `agents_runner/agent_systems/qwen/` and `agents_runner/agent_systems/opencode/`.
+- Wire install, verify, non-interactive planning, interactive command building, setup/login/status, prompt templates, display metadata, and optional themes.
+- Update UI and status surfaces so both systems appear anywhere agent systems are selected, displayed, or validated.
+- Keep package/install references PixelArch-first and use `yay` when install commands are needed.
+
+### Non-goals
+
+- No implementation in this planning pass.
+- No `README.md` updates.
+- No new tests unless explicitly requested later.
+- No unrelated refactors; only make narrow cleanups where hard-coded agent assumptions block Qwen/OpenCode.
+- Do not change the default system from `codex` as part of this work.
+- Do not broaden OpenCode persistence mounts beyond the trusted boundary described below unless runtime evidence later proves it is required.
+
+## 3) Confirmed CLI/install naming matrix (OpenCode + Qwen)
+
+### OpenCode
+
+- Runtime binary: `opencode`.
+- Confirmed evidence:
+  - `opencode --version` works locally (`1.2.27`).
+  - `opencode --help` works locally.
+  - `yay -Si opencode` exists in PixelArch `extra`, version `1.2.27-1`.
+- Install command to use in plugin/runtime planning: `yay -S --noconfirm --needed opencode`.
+- Runtime path model from audit:
+  - config: `~/.config/opencode`
+  - data: `~/.local/share/opencode`
+  - cache: `~/.cache/opencode`
+- Mount policy: OpenCode must use a dual mount for config + data as an intentional trusted boundary. Do not collapse it to one mount, and do not mount cache by default. The goal is to preserve functionality, auth, and session continuity without widening persistence unnecessarily.
+
+### Qwen
+
+- Install/package corroboration:
+  - `yay -Si qwen-code` exists, version `0.12.6-1`, URL `https://github.com/QwenLM/qwen-code`.
+  - `yay -Si qwen` is not a valid package target.
+  - `command -v qwen` succeeds in this environment while `command -v qwen-code` is absent, so the runtime binary is `qwen`.
+  - `qwen --version` works and reports `0.12.6`.
+  - `npm view @qwen-code/qwen-code` returns package `@qwen-code/qwen-code` and its `bin` entry is `qwen`.
+- Preferred install command to use in plugin/runtime planning: `yay -S --noconfirm --needed qwen-code`.
+- Runtime executable:
+  - Binary: `qwen` (the `qwen-code` package installs this binary; the `qwen-code` CLI is not provided).
+  - Verified by running `qwen --help` and `qwen --version`, then lock `qwen` for that environment so all setup/status checks and command generation reuse the same executable.
+  - `qwen --help` lists a limited set of safe flags that overlap with Gemini; we will only converge on the confirmed ones:
+    - `--approval-mode yolo`, `--include-directories`, `-i/--prompt-interactive`.
+    - Prompt input is best served via the positional query argument for one-shot flows, and `-p/--prompt` should remain deprecated compatibility only.
+    - Do not assume `--no-sandbox` is a default flag for Qwen; we will add it explicitly only if the runtime help output confirms it as required.
+  - Current docs indicate user config at `~/.qwen/settings.json`; implementation should use `~/.qwen` as the planned default host config dir, then confirm any auth sidecar details during runtime validation.
+
+## 4) Architecture impact map (by subsystem with file paths)
+
+### Plugin core and discovery
+
+- `agents_runner/agent_systems/models.py`
+  - Validate whether the current plugin contract is sufficient.
+  - Prefer no contract expansion unless Qwen executable locking cannot stay localized to plugin/status helpers.
+- `agents_runner/agent_systems/registry.py`
+  - Built-in folder discovery already exists; verify new plugin folders are auto-discovered without new registry entries.
+- `agents_runner/agent_systems/__init__.py`
+  - Keep exports/docstring aligned if examples or package notes need a refresh.
+- New files to add:
+  - `agents_runner/agent_systems/qwen/plugin.py`
+  - `agents_runner/agent_systems/qwen/__init__.py`
+  - `agents_runner/agent_systems/opencode/plugin.py`
+  - `agents_runner/agent_systems/opencode/__init__.py`
+
+### Install and command/runtime plumbing
+
+- `agents_runner/agent_install.py`
+  - Add install plans for Qwen and OpenCode.
+  - Keep install name and runtime executable distinct where needed, especially for Qwen (`qwen-code` package vs `qwen` runtime).
+- `agents_runner/agent_cli.py`
+  - Ensure default config dirs, container config dirs, extra mounts, and verify clauses stay plugin-driven.
+  - Confirm OpenCode additional mounts render correctly in Docker mount strings.
+- `agents_runner/ui/main_window_tasks_interactive_command.py`
+  - Ensure interactive command normalization and prompt injection behave correctly for Qwen/OpenCode.
+- `agents_runner/ui/main_window_tasks_interactive.py`
+  - Confirm plugin default command resolution and cross-agent mount assembly work with both systems.
+- `agents_runner/ui/main_window_tasks_interactive_docker.py`
+  - Ensure launch-time Docker mount assembly respects OpenCode dual mounts and plugin verification rules.
+- `agents_runner/docker/agent_worker_setup.py`
+  - Ensure runtime environment planning carries plugin mounts/install plans forward during image prep.
+- `agents_runner/execution/supervisor.py`
+  - Validate attempt keys, config-dir resolution, and logging remain correct for new systems.
+
+### Setup, status, and first-run flows
+
+- `agents_runner/setup/commands.py`
+  - Expose setup/config/verify commands for Qwen and OpenCode.
+- `agents_runner/setup/agent_status.py`
+  - Keep the existing generic `detect_all_agents()` flow; MVP skips a dedicated `detect_qwen_status()` so Qwen rows may temporarily remain `Unknown`/unavailable in first-run and test-chain views. Document that execution is not blocked by this omission and that a future status integration will replace the placeholder state.
+  - OpenCode should prefer CLI-backed provider/auth inspection and keep a clear fallback policy.
+- `agents_runner/ui/dialogs/first_run_setup.py`
+  - Show both systems in first-run status/setup rows with correct display names.
+- `agents_runner/ui/dialogs/test_chain_dialog.py`
+  - Ensure chain testing includes both systems via `detect_all_agents()` results.
+
+### UI, settings, display, and themes
+
+- `agents_runner/ui/pages/settings_form.py`
+  - Agent picker is already plugin-driven; verify labels and theme availability once new plugins exist.
+- `agents_runner/ui/pages/environments_agents.py`
+  - Replace raw `agent.title()` display with plugin display names so `OpenCode` renders cleanly and future slugs stay consistent.
+- `agents_runner/ui/main_window_settings.py`
+  - Keep config-dir resolution and cross-agent mount generation plugin-driven for both systems.
+- `agents_runner/agent_display.py`
+  - Add display names and GitHub URLs for Qwen and OpenCode.
+- `agents_runner/ui/graphics.py`
+  - Ensure auto-theme discovery and fallback behavior pick up the new themes.
+- Possible new theme directories:
+  - `agents_runner/ui/themes/qwen/`
+  - `agents_runner/ui/themes/opencode/`
+
+### Prompt templates
+
+- `agents_runner/prompts/templates/agentcli/qwen.md`
+- `agents_runner/prompts/templates/agentcli/opencode.md`
+- `agents_runner/docker/agent_worker_prompt.py`
+  - No new logic should be needed if template filenames match plugin names, but this loader is the runtime consumer and should be part of validation.
+
+### Secondary hard-coded reliability/display surfaces found during review
+
+- `agents_runner/ui/widgets/agent_chain_status.py`
+  - Replace raw `title()` formatting with centralized display labels.
+- `agents_runner/ui/pages/new_task.py`
+  - Already routes through `agent_display.py`; new mappings must be present so override menus look right.
+- `agents_runner/core/agent/rate_limit.py`
+  - Add Qwen/OpenCode patterns only if runtime logs show agent-specific rate-limit signals that differ from current generic handling.
+- `agents_runner/execution/supervisor_errors.py`
+  - Extend agent-specific failure signatures if logs show missing-command or provider-specific wording that is not already caught.
+
+## 5) Phased implementation plan (ordered, with checkboxes)
+
+### Shared groundwork
+
+- [ ] Confirm the current plugin contract can stay unchanged; only add a narrow helper surface if Qwen executable locking cannot be handled inside plugin/status code.
+- [ ] Note that Qwen comes from the QwenLM project and is not literally a Google Gemini model; we can reuse the Gemini plugin implementation as structural guidance but must avoid implying model-family equivalence.
+- [ ] Add centralized display metadata for `qwen` and `opencode` so UI surfaces stop relying on raw slug formatting.
+- [ ] Establish final planned config/mount defaults before editing runtime code:
+  - Qwen: host `~/.qwen` -> container `/home/midori-ai/.qwen`.
+  - OpenCode: host `~/.config/opencode` -> container `/home/midori-ai/.config/opencode` plus host `~/.local/share/opencode` -> container `/home/midori-ai/.local/share/opencode`.
+- [ ] Record the explicit policy that OpenCode config + data mounts are intentional, trusted, and sufficient by default; cache is not part of the default persistence boundary.
+- [ ] Verify OpenCode’s config and auth roots before coding mounts: run `opencode debug paths` (and `opencode providers list` if needed) to confirm config stays under `~/.config/opencode` and auth/data under `~/.local/share/opencode` (expect `auth.json` or similar files there).
+- [ ] Add prompt template placeholders early so runtime template loading does not warn once plugins are discoverable.
+
+### Qwen track
+
+- [ ] Create `agents_runner/agent_systems/qwen/__init__.py` and `agents_runner/agent_systems/qwen/plugin.py`.
+- [ ] Set Qwen install command to `yay -S --noconfirm --needed qwen-code` and keep package naming separated from runtime executable selection.
+- [ ] Implement Qwen executable verification by running `qwen --version` and `qwen --help`, then lock `qwen` for that environment so all setup/status checks and command generation reuse the verified binary.
+- [ ] Implement Qwen non-interactive planning around documented headless mode while only including flags confirmed by `qwen --help` (currently `--approval-mode yolo`, `--include-directories`, `-i/--prompt-interactive`, and the positional query argument for one-shot flows), and explicitly avoid assuming `--no-sandbox` or other undocumented defaults.
+- [ ] Implement Qwen interactive command building from actual help output once available in the target environment; include workspace and prompt handling only for flags confirmed by runtime help.
+- [ ] Add `agents_runner/prompts/templates/agentcli/qwen.md` with Qwen-specific guidance.
+- [ ] Add Qwen setup/verify/status integration in `agents_runner/setup/commands.py`, the existing `detect_all_agents()` flow within `agents_runner/setup/agent_status.py`, `agents_runner/ui/dialogs/first_run_setup.py`, and `agents_runner/ui/dialogs/test_chain_dialog.py`.
+- [ ] Use `StatusType.UNKNOWN` rather than a false negative when Qwen auth evidence is incomplete, and document that Qwen status rows in first-run/test-chain may show `Unknown`/unavailable until a dedicated detection helper replaces the placeholder.
+
+### OpenCode track
+
+- [ ] Create `agents_runner/agent_systems/opencode/__init__.py` and `agents_runner/agent_systems/opencode/plugin.py`.
+- [ ] Set OpenCode install command to `yay -S --noconfirm --needed opencode` and verify with `opencode --version`.
+- [ ] Implement OpenCode non-interactive planning around `opencode run` and interactive planning around `opencode [project]` plus prompt support validated by local help output.
+- [ ] Document that the CLI flow (`opencode run ...`) is considered janky and unsupported compared to OpenCode’s preferred TUI/WebUI modes, and keep that disclaimer visible whenever we mention CLI execution plans.
+- [ ] Implement OpenCode `additional_config_mounts()` so Docker always mounts both config and data roots as RW, while leaving cache unmapped by default.
+- [ ] Add OpenCode setup/config/status commands centered on:
+  - setup/login: `opencode providers login`
+  - verify: `opencode --version`
+  - config/debug: `opencode providers list` and `opencode debug paths` / `opencode debug config`
+- [ ] Add `agents_runner/prompts/templates/agentcli/opencode.md` so OpenCode can participate cleanly in normal and cross-agent prompt assembly.
+- [ ] Add OpenCode status detection that prefers `opencode providers list` and falls back to `~/.local/share/opencode/auth.json` or equivalent data-root evidence only when CLI parsing is insufficient.
+
+### Cross-cutting UI/setup/status/prompt/theme tasks
+
+- [ ] Update display/UI consumers so both systems render with stable display names in settings, environment agent pickers, override menus, first-run setup, and chain status widgets.
+- [ ] Add `agents_runner/ui/themes/qwen/` and `agents_runner/ui/themes/opencode/` and set plugin `ui_theme` values to match.
+- [ ] Validate that `agents_runner/ui/graphics.py` discovers both themes and that auto-theme sync follows the selected active agent.
+- [ ] Validate cross-agent mount behavior so OpenCode dual mounts and any Qwen config overrides still deduplicate correctly in interactive and non-interactive launches.
+- [ ] Confirm prompt templates load for primary-agent and allowlisted cross-agent scenarios without warning spam from `agents_runner/docker/agent_worker_prompt.py`.
+- [ ] Audit secondary hard-coded reliability files (`agents_runner/core/agent/rate_limit.py`, `agents_runner/execution/supervisor_errors.py`) after first live runs and extend only if logs show gaps.
+
+## 6) Acceptance criteria per phase
+
+### Shared groundwork acceptance
+
+- New plugin folders are discoverable without adding manual registry entries.
+- UI display paths can show `Qwen` and `OpenCode` consistently instead of raw slug formatting.
+- The OpenCode dual mount policy is explicit: config + data are mounted, cache is not.
+- The Qwen executable verification procedure is explicit and reusable: run `qwen --version` and `qwen --help`, then lock the verified `qwen` binary for that environment.
+- Config and auth folders are confirmed: OpenCode config stays in `~/.config/opencode` and auth/data reside in `~/.local/share/opencode` (expecting `auth.json` or similar provider data), which we verify by running `opencode providers list`/`opencode debug paths` before coding mounts.
+
+### Qwen acceptance
+
+- `qwen` appears anywhere agent systems are selected or displayed.
+- Qwen install references use `qwen-code` and never rely on a nonexistent `qwen` package.
+- Qwen host-side setup/status logic uses `qwen --version` and `qwen --help` for authoritative runtime checks and keeps `qwen` locked as the executable.
+- Qwen runtime planning is Qwen-specific, not a blind Gemini clone; only `--approval-mode yolo`, `--include-directories`, `-i/--prompt-interactive`, and the positional query argument are adopted from the confirmed help output, and `-p/--prompt` remains compatibility-only.
+- Qwen prompt template exists and loads without warnings.
+- Qwen appears in first-run setup and test-chain status flows with a documented installed/logged-in/unknown policy, explicitly noting that MVP status rows may initially show `Unknown`/unavailable.
+
+### OpenCode acceptance
+
+- `opencode` appears anywhere agent systems are selected or displayed.
+- OpenCode install references use `yay -S --noconfirm --needed opencode`.
+- Non-interactive and interactive planning use documented OpenCode commands rather than generic shell wrappers.
+- Docker launches mount both `~/.config/opencode` and `~/.local/share/opencode` as the default trusted persistence boundary.
+- OpenCode setup/status flows can launch provider login and detect whether credentials/providers are configured.
+- OpenCode prompt template exists and loads without warnings.
+
+### Cross-cutting acceptance
+
+- Settings/theme UI can discover and render Qwen/OpenCode themes.
+- Environment agent add/select flows show correct display names.
+- First-run setup, test-chain status, new-task override menus, and PR/summary displays show friendly labels and links.
+- Cross-agent mount de-duplication still works when OpenCode contributes extra mounts.
+- Existing agents continue to behave as before.
+
+## 7) Validation checklist (commands/manual checks; no new tests)
+
+### Repo-wide validation after implementation
+
+```bash
+uv sync --group ci
+uv run ruff format .
+uv run ruff check .
+uv run basedpyright
+```
+
+Do not add or run new tests unless they are explicitly requested later.
+
+### Runtime evidence checks
+
+```bash
+opencode --version
+opencode --help
+opencode run --help
+opencode providers --help
+opencode debug paths
+yay -Si opencode
+yay -Si qwen-code
+npm view @qwen-code/qwen-code bin repository.url homepage
+qwen --version
+qwen --help
+```
+
+### Manual product checks
+
+- Launch `uv run main.py`.
+- Settings page:
+  - `Qwen` and `OpenCode` appear in the default agent picker.
+  - Their themes appear in theme previews if theme dirs are added.
+- Environments page:
+  - Add-agent dropdown shows friendly display names, not raw slug casing.
+  - Per-agent config override fields accept plugin defaults cleanly.
+- First-run setup and Test Chain:
+  - Both systems appear in status rows.
+  - Status text is sensible for installed, not installed, and low-confidence auth cases.
+- Non-interactive runs:
+  - Qwen plans the documented headless command.
+  - OpenCode plans `opencode run`.
+- Interactive runs:
+  - Qwen and OpenCode launch with plugin default commands.
+  - OpenCode container sees both config and data mounts.
+- Prompt loading:
+  - No warnings for missing `templates/agentcli/qwen` or `templates/agentcli/opencode`.
+
+## 8) Risk register + mitigations
+
+| Risk | Why it matters | Mitigation |
+| --- | --- | --- |
+| Qwen runtime binary drift (`qwen` vs `qwen-code`) | Host setup/status commands can fail even when Qwen is installed | Verify the `qwen` binary with `qwen --version` / `qwen --help` and lock that executable per environment so setup/status checks do not target the wrong name |
+| Qwen package vs runtime name mismatch | Install can succeed while runtime verification still checks the wrong name | Keep install package (`qwen-code`) separate from runtime executable selection and validate both paths explicitly |
+| Qwen auth detection uncertainty | False negatives in first-run/setup UX create bad guidance | Prefer `UNKNOWN` when only partial evidence exists; only report logged-in on confirmed signals |
+| OpenCode single-mount simplification | Auth/session behavior can break if only config is mounted | Treat config + data as the default trusted mount boundary and validate both mounts in Docker launches |
+| OpenCode over-mounting | Mounting cache/state without evidence widens persistence and review surface | Keep cache out of the default policy; add more only if runtime evidence proves it is required |
+| UI label drift | Raw slug formatting makes new agents look unfinished and inconsistent | Route labels through `display_name` / `agent_display.py` and audit `title()` / `capitalize()` call sites |
+| Missing templates or themes | New systems may load with warnings or fall back to generic visuals | Add prompt templates before enabling plugins and add matching theme directories if `ui_theme` is declared |
+| Reliability pattern gaps | Retry/cooldown logic may misclassify new vendor errors | Review first live logs and extend `rate_limit.py` / `supervisor_errors.py` only where evidence shows gaps |
+
+## 9) Dependency/issue sequencing map
+
+1. Use `#54` as the Qwen umbrella issue.
+2. Land the Qwen plugin/template/runtime work under `#204` first, because setup/status and UI value depend on the plugin existing.
+3. Land Qwen setup/login/status work under `#205` after or alongside `#204`, once commands and config defaults are stable enough to expose in UI.
+4. Treat closed `#206` as background context only: it already pushed the repo toward plugin-driven config handling, so new Qwen/OpenCode work should reuse that direction rather than reintroduce per-agent hard-coded settings keys.
+5. Treat closed `#207` as historical context, not a source of truth, because its package assumption (`qwen-code-bin`) is stale relative to current verified PixelArch package info (`qwen-code`).
+6. OpenCode currently has no equivalent issue structure. Create one before implementation if maintainers want parity with Qwen tracking:
+   - Parent issue: implement OpenCode agent system.
+   - Child issue A: strict OpenCode plugin + prompt/template + runtime/mount integration.
+   - Child issue B: OpenCode setup/login/status integration.
+7. Recommended implementation order:
+   - Shared groundwork
+   - Qwen plugin/runtime/template (`#204`)
+   - OpenCode plugin/runtime/template (new child issue A)
+   - Qwen setup/status (`#205`)
+   - OpenCode setup/status (new child issue B)
+   - Cross-cutting UI/theme/reliability sweep
+
+## 10) Decision log (locked)
+
+- D1 – Qwen login-status detection for MVP is intentionally limited to the existing `detect_all_agents()` flow. No explicit `detect_qwen_status()` is planned for MVP, so first-run/test-chain rows can show `Unknown`/unavailable, but execution is not blocked and future work will replace the placeholder state when reliable signals emerge.
+- D2 – Qwen runtime flags only align with the documented `qwen --help` output. We adopt the confirmed overlaps (`--approval-mode yolo`, `--include-directories`, `-i/--prompt-interactive`, and the positional prompt argument), treat `-p/--prompt` as deprecated compatibility, and explicitly avoid assuming undocumented defaults such as `--no-sandbox`.

--- a/agents_runner/agent_display.py
+++ b/agents_runner/agent_display.py
@@ -7,13 +7,17 @@ AGENT_DISPLAY_NAMES = {
     "claude": "Claude Code",
     "copilot": "Github Copilot",
     "gemini": "Google Gemini",
+    "opencode": "OpenCode",
+    "qwen": "Qwen",
 }
 
 AGENT_GITHUB_URLS = {
-    "codex": "https://github.com/openai/codex",
     "claude": "https://github.com/anthropics/claude-code",
+    "codex": "https://github.com/openai/codex",
     "copilot": "https://github.com/github/copilot-cli",
     "gemini": "https://github.com/google-gemini/gemini-cli",
+    "opencode": "https://github.com/anomalyco/opencode",
+    "qwen": "https://github.com/QwenLM/qwen-code",
 }
 
 

--- a/agents_runner/agent_labels.py
+++ b/agents_runner/agent_labels.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from agents_runner.agent_systems import get_agent_system
+
+
+def format_agent_ui_label(agent_name: str) -> str:
+    """Return a friendly UI label for an agent or setup target."""
+
+    normalized = str(agent_name or "").strip().lower()
+    if not normalized:
+        return "Unknown"
+
+    try:
+        plugin = get_agent_system(normalized)
+    except Exception:
+        plugin = None
+
+    display_name = str(getattr(plugin, "display_name", "") or "").strip()
+    if display_name:
+        return display_name
+
+    if normalized == "github":
+        return "GitHub"
+
+    words = normalized.replace("-", " ").replace("_", " ").split()
+    if not words:
+        return "Unknown"
+    return " ".join(word.capitalize() for word in words)

--- a/agents_runner/agent_systems/claude/plugin.py
+++ b/agents_runner/agent_systems/claude/plugin.py
@@ -14,6 +14,11 @@ from agents_runner.agent_systems.models import (
     UiThemeSpec,
 )
 from agents_runner.agent_systems.interactive_command import move_positional_to_end
+from agents_runner.agent_systems.status import AgentStatus
+from agents_runner.agent_systems.status import StatusType
+from agents_runner.agent_systems.status import command_in_path
+from agents_runner.agent_systems.status import installed_status
+from agents_runner.agent_systems.status import not_installed_status
 
 
 CONTAINER_HOME = Path("/home/midori-ai")
@@ -97,6 +102,35 @@ class ClaudeAgentSystemPlugin:
 
     def install_command(self) -> str:
         return "yay -S --noconfirm --needed claude-code"
+
+    def detect_status(self) -> AgentStatus:
+        if not command_in_path("claude"):
+            return not_installed_status(agent=self.name)
+
+        config_dir = Path.home() / ".claude"
+        if not config_dir.exists():
+            return installed_status(
+                agent=self.name,
+                logged_in=False,
+                status_text="Not logged in (no config)",
+            )
+
+        try:
+            if any(config_dir.iterdir()):
+                return installed_status(
+                    agent=self.name,
+                    logged_in=True,
+                    status_text="Possibly logged in (config exists)",
+                    status_type=StatusType.UNKNOWN,
+                )
+        except OSError:
+            pass
+
+        return installed_status(
+            agent=self.name,
+            logged_in=False,
+            status_text="Not logged in",
+        )
 
     def default_interactive_command(self) -> str:
         return "--add-dir /home/midori-ai/workspace"

--- a/agents_runner/agent_systems/codex/plugin.py
+++ b/agents_runner/agent_systems/codex/plugin.py
@@ -14,6 +14,11 @@ from agents_runner.agent_systems.models import (
     PromptDeliverySpec,
     UiThemeSpec,
 )
+from agents_runner.agent_systems.status import AgentStatus
+from agents_runner.agent_systems.status import StatusType
+from agents_runner.agent_systems.status import command_in_path
+from agents_runner.agent_systems.status import installed_status
+from agents_runner.agent_systems.status import not_installed_status
 from agents_runner.agent_systems.interactive_command import move_positional_to_end
 
 
@@ -99,6 +104,44 @@ class CodexAgentSystemPlugin:
 
     def install_command(self) -> str:
         return "yay -S --noconfirm --needed openai-codex"
+
+    def detect_status(self) -> AgentStatus:
+        if not command_in_path("codex"):
+            return not_installed_status(agent=self.name)
+
+        try:
+            result = subprocess.run(
+                ["codex", "login", "status"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except subprocess.TimeoutExpired:
+            return installed_status(
+                agent=self.name,
+                logged_in=False,
+                status_text="Unknown (timeout)",
+                status_type=StatusType.UNKNOWN,
+            )
+        except (FileNotFoundError, OSError):
+            return installed_status(
+                agent=self.name,
+                logged_in=False,
+                status_text="Unknown (command failed)",
+                status_type=StatusType.UNKNOWN,
+            )
+
+        if result.returncode == 0:
+            return installed_status(
+                agent=self.name,
+                logged_in=True,
+                status_text="Logged in",
+            )
+        return installed_status(
+            agent=self.name,
+            logged_in=False,
+            status_text="Not logged in",
+        )
 
     def default_interactive_command(self) -> str:
         return "--sandbox danger-full-access"

--- a/agents_runner/agent_systems/copilot/plugin.py
+++ b/agents_runner/agent_systems/copilot/plugin.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 
 from pathlib import Path
 
@@ -14,6 +15,11 @@ from agents_runner.agent_systems.models import (
     UiThemeSpec,
 )
 from agents_runner.agent_systems.interactive_command import move_flag_value_to_end
+from agents_runner.agent_systems.status import AgentStatus
+from agents_runner.agent_systems.status import StatusType
+from agents_runner.agent_systems.status import command_in_path
+from agents_runner.agent_systems.status import installed_status
+from agents_runner.agent_systems.status import not_installed_status
 
 
 CONTAINER_HOME = Path("/home/midori-ai")
@@ -93,6 +99,60 @@ class CopilotAgentSystemPlugin:
 
     def install_command(self) -> str:
         return "yay -S --noconfirm --needed github-copilot-cli"
+
+    def detect_status(self) -> AgentStatus:
+        if not command_in_path("copilot"):
+            return not_installed_status(agent=self.name)
+
+        try:
+            result = subprocess.run(
+                ["gh", "auth", "status"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except subprocess.TimeoutExpired:
+            return installed_status(
+                agent=self.name,
+                logged_in=False,
+                status_text="Unknown (timeout)",
+                status_type=StatusType.UNKNOWN,
+            )
+        except (FileNotFoundError, OSError):
+            return installed_status(
+                agent=self.name,
+                logged_in=False,
+                status_text="Unknown (gh CLI not found)",
+                status_type=StatusType.UNKNOWN,
+            )
+
+        if result.returncode == 0 and "Logged in" in result.stdout:
+            username = None
+            for line in result.stdout.split("\n"):
+                if "Logged in to github.com account" not in line:
+                    continue
+                parts = line.split("account")
+                if len(parts) > 1:
+                    username = parts[1].split("(")[0].strip() or None
+                    break
+            if username:
+                return installed_status(
+                    agent=self.name,
+                    logged_in=True,
+                    status_text=f"Logged in as {username}",
+                    username=username,
+                )
+            return installed_status(
+                agent=self.name,
+                logged_in=True,
+                status_text="Logged in",
+            )
+
+        return installed_status(
+            agent=self.name,
+            logged_in=False,
+            status_text="Not logged in to GitHub",
+        )
 
     def default_interactive_command(self) -> str:
         return f"--yolo --add-dir {WORKSPACE_DIR}"

--- a/agents_runner/agent_systems/models.py
+++ b/agents_runner/agent_systems/models.py
@@ -5,6 +5,8 @@ from typing import Literal, Protocol, runtime_checkable
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from agents_runner.agent_systems.status import AgentStatus
+
 
 class PromptDeliverySpec(BaseModel):
     """How an agent CLI accepts the initial prompt."""
@@ -129,6 +131,8 @@ class AgentSystemPlugin(Protocol):
     def install_command(self) -> str: ...
 
     def default_interactive_command(self) -> str: ...
+
+    def detect_status(self) -> AgentStatus: ...
 
     def sanitize_interactive_command_parts(self, *, cmd_parts: list[str]) -> list[str]:
         """Normalize interactive command parts for storage in settings.

--- a/agents_runner/agent_systems/opencode/__init__.py
+++ b/agents_runner/agent_systems/opencode/__init__.py
@@ -1,0 +1,1 @@
+"""OpenCode agent system plugin."""

--- a/agents_runner/agent_systems/opencode/plugin.py
+++ b/agents_runner/agent_systems/opencode/plugin.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+
+from pathlib import Path
+
+from agents_runner.agent_systems.interactive_command import move_flag_value_to_end
+from agents_runner.agent_systems.interactive_command import move_positional_to_end
+from agents_runner.agent_systems.models import (
+    AgentSystemPlan,
+    AgentSystemRequest,
+    CapabilitySpec,
+    ExecSpec,
+    MountSpec,
+    PromptDeliverySpec,
+    UiThemeSpec,
+)
+from agents_runner.agent_systems.status import AgentStatus
+from agents_runner.agent_systems.status import StatusType
+from agents_runner.agent_systems.status import command_in_path
+from agents_runner.agent_systems.status import installed_status
+from agents_runner.agent_systems.status import not_installed_status
+
+
+CONTAINER_HOME = Path("/home/midori-ai")
+WORKSPACE_DIR = "/home/midori-ai/workspace"
+_OPENCODE_CONFIG_DIR = CONTAINER_HOME / ".config" / "opencode"
+_OPENCODE_DATA_DIR = CONTAINER_HOME / ".local" / "share" / "opencode"
+_HOST_DATA_DIR = Path("~/.local/share/opencode").expanduser()
+_TOP_LEVEL_SUBCOMMANDS = {
+    "completion",
+    "acp",
+    "mcp",
+    "attach",
+    "run",
+    "debug",
+    "providers",
+    "agent",
+    "upgrade",
+    "uninstall",
+    "serve",
+    "web",
+    "models",
+    "stats",
+    "export",
+    "import",
+    "github",
+    "pr",
+    "session",
+    "db",
+}
+_TOP_LEVEL_VALUE_OPTIONS = {
+    "--log-level",
+    "--port",
+    "--hostname",
+    "--mdns-domain",
+    "--cors",
+    "-m",
+    "--model",
+    "-s",
+    "--session",
+    "--prompt",
+    "--agent",
+}
+
+
+def _top_level_subcommand(parts: list[str]) -> str:
+    if len(parts) < 2:
+        return ""
+    candidate = str(parts[1] or "").strip().lower()
+    if candidate in _TOP_LEVEL_SUBCOMMANDS:
+        return candidate
+    return ""
+
+
+def _has_top_level_project(parts: list[str]) -> bool:
+    expect_value = False
+    for token in parts[1:]:
+        current = str(token or "").strip()
+        if not current:
+            continue
+        if expect_value:
+            expect_value = False
+            continue
+        if current in _TOP_LEVEL_VALUE_OPTIONS:
+            expect_value = True
+            continue
+        if current.startswith("-"):
+            continue
+        if current.lower() in _TOP_LEVEL_SUBCOMMANDS:
+            return False
+        return True
+    return False
+
+
+class OpenCodeAgentSystemPlugin:
+    name = "opencode"
+    display_name = "OpenCode"
+    capabilities = CapabilitySpec(
+        supports_noninteractive=True,
+        supports_interactive=True,
+        supports_cross_agents=False,
+        supports_sub_agents=False,
+        requires_github_token=False,
+    )
+    ui_theme = UiThemeSpec(theme_name="opencode")
+
+    def plan(self, req: AgentSystemRequest) -> AgentSystemPlan:
+        context = req.context
+        prompt = str(req.prompt or "").strip()
+
+        argv = [
+            "opencode",
+            "run",
+            "--dir",
+            str(context.workspace_container),
+            *list(context.extra_cli_args),
+        ]
+        if prompt:
+            argv.append(prompt)
+
+        mounts = [
+            MountSpec(
+                src=context.config_host,
+                dst=self.container_config_dir(),
+                mode="rw",
+            ),
+            *self.additional_config_mounts(host_config_dir=context.config_host),
+        ]
+
+        return AgentSystemPlan(
+            system_name=self.name,
+            interactive=bool(req.interactive),
+            capabilities=self.capabilities,
+            mounts=mounts,
+            exec_spec=ExecSpec(argv=argv),
+            prompt_delivery=PromptDeliverySpec(mode="positional"),
+        )
+
+    def container_config_dir(self) -> Path:
+        return _OPENCODE_CONFIG_DIR
+
+    def default_host_config_dir(self) -> str:
+        return os.path.expanduser("~/.config/opencode")
+
+    def additional_config_mounts(self, *, host_config_dir: Path) -> list[MountSpec]:
+        try:
+            _HOST_DATA_DIR.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            pass
+
+        return [
+            MountSpec(
+                src=_HOST_DATA_DIR,
+                dst=_OPENCODE_DATA_DIR,
+                mode="rw",
+            )
+        ]
+
+    def setup_command(self) -> str | None:
+        return "opencode providers login; read -p 'Press Enter to close...'"
+
+    def config_command(self) -> str | None:
+        return (
+            "opencode providers list; opencode debug paths; opencode debug config; "
+            "read -p 'Press Enter to close...'"
+        )
+
+    def verify_command(self) -> list[str]:
+        return ["opencode", "--version"]
+
+    def install_command(self) -> str:
+        return "yay -S --noconfirm --needed opencode"
+
+    def detect_status(self) -> AgentStatus:
+        if not command_in_path("opencode"):
+            return not_installed_status(agent=self.name)
+
+        auth_file = Path.home() / ".local" / "share" / "opencode" / "auth.json"
+        try:
+            result = subprocess.run(
+                ["opencode", "providers", "list"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except subprocess.TimeoutExpired:
+            return installed_status(
+                agent=self.name,
+                logged_in=False,
+                status_text="Unknown (timeout)",
+                status_type=StatusType.UNKNOWN,
+            )
+        except (FileNotFoundError, OSError):
+            return installed_status(
+                agent=self.name,
+                logged_in=False,
+                status_text="Unknown (command failed)",
+                status_type=StatusType.UNKNOWN,
+            )
+
+        combined = "\n".join(
+            part.strip() for part in (result.stdout, result.stderr) if str(part).strip()
+        )
+        normalized = combined.lower()
+        has_credentials = bool(
+            re.search(r"\b[1-9]\d*\s+credentials?\b", normalized)
+            or re.search(r"\b[1-9]\d*\s+environment variables?\b", normalized)
+        )
+
+        if result.returncode == 0 and has_credentials:
+            return installed_status(
+                agent=self.name,
+                logged_in=True,
+                status_text="Configured providers detected",
+            )
+        if result.returncode == 0 and auth_file.is_file():
+            return installed_status(
+                agent=self.name,
+                logged_in=True,
+                status_text="Configured credentials detected",
+            )
+        if result.returncode == 0:
+            return installed_status(
+                agent=self.name,
+                logged_in=False,
+                status_text="Not logged in",
+            )
+        return installed_status(
+            agent=self.name,
+            logged_in=False,
+            status_text="Unknown (provider output unavailable)",
+            status_type=StatusType.UNKNOWN,
+        )
+
+    def default_interactive_command(self) -> str:
+        return "opencode"
+
+    def sanitize_interactive_command_parts(self, *, cmd_parts: list[str]) -> list[str]:
+        return list(cmd_parts)
+
+    def build_interactive_command_parts(
+        self,
+        *,
+        cmd_parts: list[str],
+        agent_cli_args: list[str],
+        prompt: str,
+        is_help_launch: bool,
+        help_repos_dir: str,
+    ) -> list[str]:
+        del is_help_launch
+        del help_repos_dir
+
+        parts = list(cmd_parts)
+        subcommand = _top_level_subcommand(parts)
+
+        if agent_cli_args:
+            parts.extend(agent_cli_args)
+
+        if subcommand and subcommand != "run":
+            return parts
+
+        if subcommand == "run":
+            if "--dir" not in parts:
+                parts.extend(["--dir", WORKSPACE_DIR])
+            if prompt:
+                move_positional_to_end(parts, prompt)
+            return parts
+
+        if prompt:
+            if "--prompt" in parts:
+                move_flag_value_to_end(parts, {"--prompt"})
+            else:
+                parts.extend(["--prompt", prompt])
+
+        if not _has_top_level_project(parts):
+            parts.append(WORKSPACE_DIR)
+
+        return parts
+
+
+PLUGIN = OpenCodeAgentSystemPlugin()

--- a/agents_runner/agent_systems/qwen/__init__.py
+++ b/agents_runner/agent_systems/qwen/__init__.py
@@ -1,0 +1,1 @@
+"""Qwen agent system plugin."""

--- a/agents_runner/agent_systems/qwen/plugin.py
+++ b/agents_runner/agent_systems/qwen/plugin.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import os
+import subprocess
 
 from pathlib import Path
 
+from agents_runner.agent_systems.interactive_command import move_flag_value_to_end
 from agents_runner.agent_systems.models import (
     AgentSystemPlan,
     AgentSystemRequest,
@@ -13,41 +15,53 @@ from agents_runner.agent_systems.models import (
     PromptDeliverySpec,
     UiThemeSpec,
 )
-from agents_runner.agent_systems.interactive_command import move_flag_value_to_end
 from agents_runner.agent_systems.status import AgentStatus
 from agents_runner.agent_systems.status import command_in_path
-from agents_runner.agent_systems.status import installed_status
 from agents_runner.agent_systems.status import not_installed_status
+from agents_runner.agent_systems.status import unknown_installed_status
 
 
 CONTAINER_HOME = Path("/home/midori-ai")
+WORKSPACE_DIR = "/home/midori-ai/workspace"
+_QWEN_SUBCOMMANDS = {"mcp", "extensions", "hooks", "hook"}
 
 
-class GeminiAgentSystemPlugin:
-    name = "gemini"
-    display_name = "Gemini"
+def _ensure_include_directory(parts: list[str], directory: str) -> None:
+    directory = str(directory or "").strip()
+    if not directory:
+        return
+
+    for idx, part in enumerate(parts[:-1]):
+        if part != "--include-directories":
+            continue
+        if parts[idx + 1] == directory:
+            return
+
+    parts.extend(["--include-directories", directory])
+
+
+class QwenAgentSystemPlugin:
+    name = "qwen"
+    display_name = "Qwen"
     capabilities = CapabilitySpec(
         supports_noninteractive=True,
         supports_interactive=True,
-        supports_cross_agents=True,
-        supports_sub_agents=True,
+        supports_cross_agents=False,
+        supports_sub_agents=False,
         requires_github_token=False,
     )
-    ui_theme = UiThemeSpec(theme_name="gemini")
+    ui_theme = UiThemeSpec(theme_name="qwen")
 
     def plan(self, req: AgentSystemRequest) -> AgentSystemPlan:
         context = req.context
         prompt = str(req.prompt or "").strip()
 
         argv = [
-            "gemini",
-            "--no-sandbox",
+            "qwen",
             "--approval-mode",
             "yolo",
             "--include-directories",
             str(context.workspace_container),
-            "--include-directories",
-            "/tmp",
             *list(context.extra_cli_args),
         ]
         if prompt:
@@ -72,77 +86,66 @@ class GeminiAgentSystemPlugin:
         )
 
     def container_config_dir(self) -> Path:
-        return CONTAINER_HOME / ".gemini"
+        return CONTAINER_HOME / ".qwen"
 
     def default_host_config_dir(self) -> str:
-        return os.path.expanduser("~/.gemini")
+        return os.path.expanduser("~/.qwen")
 
     def additional_config_mounts(self, *, host_config_dir: Path) -> list[MountSpec]:
         return []
 
     def setup_command(self) -> str | None:
-        return None
+        return "qwen; read -p 'Press Enter to close...'"
 
     def config_command(self) -> str | None:
-        return None
+        return "qwen --help; read -p 'Press Enter to close...'"
 
     def verify_command(self) -> list[str]:
-        return ["gemini", "--version"]
+        return ["sh", "-lc", "qwen --version && qwen --help >/dev/null"]
 
     def install_command(self) -> str:
-        return "yay -S --noconfirm --needed gemini-cli"
+        return "yay -S --noconfirm --needed qwen-code"
 
     def detect_status(self) -> AgentStatus:
-        if not command_in_path("gemini"):
+        if not command_in_path("qwen"):
             return not_installed_status(agent=self.name)
 
-        if os.environ.get("GEMINI_API_KEY"):
-            return installed_status(
-                agent=self.name,
-                logged_in=True,
-                status_text="Logged in (GEMINI_API_KEY)",
+        try:
+            version_result = subprocess.run(
+                ["qwen", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
             )
-        if os.environ.get("GOOGLE_GENAI_USE_VERTEXAI"):
-            return installed_status(
-                agent=self.name,
-                logged_in=True,
-                status_text="Logged in (VERTEXAI)",
+            help_result = subprocess.run(
+                ["qwen", "--help"],
+                capture_output=True,
+                text=True,
+                timeout=5,
             )
-        if os.environ.get("GOOGLE_GENAI_USE_GCA"):
-            return installed_status(
+        except subprocess.TimeoutExpired:
+            return unknown_installed_status(
                 agent=self.name,
-                logged_in=True,
-                status_text="Logged in (GCA)",
+                message="Unknown (qwen runtime check timed out)",
             )
-
-        gemini_config_dir = Path.home() / ".gemini"
-        google_accounts = gemini_config_dir / "google_accounts.json"
-        oauth_creds = gemini_config_dir / "oauth_creds.json"
-
-        if google_accounts.exists() and google_accounts.is_file():
-            return installed_status(
+        except (FileNotFoundError, OSError):
+            return unknown_installed_status(
                 agent=self.name,
-                logged_in=True,
-                status_text="Logged in (google_accounts.json)",
-            )
-        if oauth_creds.exists() and oauth_creds.is_file():
-            return installed_status(
-                agent=self.name,
-                logged_in=True,
-                status_text="Logged in (oauth_creds.json)",
+                message="Unknown (qwen runtime check failed)",
             )
 
-        return installed_status(
+        if version_result.returncode == 0 and help_result.returncode == 0:
+            return unknown_installed_status(
+                agent=self.name,
+                message="Installed; login status unknown",
+            )
+        return unknown_installed_status(
             agent=self.name,
-            logged_in=False,
-            status_text="Not logged in (no auth method found)",
+            message="Unknown (qwen runtime check failed)",
         )
 
     def default_interactive_command(self) -> str:
-        return (
-            "--no-sandbox --approval-mode yolo --include-directories "
-            "/home/midori-ai/workspace"
-        )
+        return "--approval-mode yolo --include-directories /home/midori-ai/workspace"
 
     def sanitize_interactive_command_parts(self, *, cmd_parts: list[str]) -> list[str]:
         return list(cmd_parts)
@@ -158,36 +161,24 @@ class GeminiAgentSystemPlugin:
     ) -> list[str]:
         parts = list(cmd_parts)
 
+        subcommand = ""
+        if len(parts) >= 2:
+            candidate = str(parts[1] or "").strip().lower()
+            if candidate in _QWEN_SUBCOMMANDS:
+                subcommand = candidate
+
         if agent_cli_args:
             parts.extend(agent_cli_args)
 
-        if "--include-directories" not in parts:
-            parts[1:1] = ["--include-directories", "/home/midori-ai/workspace"]
-
-        if is_help_launch:
-            if help_repos_dir not in parts:
-                parts[1:1] = ["--include-directories", help_repos_dir]
-
-            if "--sandbox" in parts:
-                idx = parts.index("--sandbox")
-                parts.pop(idx)
-                if idx < len(parts) and not parts[idx].startswith("-"):
-                    parts.pop(idx)
-            if "-s" in parts:
-                parts.remove("-s")
-
-            if "--no-sandbox" not in parts:
-                parts[1:1] = ["--no-sandbox"]
-
-        if (
-            "--sandbox" not in parts
-            and "--no-sandbox" not in parts
-            and "-s" not in parts
-        ):
-            parts[1:1] = ["--no-sandbox"]
+        if subcommand:
+            return parts
 
         if "--approval-mode" not in parts:
             parts[1:1] = ["--approval-mode", "yolo"]
+
+        _ensure_include_directory(parts, WORKSPACE_DIR)
+        if is_help_launch:
+            _ensure_include_directory(parts, help_repos_dir)
 
         if prompt:
             has_interactive_prompt = "-i" in parts or "--prompt-interactive" in parts
@@ -202,4 +193,4 @@ class GeminiAgentSystemPlugin:
         return parts
 
 
-PLUGIN = GeminiAgentSystemPlugin()
+PLUGIN = QwenAgentSystemPlugin()

--- a/agents_runner/agent_systems/smoke_agent/plugin.py
+++ b/agents_runner/agent_systems/smoke_agent/plugin.py
@@ -13,6 +13,10 @@ from agents_runner.agent_systems.models import (
     MountSpec,
     PromptDeliverySpec,
 )
+from agents_runner.agent_systems.status import AgentStatus
+from agents_runner.agent_systems.status import command_in_path
+from agents_runner.agent_systems.status import installed_status
+from agents_runner.agent_systems.status import not_installed_status
 
 
 CONTAINER_HOME = Path("/home/midori-ai")
@@ -88,6 +92,15 @@ class SmokeAgentSystemPlugin:
 
     def install_command(self) -> str:
         return 'echo "smoke agent installing"'
+
+    def detect_status(self) -> AgentStatus:
+        if not command_in_path("sh"):
+            return not_installed_status(agent=self.name)
+        return installed_status(
+            agent=self.name,
+            logged_in=True,
+            status_text="Ready",
+        )
 
     def default_interactive_command(self) -> str:
         return ""

--- a/agents_runner/agent_systems/status.py
+++ b/agents_runner/agent_systems/status.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import shutil
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+
+class StatusType(Enum):
+    """Agent status types."""
+
+    LOGGED_IN = "logged_in"
+    NOT_LOGGED_IN = "not_logged_in"
+    NOT_INSTALLED = "not_installed"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class AgentStatus:
+    """Agent installation and authentication status."""
+
+    agent: str
+    installed: bool
+    logged_in: bool
+    status_text: str
+    status_type: StatusType
+    username: str | None = None
+    last_checked: datetime | None = None
+
+
+def command_in_path(command: str) -> bool:
+    """Check whether a command exists in PATH."""
+
+    raw = str(command or "").strip().lower()
+    if not raw:
+        return False
+    return shutil.which(raw) is not None
+
+
+def status_now() -> datetime:
+    return datetime.now()
+
+
+def not_installed_status(*, agent: str) -> AgentStatus:
+    return AgentStatus(
+        agent=agent,
+        installed=False,
+        logged_in=False,
+        status_text="Not installed",
+        status_type=StatusType.NOT_INSTALLED,
+        last_checked=status_now(),
+    )
+
+
+def installed_status(
+    *,
+    agent: str,
+    logged_in: bool,
+    status_text: str,
+    status_type: StatusType | None = None,
+    username: str | None = None,
+) -> AgentStatus:
+    resolved_status_type = status_type
+    if resolved_status_type is None:
+        resolved_status_type = (
+            StatusType.LOGGED_IN if logged_in else StatusType.NOT_LOGGED_IN
+        )
+    return AgentStatus(
+        agent=agent,
+        installed=True,
+        logged_in=logged_in,
+        status_text=status_text,
+        status_type=resolved_status_type,
+        username=username,
+        last_checked=status_now(),
+    )
+
+
+def unknown_installed_status(*, agent: str, message: str) -> AgentStatus:
+    return installed_status(
+        agent=agent,
+        logged_in=False,
+        status_text=message,
+        status_type=StatusType.UNKNOWN,
+    )

--- a/agents_runner/prompts/templates/agentcli/opencode.md
+++ b/agents_runner/prompts/templates/agentcli/opencode.md
@@ -1,0 +1,30 @@
+## Prompt
+
+Runtime: OpenCode CLI.
+
+This section is appended because OpenCode is selected and available for this run. Use it as selection guidance and execution notes.
+
+**Strengths**
+- Best when you want OpenCode itself, especially for TUI or WebUI-driven sessions
+
+**Avoid when**
+- You need polished one-shot CLI automation; `opencode run` works, but it is rougher than OpenCode's preferred TUI/WebUI flows
+
+**How Agents Runner runs it**
+- Non-interactive command:
+  ```
+  opencode run --dir <WORKDIR> [extra_args] <PROMPT>
+  ```
+- Interactive command:
+  ```
+  opencode [options] [--prompt <PROMPT>] <WORKDIR>
+  ```
+- Persistence: both `~/.config/opencode` and `~/.local/share/opencode` are mounted so config, auth, and session data stay available
+
+**Setup and status**
+- Login flow: `opencode providers login`
+- Status/debug: `opencode providers list`, `opencode debug paths`
+
+**Prompt contract**
+- Prefer OpenCode TUI/WebUI for longer sessions
+- Use `opencode run` as the app's CLI fallback, not as proof that the CLI is OpenCode's best mode

--- a/agents_runner/prompts/templates/agentcli/qwen.md
+++ b/agents_runner/prompts/templates/agentcli/qwen.md
@@ -1,0 +1,29 @@
+## Prompt
+
+Runtime: Qwen Code CLI.
+
+This section is appended because Qwen is selected and available for this run. Use it as selection guidance and execution notes.
+
+**Strengths**
+- Good general-purpose code work when you want a Gemini-like CLI flow without assuming Gemini-specific flags
+
+**Avoid when**
+- The task depends on undocumented Qwen CLI behavior or flags that were not confirmed from `qwen --help`
+
+**How Agents Runner runs it**
+- Command:
+  ```
+  qwen --approval-mode yolo --include-directories <WORKDIR> [extra_args] <PROMPT>
+  ```
+- Interactive prompt seeding uses `-i <PROMPT>` / `--prompt-interactive <PROMPT>`
+- Access: `<WORKDIR>` is included (default `~/workspace`)
+- Safety: only confirmed Qwen flags are assumed; do not assume `--no-sandbox`
+- Compatibility: positional prompts are preferred for one-shot runs; `-p/--prompt` exists only as deprecated compatibility
+
+**Config and auth**
+- Default config root: `~/.qwen`
+- MVP note: setup can launch normally even when login-status UI remains `Unknown`
+
+**Prompt contract**
+- Treat `<PROMPT>` as the full task input for one-shot runs
+- Keep Qwen-specific guidance limited to confirmed runtime behavior

--- a/agents_runner/setup/agent_status.py
+++ b/agents_runner/setup/agent_status.py
@@ -1,109 +1,24 @@
-"""Agent installation and login status detection.
+"""Agent installation and login status detection."""
 
-This module provides functions to detect whether agent CLIs are installed
-and whether they are logged in/authenticated.
-"""
+from __future__ import annotations
 
-import os
-import shutil
 import subprocess
 
-from dataclasses import dataclass
-from datetime import datetime
-from enum import Enum
-from pathlib import Path
-
-from agents_runner.agent_cli import normalize_agent
-
-
-class StatusType(Enum):
-    """Agent status types."""
-
-    LOGGED_IN = "logged_in"
-    NOT_LOGGED_IN = "not_logged_in"
-    NOT_INSTALLED = "not_installed"
-    UNKNOWN = "unknown"
+from agents_runner.agent_systems import available_agent_system_names
+from agents_runner.agent_systems import get_agent_system
+from agents_runner.agent_systems.status import AgentStatus
+from agents_runner.agent_systems.status import StatusType
+from agents_runner.agent_systems.status import command_in_path
+from agents_runner.agent_systems.status import installed_status
+from agents_runner.agent_systems.status import not_installed_status
 
 
-@dataclass
-class AgentStatus:
-    """Agent installation and authentication status."""
+def detect_gh_status() -> AgentStatus:
+    """Detect GitHub CLI installation and login status."""
 
-    agent: str
-    installed: bool
-    logged_in: bool
-    status_text: str
-    status_type: StatusType
-    username: str | None = None
-    last_checked: datetime | None = None
+    if not command_in_path("gh"):
+        return not_installed_status(agent="github")
 
-
-def check_agent_installed(agent: str) -> bool:
-    """Check if agent CLI is installed (present in PATH).
-
-    Args:
-        agent: Agent name (codex, claude, copilot, gemini)
-
-    Returns:
-        True if CLI is in PATH, False otherwise
-    """
-    agent = normalize_agent(agent)
-    return shutil.which(agent) is not None
-
-
-def check_codex_login() -> tuple[bool, str]:
-    """Check codex login status.
-
-    Returns:
-        (logged_in: bool, status_message: str)
-    """
-    try:
-        result = subprocess.run(
-            ["codex", "login", "status"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if result.returncode == 0:
-            return (True, "Logged in")
-        return (False, "Not logged in")
-    except subprocess.TimeoutExpired:
-        return (False, "Unknown (timeout)")
-    except (FileNotFoundError, OSError):
-        return (False, "Unknown (command failed)")
-
-
-def check_claude_login() -> tuple[bool, str]:
-    """Check claude login status.
-
-    Note: Claude Code does not have a simple auth status command.
-    We check for the existence of config files as a heuristic.
-
-    Returns:
-        (logged_in: bool, status_message: str)
-    """
-    config_dir = Path.home() / ".claude"
-    if not config_dir.exists():
-        return (False, "Not logged in (no config)")
-
-    # Check if config directory has files
-    try:
-        if any(config_dir.iterdir()):
-            return (True, "Possibly logged in (config exists)")
-    except OSError:
-        pass
-
-    return (False, "Not logged in")
-
-
-def check_copilot_login() -> tuple[bool, str]:
-    """Check GitHub Copilot login status via gh CLI.
-
-    Copilot uses GitHub CLI for authentication.
-
-    Returns:
-        (logged_in: bool, status_message: str)
-    """
     try:
         result = subprocess.run(
             ["gh", "auth", "status"],
@@ -111,237 +26,70 @@ def check_copilot_login() -> tuple[bool, str]:
             text=True,
             timeout=5,
         )
-        if result.returncode == 0 and "Logged in" in result.stdout:
-            # Try to extract username
-            for line in result.stdout.split("\n"):
-                if "Logged in to github.com account" in line:
-                    parts = line.split("account")
-                    if len(parts) > 1:
-                        username = parts[1].split("(")[0].strip()
-                        return (True, f"Logged in as {username}")
-            return (True, "Logged in")
-        return (False, "Not logged in to GitHub")
     except subprocess.TimeoutExpired:
-        return (False, "Unknown (timeout)")
-    except (FileNotFoundError, OSError):
-        return (False, "Unknown (gh CLI not found)")
-
-
-def check_gemini_login() -> tuple[bool, str]:
-    """Check Gemini login status.
-
-    Gemini can be authenticated via:
-    - GEMINI_API_KEY environment variable
-    - GOOGLE_GENAI_USE_VERTEXAI environment variable
-    - GOOGLE_GENAI_USE_GCA environment variable
-    - ~/.gemini/google_accounts.json (OAuth account data)
-    - ~/.gemini/oauth_creds.json (OAuth credentials)
-
-    Returns:
-        (logged_in: bool, status_message: str)
-    """
-    # Check environment variables
-    if os.environ.get("GEMINI_API_KEY"):
-        return (True, "Logged in (GEMINI_API_KEY)")
-    if os.environ.get("GOOGLE_GENAI_USE_VERTEXAI"):
-        return (True, "Logged in (VERTEXAI)")
-    if os.environ.get("GOOGLE_GENAI_USE_GCA"):
-        return (True, "Logged in (GCA)")
-
-    # Check for OAuth credential files
-    gemini_config_dir = Path.home() / ".gemini"
-    google_accounts = gemini_config_dir / "google_accounts.json"
-    oauth_creds = gemini_config_dir / "oauth_creds.json"
-
-    if google_accounts.exists() and google_accounts.is_file():
-        return (True, "Logged in (google_accounts.json)")
-    if oauth_creds.exists() and oauth_creds.is_file():
-        return (True, "Logged in (oauth_creds.json)")
-
-    return (False, "Not logged in (no auth method found)")
-
-
-def check_gh_status() -> tuple[bool, str]:
-    """Check GitHub CLI login status.
-
-    This is separate from Copilot as gh CLI is used for PR metadata
-    across all agents.
-
-    Returns:
-        (logged_in: bool, status_message: str)
-    """
-    # Same implementation as check_copilot_login but for gh CLI specifically
-    return check_copilot_login()
-
-
-def detect_codex_status() -> AgentStatus:
-    """Detect Codex installation and login status.
-
-    Returns:
-        AgentStatus with detection results
-    """
-    installed = check_agent_installed("codex")
-    if not installed:
-        return AgentStatus(
-            agent="codex",
-            installed=False,
-            logged_in=False,
-            status_text="Not installed",
-            status_type=StatusType.NOT_INSTALLED,
-            last_checked=datetime.now(),
-        )
-
-    logged_in, message = check_codex_login()
-    return AgentStatus(
-        agent="codex",
-        installed=True,
-        logged_in=logged_in,
-        status_text=message,
-        status_type=StatusType.LOGGED_IN if logged_in else StatusType.NOT_LOGGED_IN,
-        last_checked=datetime.now(),
-    )
-
-
-def detect_claude_status() -> AgentStatus:
-    """Detect Claude installation and login status.
-
-    Returns:
-        AgentStatus with detection results
-    """
-    installed = check_agent_installed("claude")
-    if not installed:
-        return AgentStatus(
-            agent="claude",
-            installed=False,
-            logged_in=False,
-            status_text="Not installed",
-            status_type=StatusType.NOT_INSTALLED,
-            last_checked=datetime.now(),
-        )
-
-    logged_in, message = check_claude_login()
-    # Claude detection is heuristic, so mark as unknown if config exists
-    if logged_in and "Possibly" in message:
-        status_type = StatusType.UNKNOWN
-    else:
-        status_type = StatusType.LOGGED_IN if logged_in else StatusType.NOT_LOGGED_IN
-
-    return AgentStatus(
-        agent="claude",
-        installed=True,
-        logged_in=logged_in,
-        status_text=message,
-        status_type=status_type,
-        last_checked=datetime.now(),
-    )
-
-
-def detect_copilot_status() -> AgentStatus:
-    """Detect GitHub Copilot installation and login status.
-
-    Returns:
-        AgentStatus with detection results
-    """
-    installed = check_agent_installed("copilot")
-    if not installed:
-        return AgentStatus(
-            agent="copilot",
-            installed=False,
-            logged_in=False,
-            status_text="Not installed",
-            status_type=StatusType.NOT_INSTALLED,
-            last_checked=datetime.now(),
-        )
-
-    logged_in, message = check_copilot_login()
-    # Extract username if present
-    username = None
-    if "as " in message:
-        username = message.split("as ")[-1].strip()
-
-    return AgentStatus(
-        agent="copilot",
-        installed=True,
-        logged_in=logged_in,
-        status_text=message,
-        status_type=StatusType.LOGGED_IN if logged_in else StatusType.NOT_LOGGED_IN,
-        username=username,
-        last_checked=datetime.now(),
-    )
-
-
-def detect_gemini_status() -> AgentStatus:
-    """Detect Gemini installation and login status.
-
-    Returns:
-        AgentStatus with detection results
-    """
-    installed = check_agent_installed("gemini")
-    if not installed:
-        return AgentStatus(
-            agent="gemini",
-            installed=False,
-            logged_in=False,
-            status_text="Not installed",
-            status_type=StatusType.NOT_INSTALLED,
-            last_checked=datetime.now(),
-        )
-
-    logged_in, message = check_gemini_login()
-    return AgentStatus(
-        agent="gemini",
-        installed=True,
-        logged_in=logged_in,
-        status_text=message,
-        status_type=StatusType.LOGGED_IN if logged_in else StatusType.NOT_LOGGED_IN,
-        last_checked=datetime.now(),
-    )
-
-
-def detect_gh_status() -> AgentStatus:
-    """Detect GitHub CLI installation and login status.
-
-    Returns:
-        AgentStatus with detection results
-    """
-    installed = check_agent_installed("gh")
-    if not installed:
-        return AgentStatus(
+        return installed_status(
             agent="github",
-            installed=False,
             logged_in=False,
-            status_text="Not installed",
-            status_type=StatusType.NOT_INSTALLED,
-            last_checked=datetime.now(),
+            status_text="Unknown (timeout)",
+            status_type=StatusType.UNKNOWN,
+        )
+    except (FileNotFoundError, OSError):
+        return installed_status(
+            agent="github",
+            logged_in=False,
+            status_text="Unknown (gh CLI not found)",
+            status_type=StatusType.UNKNOWN,
         )
 
-    logged_in, message = check_gh_status()
-    # Extract username if present
-    username = None
-    if "as " in message:
-        username = message.split("as ")[-1].strip()
+    if result.returncode == 0 and "Logged in" in result.stdout:
+        username = None
+        for line in result.stdout.split("\n"):
+            if "Logged in to github.com account" not in line:
+                continue
+            parts = line.split("account")
+            if len(parts) > 1:
+                username = parts[1].split("(")[0].strip() or None
+                break
+        if username:
+            return installed_status(
+                agent="github",
+                logged_in=True,
+                status_text=f"Logged in as {username}",
+                username=username,
+            )
+        return installed_status(
+            agent="github",
+            logged_in=True,
+            status_text="Logged in",
+        )
 
-    return AgentStatus(
+    return installed_status(
         agent="github",
-        installed=True,
-        logged_in=logged_in,
-        status_text=message,
-        status_type=StatusType.LOGGED_IN if logged_in else StatusType.NOT_LOGGED_IN,
-        username=username,
-        last_checked=datetime.now(),
+        logged_in=False,
+        status_text="Not logged in to GitHub",
     )
 
 
 def detect_all_agents() -> list[AgentStatus]:
-    """Detect status for all supported agents and GitHub CLI.
+    """Detect status for all supported agents and GitHub CLI."""
 
-    Returns:
-        List of AgentStatus for all agents
-    """
-    return [
-        detect_codex_status(),
-        detect_claude_status(),
-        detect_copilot_status(),
-        detect_gemini_status(),
-        detect_gh_status(),
-    ]
+    statuses: list[AgentStatus] = []
+    for agent_name in available_agent_system_names(include_internal=False):
+        try:
+            plugin = get_agent_system(agent_name)
+            statuses.append(plugin.detect_status())
+        except Exception:
+            statuses.append(
+                installed_status(
+                    agent=agent_name,
+                    logged_in=False,
+                    status_text="Unknown (status detection failed)",
+                    status_type=StatusType.UNKNOWN,
+                )
+            )
+
+    statuses.append(detect_gh_status())
+    return statuses
+
+
+__all__ = ["AgentStatus", "StatusType", "detect_all_agents", "detect_gh_status"]

--- a/agents_runner/setup/commands.py
+++ b/agents_runner/setup/commands.py
@@ -16,7 +16,7 @@ def get_setup_command(agent_name: str) -> str | None:
     the target in a terminal window.
 
     Args:
-        agent_name: Agent system name (codex, claude, copilot, gemini) or "github"
+        agent_name: Agent system name or "github"
 
     Returns:
         Shell command string, or None if agent doesn't support setup
@@ -36,7 +36,7 @@ def get_login_command(agent_name: str) -> str | None:
     Same as get_setup_command, provided for clarity in per-agent management.
 
     Args:
-        agent_name: Agent system name (codex, claude, copilot, gemini) or "github"
+        agent_name: Agent system name or "github"
 
     Returns:
         Shell command string, or None if agent doesn't support login
@@ -51,7 +51,7 @@ def get_config_command(agent_name: str) -> str | None:
     configuration information.
 
     Args:
-        agent_name: Agent system name (codex, claude, copilot, gemini) or "github"
+        agent_name: Agent system name or "github"
 
     Returns:
         Shell command string, or None if agent doesn't have a config command
@@ -71,7 +71,7 @@ def get_verify_command(agent_name: str) -> str:
     This command tests that the agent CLI is working.
 
     Args:
-        agent_name: Agent system name (codex, claude, copilot, gemini) or "github"
+        agent_name: Agent system name or "github"
 
     Returns:
         Shell command string

--- a/agents_runner/ui/dialogs/first_run_setup.py
+++ b/agents_runner/ui/dialogs/first_run_setup.py
@@ -22,7 +22,10 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from agents_runner.setup.agent_status import detect_all_agents, AgentStatus, StatusType
+from agents_runner.agent_labels import format_agent_ui_label
+from agents_runner.agent_systems.status import AgentStatus
+from agents_runner.agent_systems.status import StatusType
+from agents_runner.setup.agent_status import detect_all_agents
 from agents_runner.setup.orchestrator import (
     SetupOrchestrator,
     mark_setup_complete,
@@ -162,7 +165,7 @@ class FirstRunSetupDialog(ThemedDialog):
             self._status_table.insertRow(row)
 
             # Agent name
-            name_item = QTableWidgetItem(status.agent.capitalize())
+            name_item = QTableWidgetItem(format_agent_ui_label(status.agent))
             self._status_table.setItem(row, 0, name_item)
 
             # Installed status
@@ -189,7 +192,7 @@ class FirstRunSetupDialog(ThemedDialog):
             # Setup checkbox
             checkbox = QCheckBox()
             # Pre-check if installed and not logged in
-            if status.installed and not status.logged_in:
+            if status.installed and status.status_type == StatusType.NOT_LOGGED_IN:
                 checkbox.setChecked(True)
             # Disable if not installed or already logged in
             if not status.installed or status.logged_in:
@@ -364,7 +367,7 @@ class SetupProgressDialog(ThemedDialog):
             status_message: Status message to display
         """
         self._title_label.setText(f"Setting up agent {current} of {total}")
-        self._current_label.setText(f"Current: {agent.capitalize()}")
+        self._current_label.setText(f"Current: {format_agent_ui_label(agent)}")
         self._status_label.setText(status_message)
         self._progress_bar.setValue(
             current - 1 if "Starting in" in status_message else current
@@ -375,10 +378,14 @@ class SetupProgressDialog(ThemedDialog):
         remaining = [a for a in self._agents[current:]]
 
         completed_text = (
-            ", ".join([a.capitalize() for a in completed]) if completed else "None"
+            ", ".join([format_agent_ui_label(a) for a in completed])
+            if completed
+            else "None"
         )
         remaining_text = (
-            ", ".join([a.capitalize() for a in remaining]) if remaining else "None"
+            ", ".join([format_agent_ui_label(a) for a in remaining])
+            if remaining
+            else "None"
         )
 
         self._completed_label.setText(f"Completed: {completed_text}")

--- a/agents_runner/ui/dialogs/test_chain_dialog.py
+++ b/agents_runner/ui/dialogs/test_chain_dialog.py
@@ -13,13 +13,13 @@ from PySide6.QtWidgets import QDialogButtonBox
 from PySide6.QtWidgets import QLabel
 from PySide6.QtWidgets import QWidget
 
-from agents_runner.setup.agent_status import AgentStatus
+from agents_runner.agent_systems.status import AgentStatus
 from agents_runner.setup.agent_status import detect_all_agents
 from agents_runner.ui.dialogs.themed_dialog import ThemedDialog
 from agents_runner.ui.widgets import AgentChainStatusWidget
 
 if TYPE_CHECKING:
-    from agents_runner.cooldown import CooldownManager
+    from agents_runner.core.agent.cooldown_manager import CooldownManager
 
 
 class AgentStatusCheckThread(QThread):
@@ -89,7 +89,7 @@ class TestChainDialog(ThemedDialog):
         layout.addStretch(1)
 
         # Buttons
-        buttons = QDialogButtonBox(QDialogButtonBox.Close)
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Close)
         buttons.rejected.connect(self.reject)
         layout.addWidget(buttons)
 
@@ -117,7 +117,7 @@ class TestChainDialog(ThemedDialog):
         self._loading.setVisible(False)
 
         # Get cooldown status
-        cooldowns = {}
+        cooldowns: dict[str, bool] = {}
         if self._cooldown_manager:
             for agent in self._agents:
                 cooldowns[agent] = self._cooldown_manager.is_on_cooldown(agent)

--- a/agents_runner/ui/main_window_settings.py
+++ b/agents_runner/ui/main_window_settings.py
@@ -12,6 +12,7 @@ from agents_runner.agent_cli import container_config_dir
 from agents_runner.agent_cli import additional_config_mounts
 from agents_runner.agent_cli import available_agents
 from agents_runner.agent_cli import default_host_config_dir
+from agents_runner.agent_labels import format_agent_ui_label
 from agents_runner.agent_systems import get_agent_system
 from agents_runner.ide_systems import IDE_DISPLAY_CONTAINER_DESKTOP
 from agents_runner.ide_systems import get_default_ide_system_name
@@ -791,9 +792,10 @@ class MainWindowSettingsMixin:
             return ""
         agent_cli = normalize_agent(str(getattr(inst, "agent_cli", "") or "codex"))
         agent_id = str(getattr(inst, "agent_id", "") or "").strip()
+        display_name = format_agent_ui_label(agent_cli)
         if agent_id and agent_id != agent_cli:
-            return f"{agent_cli} ({agent_id})"
-        return agent_cli
+            return f"{display_name} ({agent_id})"
+        return display_name
 
     def _compute_cross_agent_config_mounts(
         self,

--- a/agents_runner/ui/main_window_tasks_agent.py
+++ b/agents_runner/ui/main_window_tasks_agent.py
@@ -13,6 +13,7 @@ from PySide6.QtCore import QThread
 
 from PySide6.QtWidgets import QMessageBox
 
+from agents_runner.agent_labels import format_agent_ui_label
 from agents_runner.environments import WORKSPACE_CLONED
 from agents_runner.environments import WORKSPACE_MOUNTED
 from agents_runner.environments.cleanup import cleanup_task_workspace
@@ -618,12 +619,14 @@ class MainWindowTasksAgentMixin:
                             None,
                         )
                         if fallback_agent:
-                            fallback_name = fallback_agent.agent_cli.capitalize()
+                            fallback_name = format_agent_ui_label(
+                                fallback_agent.agent_cli
+                            )
 
             # Show cooldown modal
             modal = CooldownModal(
                 self,
-                agent_name=agent_cli.capitalize(),
+                agent_name=format_agent_ui_label(agent_cli),
                 watch_state=watch_state,
                 fallback_agent_name=fallback_name,
             )

--- a/agents_runner/ui/pages/environments_agents.py
+++ b/agents_runner/ui/pages/environments_agents.py
@@ -21,6 +21,7 @@ from PySide6.QtWidgets import QWidget
 
 from agents_runner.agent_cli import normalize_agent
 from agents_runner.agent_cli import available_agents
+from agents_runner.agent_labels import format_agent_ui_label
 from agents_runner.environments.model import AgentInstance
 from agents_runner.environments.model import AgentSelection
 from agents_runner.ui.constants import (
@@ -127,7 +128,7 @@ class AgentsTabWidget(QWidget):
         controls_row.addWidget(QLabel("Add agent"))
         self._add_agent_cli = QComboBox()
         for agent in available_agents(include_internal=False):
-            self._add_agent_cli.addItem(agent.title(), agent)
+            self._add_agent_cli.addItem(format_agent_ui_label(agent), agent)
         controls_row.addWidget(self._add_agent_cli)
 
         add_btn = QToolButton()
@@ -354,7 +355,8 @@ class AgentsTabWidget(QWidget):
         self.agents_changed.emit()
 
     def _agent_cli_widget(self, row_index: int, inst: AgentInstance) -> QWidget:
-        label = QLabel(normalize_agent(inst.agent_cli).title())
+        del row_index
+        label = QLabel(format_agent_ui_label(normalize_agent(inst.agent_cli)))
         label.setAlignment(Qt.AlignCenter)
         label.setStyleSheet("color: rgba(237, 239, 245, 200);")
         return label
@@ -568,7 +570,7 @@ class AgentsTabWidget(QWidget):
             self._pinned_agent.clear()
             for inst in self._rows:
                 self._pinned_agent.addItem(
-                    f"{inst.agent_id} ({normalize_agent(inst.agent_cli)})",
+                    f"{inst.agent_id} ({format_agent_ui_label(normalize_agent(inst.agent_cli))})",
                     inst.agent_id,
                 )
             if (
@@ -608,7 +610,7 @@ class AgentsTabWidget(QWidget):
                 if other.agent_id == inst.agent_id:
                     continue
                 combo.addItem(
-                    f"{other.agent_id} ({normalize_agent(other.agent_cli)})",
+                    f"{other.agent_id} ({format_agent_ui_label(normalize_agent(other.agent_cli))})",
                     other.agent_id,
                 )
             if current_value and current_value in ids:

--- a/agents_runner/ui/pages/settings_form.py
+++ b/agents_runner/ui/pages/settings_form.py
@@ -23,8 +23,8 @@ from PySide6.QtWidgets import QVBoxLayout
 from PySide6.QtWidgets import QWidget
 
 from agents_runner.agent_cli import normalize_agent
+from agents_runner.agent_labels import format_agent_ui_label
 from agents_runner.agent_systems import available_agent_system_names
-from agents_runner.agent_systems import get_agent_system
 from agents_runner.agent_systems import get_default_agent_system_name
 from agents_runner.ide_systems import available_ide_system_names
 from agents_runner.ide_systems import get_default_ide_system_name
@@ -711,21 +711,12 @@ class SettingsFormMixin:
         with QSignalBlocker(self._use):
             self._use.clear()
             for agent_name in available_agent_system_names(include_internal=False):
-                label = self._format_key_label(agent_name)
-                try:
-                    plugin = get_agent_system(agent_name)
-                    display_name = str(
-                        getattr(plugin, "display_name", "") or ""
-                    ).strip()
-                    if display_name:
-                        label = display_name
-                except Exception:
-                    pass
+                label = format_agent_ui_label(agent_name)
                 self._use.addItem(label, agent_name)
 
             if self._use.count() == 0:
                 default_name = get_default_agent_system_name()
-                self._use.addItem(self._format_key_label(default_name), default_name)
+                self._use.addItem(format_agent_ui_label(default_name), default_name)
 
         preferred = normalize_agent(selected or str(self._use.itemData(0) or ""))
         self._set_combo_value(self._use, preferred, fallback=preferred)
@@ -856,6 +847,10 @@ class SettingsFormMixin:
             return "Midori AI (Dark Theme)"
         if normalized == "midoriai_light":
             return "Midori AI (Light Theme)"
+        try:
+            return format_agent_ui_label(normalized)
+        except Exception:
+            pass
         return SettingsFormMixin._format_key_label(normalized)
 
     @staticmethod

--- a/agents_runner/ui/themes/opencode/__init__.py
+++ b/agents_runner/ui/themes/opencode/__init__.py
@@ -1,0 +1,1 @@
+"""OpenCode UI theme package."""

--- a/agents_runner/ui/themes/opencode/background.py
+++ b/agents_runner/ui/themes/opencode/background.py
@@ -1,0 +1,35 @@
+"""OpenCode theme background implementation."""
+
+from __future__ import annotations
+
+from PySide6.QtGui import QColor
+
+from agents_runner.ui.themes.midori_variant import MidoriVariantSpec
+from agents_runner.ui.themes.midori_variant import create_midori_background
+
+
+_SPEC = MidoriVariantSpec(
+    theme_name="opencode",
+    base_color=QColor(14, 19, 23),
+    overlay_alpha=18,
+    top_start=QColor("#203347"),
+    top_end=QColor("#1B6D67"),
+    bottom_start=QColor("#171F28"),
+    bottom_end=QColor("#D36B2E"),
+    blob_palette=(
+        QColor(102, 205, 197, 182),
+        QColor(80, 156, 208, 168),
+        QColor(248, 176, 80, 176),
+        QColor(224, 112, 64, 170),
+        QColor(165, 226, 180, 146),
+        QColor(245, 206, 126, 132),
+    ),
+    ambient_overlay=QColor(0, 0, 0, 24),
+    boundary_angle_deg=16.0,
+    motion_speed=1.02,
+    wave_strength=0.24,
+    pulse_strength=0.24,
+    light_mode=False,
+)
+
+BACKGROUND = create_midori_background(_SPEC)

--- a/agents_runner/ui/themes/qwen/__init__.py
+++ b/agents_runner/ui/themes/qwen/__init__.py
@@ -1,0 +1,1 @@
+"""Qwen UI theme package."""

--- a/agents_runner/ui/themes/qwen/background.py
+++ b/agents_runner/ui/themes/qwen/background.py
@@ -1,0 +1,35 @@
+"""Qwen theme background implementation."""
+
+from __future__ import annotations
+
+from PySide6.QtGui import QColor
+
+from agents_runner.ui.themes.midori_variant import MidoriVariantSpec
+from agents_runner.ui.themes.midori_variant import create_midori_background
+
+
+_SPEC = MidoriVariantSpec(
+    theme_name="qwen",
+    base_color=QColor(12, 18, 24),
+    overlay_alpha=20,
+    top_start=QColor("#15324F"),
+    top_end=QColor("#0C7A83"),
+    bottom_start=QColor("#14212A"),
+    bottom_end=QColor("#C7742B"),
+    blob_palette=(
+        QColor(82, 192, 216, 190),
+        QColor(52, 165, 151, 176),
+        QColor(246, 168, 84, 170),
+        QColor(241, 125, 73, 160),
+        QColor(131, 197, 255, 150),
+        QColor(167, 230, 218, 138),
+    ),
+    ambient_overlay=QColor(0, 0, 0, 26),
+    boundary_angle_deg=15.0,
+    motion_speed=1.08,
+    wave_strength=0.26,
+    pulse_strength=0.28,
+    light_mode=False,
+)
+
+BACKGROUND = create_midori_background(_SPEC)

--- a/agents_runner/ui/widgets/agent_chain_status.py
+++ b/agents_runner/ui/widgets/agent_chain_status.py
@@ -13,7 +13,9 @@ from PySide6.QtWidgets import QToolButton
 from PySide6.QtWidgets import QVBoxLayout
 from PySide6.QtWidgets import QWidget
 
-from agents_runner.setup.agent_status import AgentStatus
+from agents_runner.agent_labels import format_agent_ui_label
+from agents_runner.agent_systems.status import AgentStatus
+from agents_runner.agent_systems.status import StatusType
 
 
 class AgentStatusIndicator(QWidget):
@@ -45,7 +47,7 @@ class AgentStatusIndicator(QWidget):
         layout.addWidget(position_label)
 
         # Agent name
-        self._name_label = QLabel(agent_name.title())
+        self._name_label = QLabel(format_agent_ui_label(agent_name))
         self._name_label.setStyleSheet("font-weight: 500;")
         layout.addWidget(self._name_label)
 
@@ -92,7 +94,11 @@ class AgentStatusIndicator(QWidget):
 
         # Logged in indicator
         if self._status.installed:
-            if self._status.logged_in:
+            if self._status.status_type == StatusType.UNKNOWN:
+                self._add_indicator(
+                    "?", self._status.status_text, "rgba(160, 160, 160, 255)"
+                )
+            elif self._status.logged_in:
                 self._add_indicator("✓", "Logged in", "rgba(95, 205, 143, 255)")
             else:
                 self._add_indicator("⚠", "Not logged in", "rgba(249, 226, 175, 255)")
@@ -225,7 +231,7 @@ class AgentChainStatusWidget(QWidget):
         unavailable = []
 
         for indicator in self._agent_indicators:
-            name = indicator.get_agent_name().title()
+            name = format_agent_ui_label(indicator.get_agent_name())
             if indicator.is_available():
                 available.append(name)
             else:


### PR DESCRIPTION
## Summary
- add first-class `qwen` and `opencode` agent-system plugins with install, verify, setup, status, command planning, prompt templates, and themes
- move agent status detection to plugin-owned logic and update setup/status UI to use friendly agent labels
- preserve OpenCode dual config/data mounts and keep Qwen login state non-blocking when only runtime checks are available

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: (unknown)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
