### PR TITLE
[FIX] Save environment tab data when navigating away from Environment...

### DIFF
--- a/agents_runner/ui/pages/environments_actions.py
+++ b/agents_runner/ui/pages/environments_actions.py
@@ -216,6 +216,11 @@ class EnvironmentsPageActionsMixin:
             self._agentsnova_trusted_users_env.get_usernames()
         )
 
+        self._env_vars_tab.flush_widget_state()
+        self._mounts_tab.flush_widget_state()
+        self._ports_tab.flush_widget_state()
+        self._agents_tab.flush_widget_state()
+
         env_vars, errors = self._env_vars_tab.get_env_vars()
         if errors:
             if show_validation_errors:

--- a/agents_runner/ui/pages/environments_agents.py
+++ b/agents_runner/ui/pages/environments_agents.py
@@ -619,6 +619,45 @@ class AgentsTabWidget(QWidget):
                     combo.setCurrentIndex(idx)
             combo.blockSignals(False)
 
+    def flush_widget_state(self) -> None:
+        for row_index in range(len(self._rows)):
+            inst = self._rows[row_index]
+
+            id_widget = self._agent_table.cellWidget(row_index, self._COL_ID)
+            if isinstance(id_widget, QLineEdit):
+                sanitized = self._sanitize_agent_id(id_widget.text())
+                if sanitized and _ID_RE.match(sanitized):
+                    inst = AgentInstance(
+                        agent_id=sanitized,
+                        agent_cli=inst.agent_cli,
+                        config_dir=inst.config_dir,
+                        cli_flags=inst.cli_flags,
+                    )
+
+            config_widget = self._agent_table.cellWidget(row_index, self._COL_CONFIG)
+            if isinstance(config_widget, QWidget):
+                line_edit = config_widget.findChild(QLineEdit)
+                if isinstance(line_edit, QLineEdit):
+                    inst = AgentInstance(
+                        agent_id=inst.agent_id,
+                        agent_cli=inst.agent_cli,
+                        config_dir=os.path.expanduser(
+                            str(line_edit.text() or "").strip()
+                        ),
+                        cli_flags=inst.cli_flags,
+                    )
+
+            flags_widget = self._agent_table.cellWidget(row_index, self._COL_CLI_FLAGS)
+            if isinstance(flags_widget, QLineEdit):
+                inst = AgentInstance(
+                    agent_id=inst.agent_id,
+                    agent_cli=inst.agent_cli,
+                    config_dir=inst.config_dir,
+                    cli_flags=str(flags_widget.text() or "").strip(),
+                )
+
+            self._rows[row_index] = inst
+
     def set_agent_selection(self, agent_selection: AgentSelection | None) -> None:
         self._selection_mode.blockSignals(True)
         try:

--- a/agents_runner/ui/pages/environments_env_vars.py
+++ b/agents_runner/ui/pages/environments_env_vars.py
@@ -169,6 +169,17 @@ class EnvVarsTabWidget(QWidget):
             parsed[key] = value
         return parsed, errors
 
+    def flush_widget_state(self) -> None:
+        if self._advanced_mode:
+            return
+        for row_index in range(len(self._rows)):
+            key_widget = self._table.cellWidget(row_index, self._COL_KEY)
+            value_widget = self._table.cellWidget(row_index, self._COL_VALUE)
+            if isinstance(key_widget, QLineEdit):
+                self._rows[row_index].key = str(key_widget.text() or "").strip()
+            if isinstance(value_widget, QLineEdit):
+                self._rows[row_index].value = str(value_widget.text() or "")
+
     def is_advanced_mode(self) -> bool:
         return bool(self._advanced_mode)
 

--- a/agents_runner/ui/pages/environments_mounts.py
+++ b/agents_runner/ui/pages/environments_mounts.py
@@ -219,6 +219,25 @@ class MountsTabWidget(QWidget):
             mounts.append(f"{host_path}:{container_path}:{mode}")
         return mounts, errors
 
+    def flush_widget_state(self) -> None:
+        if self._advanced_mode:
+            return
+        for row_index in range(len(self._rows)):
+            host_widget = self._table.cellWidget(row_index, self._COL_HOST_PATH)
+            container_widget = self._table.cellWidget(
+                row_index, self._COL_CONTAINER_PATH
+            )
+            mode_widget = self._table.cellWidget(row_index, self._COL_MODE)
+            if isinstance(host_widget, QLineEdit):
+                self._rows[row_index].host_path = str(host_widget.text() or "")
+            if isinstance(container_widget, QLineEdit):
+                self._rows[row_index].container_path = str(
+                    container_widget.text() or ""
+                )
+            if isinstance(mode_widget, QComboBox):
+                mode = str(mode_widget.currentData() or "rw").strip().lower() or "rw"
+                self._rows[row_index].mode = mode
+
     def is_advanced_mode(self) -> bool:
         return bool(self._advanced_mode)
 

