### PR TITLE
Nightly

### DIFF
--- a/.agents/docs/setup-agents.md
+++ b/.agents/docs/setup-agents.md
@@ -1,0 +1,41 @@
+# setup-agents.sh
+
+## Overview
+`setup-agents.sh` prepares the PixelArch Emerald container for your repository.
+
+## Location
+- Primary: `.agents/setup-agents.sh`
+- Fallback: `.github/setup-agents.sh`
+- Must be executable and committed
+- Runs from repository root - do NOT add cd commands
+
+## What Goes In The Script
+- Install packages not in Emerald: `yay -Syu --noconfirm --needed <packages>`
+- Install project dependencies (`uv sync`, `npm install`, etc.)
+- Configure git hooks and tooling
+
+## PixelArch Emerald Preinstalled
+See [PixelArch Emerald](https://io.midori-ai.xyz/pixelos/pixelarch/).
+Already includes: `gh`, `claude-code`, `codex`, `copilot`, `python`, `nodejs`, `rust`, `openssh`, `tmate`, `tor`, `lynx`
+
+## Environment Variable
+`MIDORI_AI_AGENTS_RUNNER_INTERACTIVE=true` for interactive mode, `false` for agent runs.
+
+## Example (from this repo)
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+uv sync
+uv sync --group ci
+git config --local core.hooksPath .githooks
+```
+
+## Anti-Patterns
+- Do NOT add cd commands - working directory is already repo root
+- Do NOT use `pacman` or plain `yay -S` - always `yay -Syu`
+- Do NOT store secrets
+- Do NOT manipulate git branches/remotes
+
+## Missing Script
+If missing, guidance is injected in non-IDE mode. Environment setting `Inject missing setup-agents prompt` controls this.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Requires `docker` and `ffmpeg` installed on the host.
 - **OpenCode** - [Install](https://github.com/anomalyco/opencode)
 - **Qwen** - [Install](https://github.com/QwenLM/qwen-code) # May not be fully supported, open a issue if you run into bugs
 
+See [.agents/docs/setup-agents.md](.agents/docs/setup-agents.md) for container setup instructions.
+
 ## Features
 
 - **Docker Integration**: Runs agents in `lunamidori5/pixelarch:emerald` container

--- a/agents_runner/setup_agents.py
+++ b/agents_runner/setup_agents.py
@@ -127,10 +127,10 @@ def _missing_instruction() -> str:
     return (
         "Repository bootstrap is missing. Create `.agents/setup-agents.sh`, "
         "make it executable, and commit it. `setup-agents.sh` is always executed "
-        "from the repository root. The script must only prepare/setup the agent "
-        "container so it is ready for use; do not perform repository setup. "
-        "Environment is PixelArch: package installs must use `yay -Syu` only; "
-        "never `pacman`; never plain `yay -S`."
+        "from the repository root (do NOT add cd commands). The script must only "
+        "prepare/setup the agent container so it is ready for use; do not perform "
+        "repository setup. Environment is PixelArch: package installs must use "
+        "`yay -Syu` only; never `pacman`; never plain `yay -S`."
     )
 
 

--- a/agents_runner/tests/test_docker_e2e.py
+++ b/agents_runner/tests/test_docker_e2e.py
@@ -22,6 +22,7 @@ import os
 import subprocess
 import tempfile
 import time
+import uuid
 from dataclasses import replace
 from threading import Event
 from typing import Any
@@ -77,7 +78,7 @@ def cleanup_test_containers():
                 ["ps", "-a", "--filter", "name=agents-runner-", "--format", "{{.ID}}"],
                 timeout_s=10.0,
             )
-            container_ids = result.stdout.strip().split("\n")
+            container_ids = str(result).strip().split("\n")
             container_ids = [cid.strip() for cid in container_ids if cid.strip()]
 
             # Remove each container
@@ -132,7 +133,7 @@ def test_config(temp_state_dir, request):
     # Truncate test name to stay under Docker's 63-char limit
     # Format: agents-runner-test-{test_name}-{short_uuid}
     test_name = request.node.name[:20]  # Max 20 chars for test name
-    short_uuid = f"{int(time.time() * 1000) % 1000000:06d}"  # 6-digit time-based ID
+    short_uuid = uuid.uuid4().hex[:6]
     container_name = f"agents-runner-test-{test_name}-{short_uuid}"
 
     container_id = None
@@ -160,7 +161,7 @@ def test_config(temp_state_dir, request):
                     inspect_state(container_id)
                     # Container still exists, wait
                     time.sleep(1)
-                except subprocess.CalledProcessError:
+                except Exception:
                     # Container removed successfully
                     break
 
@@ -212,10 +213,16 @@ def test_task_lifecycle_completes_successfully(test_config):
     # Modify config to use a more robust command that avoids Docker stream race conditions
     # Add 20s sleep before echo to ensure container has time to start and report state
     # Use absolute path /bin/sh to avoid PATH resolution issues in PixelArch
+    # Force git --global to use a writable path in CI while preserving strict failure behavior.
     config = replace(
         config,
         agent_cli="/bin/sh",
         agent_cli_args=["-c", "sleep 20 && echo 'test output' && exit 0"],
+        env_vars={
+            **dict(config.env_vars or {}),
+            "HOME": "/tmp",
+            "GIT_CONFIG_GLOBAL": f"/tmp/agents-runner-{task_id}.gitconfig",
+        },
     )
 
     # Task tracking
@@ -270,7 +277,12 @@ def test_task_lifecycle_completes_successfully(test_config):
     assert done_called.wait(timeout=30), "Task did not complete in time"
 
     # Verify final state
-    assert final_exit_code == 0, f"Expected exit code 0, got {final_exit_code}"
+    recent_logs = "\n".join(logs_received[-20:])
+    assert final_exit_code == 0, (
+        f"Expected exit code 0, got {final_exit_code}; "
+        f"error={final_error}; container_id={worker.container_id}\n"
+        f"Recent logs:\n{recent_logs}"
+    )
     assert final_error is None, f"Unexpected error: {final_error}"
 
     # Verify state transitions were recorded

--- a/agents_runner/ui/graphics.py
+++ b/agents_runner/ui/graphics.py
@@ -18,6 +18,7 @@ from PySide6.QtWidgets import QWidget
 from agents_runner.ui.themes.types import ThemeBackground
 
 _BACKGROUND_CACHE: dict[str, ThemeBackground | None] = {}
+_THEME_TRANSITION_DURATION_MS = 4000
 
 
 def load_background(theme_name: str) -> ThemeBackground | None:
@@ -245,6 +246,9 @@ class GlassRoot(QWidget):
         theme_name = resolve_theme_name(theme_name)
         if theme_name == self._theme_name:
             return
+        # Keep in-flight blend progress when the same target is requested repeatedly.
+        if theme_name == self._theme_to_name:
+            return
 
         self._ensure_theme_runtime(theme_name)
         background = load_background(theme_name)
@@ -264,7 +268,7 @@ class GlassRoot(QWidget):
             self._theme_anim.stop()
 
         anim = QPropertyAnimation(self, b"themeBlend", self)
-        anim.setDuration(7000)
+        anim.setDuration(_THEME_TRANSITION_DURATION_MS)
         anim.setStartValue(0.0)
         anim.setEndValue(1.0)
         anim.setEasingCurve(QEasingCurve.Type.InOutCubic)

--- a/agents_runner/ui/pages/environments_actions.py
+++ b/agents_runner/ui/pages/environments_actions.py
@@ -216,6 +216,11 @@ class EnvironmentsPageActionsMixin:
             self._agentsnova_trusted_users_env.get_usernames()
         )
 
+        self._env_vars_tab.flush_widget_state()
+        self._mounts_tab.flush_widget_state()
+        self._ports_tab.flush_widget_state()
+        self._agents_tab.flush_widget_state()
+
         env_vars, errors = self._env_vars_tab.get_env_vars()
         if errors:
             if show_validation_errors:

--- a/agents_runner/ui/pages/environments_agents.py
+++ b/agents_runner/ui/pages/environments_agents.py
@@ -619,6 +619,45 @@ class AgentsTabWidget(QWidget):
                     combo.setCurrentIndex(idx)
             combo.blockSignals(False)
 
+    def flush_widget_state(self) -> None:
+        for row_index in range(len(self._rows)):
+            inst = self._rows[row_index]
+
+            id_widget = self._agent_table.cellWidget(row_index, self._COL_ID)
+            if isinstance(id_widget, QLineEdit):
+                sanitized = self._sanitize_agent_id(id_widget.text())
+                if sanitized and _ID_RE.match(sanitized):
+                    inst = AgentInstance(
+                        agent_id=sanitized,
+                        agent_cli=inst.agent_cli,
+                        config_dir=inst.config_dir,
+                        cli_flags=inst.cli_flags,
+                    )
+
+            config_widget = self._agent_table.cellWidget(row_index, self._COL_CONFIG)
+            if isinstance(config_widget, QWidget):
+                line_edit = config_widget.findChild(QLineEdit)
+                if isinstance(line_edit, QLineEdit):
+                    inst = AgentInstance(
+                        agent_id=inst.agent_id,
+                        agent_cli=inst.agent_cli,
+                        config_dir=os.path.expanduser(
+                            str(line_edit.text() or "").strip()
+                        ),
+                        cli_flags=inst.cli_flags,
+                    )
+
+            flags_widget = self._agent_table.cellWidget(row_index, self._COL_CLI_FLAGS)
+            if isinstance(flags_widget, QLineEdit):
+                inst = AgentInstance(
+                    agent_id=inst.agent_id,
+                    agent_cli=inst.agent_cli,
+                    config_dir=inst.config_dir,
+                    cli_flags=str(flags_widget.text() or "").strip(),
+                )
+
+            self._rows[row_index] = inst
+
     def set_agent_selection(self, agent_selection: AgentSelection | None) -> None:
         self._selection_mode.blockSignals(True)
         try:

--- a/agents_runner/ui/pages/environments_env_vars.py
+++ b/agents_runner/ui/pages/environments_env_vars.py
@@ -169,6 +169,17 @@ class EnvVarsTabWidget(QWidget):
             parsed[key] = value
         return parsed, errors
 
+    def flush_widget_state(self) -> None:
+        if self._advanced_mode:
+            return
+        for row_index in range(len(self._rows)):
+            key_widget = self._table.cellWidget(row_index, self._COL_KEY)
+            value_widget = self._table.cellWidget(row_index, self._COL_VALUE)
+            if isinstance(key_widget, QLineEdit):
+                self._rows[row_index].key = str(key_widget.text() or "").strip()
+            if isinstance(value_widget, QLineEdit):
+                self._rows[row_index].value = str(value_widget.text() or "")
+
     def is_advanced_mode(self) -> bool:
         return bool(self._advanced_mode)
 

--- a/agents_runner/ui/pages/environments_mounts.py
+++ b/agents_runner/ui/pages/environments_mounts.py
@@ -219,6 +219,25 @@ class MountsTabWidget(QWidget):
             mounts.append(f"{host_path}:{container_path}:{mode}")
         return mounts, errors
 
+    def flush_widget_state(self) -> None:
+        if self._advanced_mode:
+            return
+        for row_index in range(len(self._rows)):
+            host_widget = self._table.cellWidget(row_index, self._COL_HOST_PATH)
+            container_widget = self._table.cellWidget(
+                row_index, self._COL_CONTAINER_PATH
+            )
+            mode_widget = self._table.cellWidget(row_index, self._COL_MODE)
+            if isinstance(host_widget, QLineEdit):
+                self._rows[row_index].host_path = str(host_widget.text() or "")
+            if isinstance(container_widget, QLineEdit):
+                self._rows[row_index].container_path = str(
+                    container_widget.text() or ""
+                )
+            if isinstance(mode_widget, QComboBox):
+                mode = str(mode_widget.currentData() or "rw").strip().lower() or "rw"
+                self._rows[row_index].mode = mode
+
     def is_advanced_mode(self) -> bool:
         return bool(self._advanced_mode)
 

--- a/agents_runner/ui/pages/environments_ports.py
+++ b/agents_runner/ui/pages/environments_ports.py
@@ -372,8 +372,8 @@ class PortsTabWidget(QWidget):
             host.setPlaceholderText("random")
             host.setText(str(row.host_port or ""))
             host.setValidator(validator)
-            host.editingFinished.connect(
-                lambda r=row_index, w=host: self._commit_host_port(r, w)
+            host.textChanged.connect(
+                lambda text, r=row_index: self._on_host_port_changed(r, text)
             )
             self._table.setCellWidget(row_index, self._COL_HOST, host)
 
@@ -381,8 +381,8 @@ class PortsTabWidget(QWidget):
             container.setPlaceholderText("container")
             container.setText(str(row.container_port or ""))
             container.setValidator(validator)
-            container.editingFinished.connect(
-                lambda r=row_index, w=container: self._commit_container_port(r, w)
+            container.textChanged.connect(
+                lambda text, r=row_index: self._on_container_port_changed(r, text)
             )
             self._table.setCellWidget(row_index, self._COL_CONTAINER, container)
 
@@ -394,16 +394,29 @@ class PortsTabWidget(QWidget):
             remove_btn.clicked.connect(lambda r=row_index: self._remove_row(r))
             self._table.setCellWidget(row_index, self._COL_REMOVE, remove_btn)
 
-    def _commit_host_port(self, row_index: int, widget: QLineEdit) -> None:
+    def flush_widget_state(self) -> None:
+        if self._unlocked:
+            return
+        for row_index in range(len(self._rows)):
+            host_widget = self._table.cellWidget(row_index, self._COL_HOST)
+            container_widget = self._table.cellWidget(row_index, self._COL_CONTAINER)
+            if isinstance(host_widget, QLineEdit):
+                self._rows[row_index].host_port = str(host_widget.text() or "").strip()
+            if isinstance(container_widget, QLineEdit):
+                self._rows[row_index].container_port = str(
+                    container_widget.text() or ""
+                ).strip()
+
+    def _on_host_port_changed(self, row_index: int, text: str) -> None:
         if row_index < 0 or row_index >= len(self._rows):
             return
-        self._rows[row_index].host_port = str(widget.text() or "").strip()
+        self._rows[row_index].host_port = str(text or "").strip()
         self.ports_changed.emit()
 
-    def _commit_container_port(self, row_index: int, widget: QLineEdit) -> None:
+    def _on_container_port_changed(self, row_index: int, text: str) -> None:
         if row_index < 0 or row_index >= len(self._rows):
             return
-        self._rows[row_index].container_port = str(widget.text() or "").strip()
+        self._rows[row_index].container_port = str(text or "").strip()
         self.ports_changed.emit()
 
     def _remove_row(self, row_index: int) -> None:


### PR DESCRIPTION
This pull request introduces improvements to the agent container setup documentation and enhances the reliability of the environment configuration UI in the agents runner. The most significant changes are the addition of a comprehensive setup guide for agent containers, updates to user guidance, and the implementation of new methods to ensure that UI state is consistently flushed from widgets to data models before actions like autosave.

**Documentation and Guidance Improvements:**

* Added a detailed `.agents/docs/setup-agents.md` guide explaining the purpose, location, usage, and best practices for the `setup-agents.sh` script, including anti-patterns and an example. This helps users correctly prepare the PixelArch Emerald container for their repositories.
* Updated the main `README.md` to reference the new setup guide for container configuration instructions.
* Clarified the missing setup script message in `setup_agents.py`, explicitly instructing users not to add `cd` commands, and reinforcing best practices for package installation.

**UI and Data Consistency Enhancements:**

* Implemented `flush_widget_state()` methods in the environment configuration tabs (`env_vars`, `mounts`, `ports`, `agents`) to ensure that the latest UI changes are always written back to the underlying data structures before operations like autosave. This prevents data loss from unsaved widget edits. [[1]](diffhunk://#diff-747de012e9cd05e4aaf627340b856c649159213b8cbda387d1c0d04bd191d650R172-R182) [[2]](diffhunk://#diff-468750ce1152de4d1c3d0acc2c4ed37f0ab05039404328b020c550c0e02071f5R222-R240) [[3]](diffhunk://#diff-5e2b558f99901b8fb2a150f72377e67f0d565bbc55856cabf66956e51f1b266dL397-R419) [[4]](diffhunk://#diff-407658aa0e8b8cb6de2f6a5df757452aaed492aac47391d8b83f326faf349394R622-R660)
* Modified the autosave logic in `environments_actions.py` to call these new `flush_widget_state()` methods, ensuring all user input is captured reliably.
* Updated the ports table UI to use real-time flushing of port values via `textChanged` signals, replacing the previous `editingFinished` approach for better responsiveness and data accuracy. [[1]](diffhunk://#diff-5e2b558f99901b8fb2a150f72377e67f0d565bbc55856cabf66956e51f1b266dL375-R385) [[2]](diffhunk://#diff-5e2b558f99901b8fb2a150f72377e67f0d565bbc55856cabf66956e51f1b266dL397-R419)