### PR TITLE
Fix OpenCode stdout suppression on interactive launch

### DIFF
--- a/agents_runner/docker/agent_worker_container.py
+++ b/agents_runner/docker/agent_worker_container.py
@@ -222,8 +222,10 @@ class ContainerExecutor:
     def _build_main_command_clause(self, agent_cmd: str) -> str:
         """Build the command execution clause."""
         if not self._runtime_env.custom_command_argv:
-            if self._runtime_env.agent_cli == "opencode" and agent_cmd.startswith(
-                "opencode run"
+            if (
+                self._runtime_env.agent_cli == "opencode"
+                and agent_cmd.startswith("opencode ")
+                and not agent_cmd.startswith("opencode run")
             ):
                 return f"exec {agent_cmd} >/dev/null"
             return f"exec {agent_cmd}"

--- a/agents_runner/docker/agent_worker_container.py
+++ b/agents_runner/docker/agent_worker_container.py
@@ -222,6 +222,10 @@ class ContainerExecutor:
     def _build_main_command_clause(self, agent_cmd: str) -> str:
         """Build the command execution clause."""
         if not self._runtime_env.custom_command_argv:
+            if self._runtime_env.agent_cli == "opencode" and agent_cmd.startswith(
+                "opencode run"
+            ):
+                return f"exec {agent_cmd} >/dev/null"
             return f"exec {agent_cmd}"
 
         launch_mode = str(self._runtime_env.launch_mode or "").strip().lower()


### PR DESCRIPTION
## Summary
- Move OpenCode stdout suppression from `opencode run` to the plain interactive `opencode` launch path.
- Keep stderr visible so failures still surface in logs.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode](https://github.com/anomalyco/opencode)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