--- a/agents_runner/ui/pages/environments_ports.py
+++ b/agents_runner/ui/pages/environments_ports.py
@@ -372,8 +372,8 @@ class PortsTabWidget(QWidget):
             host.setPlaceholderText("random")
             host.setText(str(row.host_port or ""))
             host.setValidator(validator)
-            host.editingFinished.connect(
-                lambda r=row_index, w=host: self._commit_host_port(r, w)
+            host.textChanged.connect(
+                lambda text, r=row_index: self._on_host_port_changed(r, text)
             )
             self._table.setCellWidget(row_index, self._COL_HOST, host)
 
@@ -381,8 +381,8 @@ class PortsTabWidget(QWidget):
             container.setPlaceholderText("container")
             container.setText(str(row.container_port or ""))
             container.setValidator(validator)
-            container.editingFinished.connect(
-                lambda r=row_index, w=container: self._commit_container_port(r, w)
+            container.textChanged.connect(
+                lambda text, r=row_index: self._on_container_port_changed(r, text)
             )
             self._table.setCellWidget(row_index, self._COL_CONTAINER, container)
 
@@ -394,16 +394,29 @@ class PortsTabWidget(QWidget):
             remove_btn.clicked.connect(lambda r=row_index: self._remove_row(r))
             self._table.setCellWidget(row_index, self._COL_REMOVE, remove_btn)
 
-    def _commit_host_port(self, row_index: int, widget: QLineEdit) -> None:
+    def flush_widget_state(self) -> None:
+        if self._unlocked:
+            return
+        for row_index in range(len(self._rows)):
+            host_widget = self._table.cellWidget(row_index, self._COL_HOST)
+            container_widget = self._table.cellWidget(row_index, self._COL_CONTAINER)
+            if isinstance(host_widget, QLineEdit):
+                self._rows[row_index].host_port = str(host_widget.text() or "").strip()
+            if isinstance(container_widget, QLineEdit):
+                self._rows[row_index].container_port = str(
+                    container_widget.text() or ""
+                ).strip()
+
+    def _on_host_port_changed(self, row_index: int, text: str) -> None:
         if row_index < 0 or row_index >= len(self._rows):
             return
-        self._rows[row_index].host_port = str(widget.text() or "").strip()
+        self._rows[row_index].host_port = str(text or "").strip()
         self.ports_changed.emit()
 
-    def _commit_container_port(self, row_index: int, widget: QLineEdit) -> None:
+    def _on_container_port_changed(self, row_index: int, text: str) -> None:
         if row_index < 0 or row_index >= len(self._rows):
             return
-        self._rows[row_index].container_port = str(widget.text() or "").strip()
+        self._rows[row_index].container_port = str(text or "").strip()
         self.ports_changed.emit()
 
     def _remove_row(self, row_index: int) -> None:


### PR DESCRIPTION
## Summary

Environment tab edits (ports, mounts, env vars, agents) were silently discarded when the user navigated away from the Environments page (Home, Tasks, Settings) without first switching to a different sub-pane within the Environments menu. The save would only succeed if the user moved between sub-panes first, because that was the only path that reliably triggered `editingFinished` on the QLineEdit widgets inside the Ports and Agents tables.

## Root Cause

The Ports tab (`PortsTabWidget`) used `QLineEdit.editingFinished` to commit edited values into its internal `_rows` data structure. The `editingFinished` signal only fires when the user presses Enter or the widget loses focus. However, the top-level navigation buttons (`QToolButton` with Qt default `TabFocus` policy) do not steal keyboard focus on mouse click, so the QLineEdit retains focus and `editingFinished` never fires. When `try_autosave()` runs on navigation, `get_ports()` reads from the stale `_rows` and saves old data, silently discarding the user's changes.

The Agents tab (`AgentsTabWidget`) had the same `editingFinished` issue on its agent_id, config_dir, and cli_flags QLineEdit fields.

The Mounts tab (`MountsTabWidget`) and Env Vars tab (`EnvVarsTabWidget`) were not affected by this root cause because they already use `textChanged` (fires on every keystroke), which keeps `_rows` current at all times.

## Changes

### `agents_runner/ui/pages/environments_ports.py`
- Changed host port and container port `QLineEdit` signals from `editingFinished` to `textChanged`, matching the pattern already used by Mounts and Env Vars tabs. This ensures `_rows` is updated on every keystroke rather than only on focus loss.
- Renamed `_commit_host_port` / `_commit_container_port` to `_on_host_port_changed` / `_on_container_port_changed` to follow the naming convention used by the other tabs.
- Updated method signatures to accept `text: str` parameter directly from the `textChanged` signal instead of reading from the widget.
- Added `flush_widget_state()` method that reads current QLineEdit cell widget values and syncs them into `_rows`. Only runs in simple mode (no-op in advanced/unlocked mode since `toPlainText()` is always current). This is a safety net for edge cases where Qt signal delivery might not occur before the save.

### `agents_runner/ui/pages/environments_mounts.py`
- Added `flush_widget_state()` method that iterates through table rows and syncs QLineEdit (host_path, container_path) and QComboBox (mode) cell widget values into `_rows`. No-op in advanced mode. This is a safety net since Mounts already uses `textChanged` and shouldn't normally need it, but ensures consistency if Qt signal delivery is delayed.

### `agents_runner/ui/pages/environments_env_vars.py`
- Added `flush_widget_state()` method that iterates through table rows and syncs QLineEdit (key, value) cell widget values into `_rows`. No-op in advanced mode. Same safety net rationale as Mounts.

### `agents_runner/ui/pages/environments_agents.py`
- Added `flush_widget_state()` method that iterates through the agent table rows and reads current widget values for three editable fields:
  - **agent_id**: Reads QLineEdit text, sanitizes via `_sanitize_agent_id()`, and validates against the `_ID_RE` regex. Does NOT perform the full uniqueness check or fallback update that `_commit_row_agent_id()` does — those are interactive validations better left to the `editingFinished` handler during normal editing flow. The flush only ensures a valid sanitized ID is captured so data is not lost.
  - **config_dir**: Reads QLineEdit text from the QWidget container (which has a QLineEdit child + Browse button), applies `os.path.expanduser()`.
  - **cli_flags**: Reads QLineEdit text directly.
- Note: The Agents tab retains its `editingFinished` signals for the normal editing flow because `_commit_row_agent_id` performs complex interactive validation (duplicate ID checks, fallback map updates, table re-render) that should not run on every keystroke. The `flush_widget_state()` approach ensures data is captured at save time without disrupting the interactive validation flow.

### `agents_runner/ui/pages/environments_actions.py`
- Added calls to `flush_widget_state()` on all four tab widgets (`_env_vars_tab`, `_mounts_tab`, `_ports_tab`, `_agents_tab`) in `try_autosave()`, immediately before the existing `get_env_vars()` / `get_mounts()` / `get_ports()` / `get_agent_selection()` reads. This ensures all widget state is synced into the tab widgets' internal data structures before the save reads them.

## How the Save-on-Leave Flow Works

1. User edits a field in Ports/Mounts/Env Vars/Agents tab
2. User clicks Home/Tasks/Settings nav button
3. `_try_autosave_before_navigation()` is called (existing behavior, no change)
4. `try_autosave()` runs:
   a. **NEW**: `flush_widget_state()` on all 4 tab widgets syncs current widget values into `_rows`
   b. `get_env_vars()` / `get_mounts()` / `get_ports()` / `get_agent_selection()` read from `_rows` (now guaranteed current)
   c. Environment is built and saved to disk
5. Navigation proceeds

## Verification

- `uv run ruff format .` — no changes needed
- `uv run ruff check .` — all checks passed
- `uv run basedpyright` — no new errors (all existing errors are pre-existing mixin type issues where `EnvironmentsPageActionsMixin` cannot resolve attributes defined on the composed `EnvironmentsPage` class)

## Files Changed

- `agents_runner/ui/pages/environments_ports.py` — `editingFinished` → `textChanged`; added `flush_widget_state()`
- `agents_runner/ui/pages/environments_mounts.py` — added `flush_widget_state()`
- `agents_runner/ui/pages/environments_env_vars.py` — added `flush_widget_state()`
- `agents_runner/ui/pages/environments_agents.py` — added `flush_widget_state()`
- `agents_runner/ui/pages/environments_actions.py` — calls `flush_widget_state()` before tab data reads

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode](https://github.com/anomalyco/opencode)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
