### PR TITLE
[DOCS] Clarify setup-agents root execution

### DIFF
--- a/.agents/docs/setup-agents.md
+++ b/.agents/docs/setup-agents.md
@@ -1,0 +1,41 @@
+# setup-agents.sh
+
+## Overview
+`setup-agents.sh` prepares the PixelArch Emerald container for your repository.
+
+## Location
+- Primary: `.agents/setup-agents.sh`
+- Fallback: `.github/setup-agents.sh`
+- Must be executable and committed
+- Runs from repository root - do NOT add cd commands
+
+## What Goes In The Script
+- Install packages not in Emerald: `yay -Syu --noconfirm --needed <packages>`
+- Install project dependencies (`uv sync`, `npm install`, etc.)
+- Configure git hooks and tooling
+
+## PixelArch Emerald Preinstalled
+See [PixelArch Emerald](https://io.midori-ai.xyz/pixelos/pixelarch/).
+Already includes: `gh`, `claude-code`, `codex`, `copilot`, `python`, `nodejs`, `rust`, `openssh`, `tmate`, `tor`, `lynx`
+
+## Environment Variable
+`MIDORI_AI_AGENTS_RUNNER_INTERACTIVE=true` for interactive mode, `false` for agent runs.
+
+## Example (from this repo)
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+uv sync
+uv sync --group ci
+git config --local core.hooksPath .githooks
+```
+
+## Anti-Patterns
+- Do NOT add cd commands - working directory is already repo root
+- Do NOT use `pacman` or plain `yay -S` - always `yay -Syu`
+- Do NOT store secrets
+- Do NOT manipulate git branches/remotes
+
+## Missing Script
+If missing, guidance is injected in non-IDE mode. Environment setting `Inject missing setup-agents prompt` controls this.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Requires `docker` and `ffmpeg` installed on the host.
 - **OpenCode** - [Install](https://github.com/anomalyco/opencode)
 - **Qwen** - [Install](https://github.com/QwenLM/qwen-code) # May not be fully supported, open a issue if you run into bugs
 
+See [.agents/docs/setup-agents.md](.agents/docs/setup-agents.md) for container setup instructions.
+
 ## Features
 
 - **Docker Integration**: Runs agents in `lunamidori5/pixelarch:emerald` container

--- a/agents_runner/setup_agents.py
+++ b/agents_runner/setup_agents.py
@@ -127,10 +127,10 @@ def _missing_instruction() -> str:
     return (
         "Repository bootstrap is missing. Create `.agents/setup-agents.sh`, "
         "make it executable, and commit it. `setup-agents.sh` is always executed "
-        "from the repository root. The script must only prepare/setup the agent "
-        "container so it is ready for use; do not perform repository setup. "
-        "Environment is PixelArch: package installs must use `yay -Syu` only; "
-        "never `pacman`; never plain `yay -S`."
+        "from the repository root (do NOT add cd commands). The script must only "
+        "prepare/setup the agent container so it is ready for use; do not perform "
+        "repository setup. Environment is PixelArch: package installs must use "
+        "`yay -Syu` only; never `pacman`; never plain `yay -S`."
     )
 
 


### PR DESCRIPTION
## Summary
- add explicit no-`cd` guidance to `docs/setup-agents.md`
- mirror the same repository-root guidance in `agents_runner/setup_agents.py`
- validate with `uv run ruff format .` and `uv run ruff check .`

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode](https://github.com/anomalyco/opencode)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
