### PR TITLE
[FIX] Prevent duplicate Docker config mounts

### DIFF
--- a/agents_runner/docker/utils.py
+++ b/agents_runner/docker/utils.py
@@ -31,9 +31,11 @@ def deduplicate_mounts(mounts: list[str]) -> list[str]:
     """
     Deduplicate mount specifications while preserving order.
 
-    Compares mount points by their container path (the part before the first or
-    second colon). If multiple mounts target the same container path, keeps only
-    the first occurrence.
+    Deduplicates by both host path and container path:
+    - If multiple mounts share the same host path, keeps the first occurrence
+    - If multiple mounts share the same container path, keeps the first occurrence
+
+    Host paths are normalized (expanduser + abspath) for comparison.
 
     Args:
         mounts: List of mount strings in format "host:container[:mode]"
@@ -41,6 +43,7 @@ def deduplicate_mounts(mounts: list[str]) -> list[str]:
     Returns:
         Deduplicated list of mounts preserving original order
     """
+    seen_host_paths: set[str] = set()
     seen_container_paths: set[str] = set()
     result: list[str] = []
 
@@ -49,17 +52,23 @@ def deduplicate_mounts(mounts: list[str]) -> list[str]:
         if not mount_str:
             continue
 
-        # Extract container path (second part of host:container[:mode])
         parts = mount_str.split(":")
         if len(parts) < 2:
-            # Malformed mount, skip
             continue
 
+        host_path_raw = parts[0]
         container_path = parts[1]
 
-        if container_path not in seen_container_paths:
-            seen_container_paths.add(container_path)
-            result.append(mount_str)
+        # Normalize host path for comparison (handles ~, relative paths)
+        host_path = os.path.abspath(os.path.expanduser(host_path_raw))
+
+        # Skip if host path or container path already seen
+        if host_path in seen_host_paths or container_path in seen_container_paths:
+            continue
+
+        seen_host_paths.add(host_path)
+        seen_container_paths.add(container_path)
+        result.append(mount_str)
 
     return result
 

--- a/agents_runner/docker/utils.py
+++ b/agents_runner/docker/utils.py
@@ -1,5 +1,41 @@
 import os
+import posixpath
 import tempfile
+
+
+def split_mount_spec(mount: str) -> tuple[str, str, str]:
+    """Split a Docker ``-v`` mount string into host/container/mode parts."""
+    mount_str = str(mount or "").strip()
+    if not mount_str:
+        return "", "", ""
+
+    parts = mount_str.split(":", 2)
+    if len(parts) < 2:
+        return "", "", ""
+
+    host_path = str(parts[0] or "").strip()
+    container_path = str(parts[1] or "").strip()
+    mode = str(parts[2] or "").strip() if len(parts) > 2 else ""
+    return host_path, container_path, mode
+
+
+def normalize_host_mount_path(path: str) -> str:
+    """Normalize a host bind-mount path for comparisons."""
+    raw = str(path or "").strip()
+    if not raw:
+        return ""
+    return os.path.normpath(
+        os.path.abspath(os.path.expanduser(os.path.expandvars(raw)))
+    )
+
+
+def normalize_container_mount_path(path: str) -> str:
+    """Normalize a container bind-mount path for comparisons."""
+    raw = str(path or "").strip()
+    if not raw:
+        return ""
+    normalized = posixpath.normpath(raw)
+    return raw if normalized == "." else normalized
 
 
 def write_preflight_script(
@@ -35,7 +71,8 @@ def deduplicate_mounts(mounts: list[str]) -> list[str]:
     - If multiple mounts share the same host path, keeps the first occurrence
     - If multiple mounts share the same container path, keeps the first occurrence
 
-    Host paths are normalized (expanduser + abspath) for comparison.
+    Host paths are normalized (expandvars + expanduser + abspath + normpath)
+    and container paths are normalized as POSIX paths for comparison.
 
     Args:
         mounts: List of mount strings in format "host:container[:mode]"
@@ -52,15 +89,12 @@ def deduplicate_mounts(mounts: list[str]) -> list[str]:
         if not mount_str:
             continue
 
-        parts = mount_str.split(":")
-        if len(parts) < 2:
+        host_path_raw, container_path_raw, _mode = split_mount_spec(mount_str)
+        if not host_path_raw or not container_path_raw:
             continue
 
-        host_path_raw = parts[0]
-        container_path = parts[1]
-
-        # Normalize host path for comparison (handles ~, relative paths)
-        host_path = os.path.abspath(os.path.expanduser(host_path_raw))
+        host_path = normalize_host_mount_path(host_path_raw)
+        container_path = normalize_container_mount_path(container_path_raw)
 
         # Skip if host path or container path already seen
         if host_path in seen_host_paths or container_path in seen_container_paths:
@@ -70,6 +104,28 @@ def deduplicate_mounts(mounts: list[str]) -> list[str]:
         seen_container_paths.add(container_path)
         result.append(mount_str)
 
+    return result
+
+
+def deduplicate_mount_args(mount_args: list[str]) -> list[str]:
+    """Deduplicate flattened Docker ``-v`` mount arguments."""
+    mount_specs: list[str] = []
+    i = 0
+    while i < len(mount_args):
+        flag = str(mount_args[i] or "").strip()
+        if flag != "-v":
+            i += 1
+            continue
+        if i + 1 >= len(mount_args):
+            break
+        spec = str(mount_args[i + 1] or "").strip()
+        if spec:
+            mount_specs.append(spec)
+        i += 2
+
+    result: list[str] = []
+    for mount in deduplicate_mounts(mount_specs):
+        result.extend(["-v", mount])
     return result
 
 

--- a/agents_runner/ui/main_window_tasks_interactive_docker.py
+++ b/agents_runner/ui/main_window_tasks_interactive_docker.py
@@ -22,7 +22,7 @@ from agents_runner.agent_cli import agent_requires_github_token
 from agents_runner.agent_cli import available_agents
 from agents_runner.agent_cli import verify_cli_clause
 from agents_runner.artifacts import get_staging_dir
-from agents_runner.docker.utils import deduplicate_mounts
+from agents_runner.docker.utils import deduplicate_mount_args, deduplicate_mounts
 from agents_runner.docker_platform import ROSETTA_INSTALL_COMMAND
 from agents_runner.docker_platform import docker_platform_args_for_pixelarch
 from agents_runner.docker_platform import has_rosetta
@@ -980,18 +980,19 @@ def _build_docker_command(
         "--name",
         container_name,
     ]
+    mount_args: list[str] = []
     if not shell_mode:
-        docker_args.extend(
+        mount_args.extend(
             [
                 "-v",
                 f"{host_config_dir}:{container_agent_dir}",
             ]
         )
+    mount_args.extend(["-v", f"{host_workdir}:{container_workdir}"])
+    mount_args.extend(extra_mount_args)
     docker_args.extend(
         [
-            "-v",
-            f"{host_workdir}:{container_workdir}",
-            *extra_mount_args,
+            *deduplicate_mount_args(mount_args),
             *preflight_mounts,
             *env_args,
             *port_args,


### PR DESCRIPTION
Updated Docker mount deduplication to normalize host and container paths before comparing them, so trailing-slash variants no longer slip through as distinct mounts. The interactive launcher now also deduplicates the final combined mount list after adding its built-in config and workspace mounts, ensuring runner-managed mounts win over conflicting user mounts before Docker sees them.

Verification run: uv run ruff format ., uv run ruff check ., uv run basedpyright agents_runner/docker/utils.py, plus targeted py_compile and runtime assertions for the interactive Docker mount assembly path.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode](https://github.com/anomalyco/opencode)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
