### PR TITLE
[TEST] Stabilize Docker E2E lifecycle CI behavior

### DIFF
--- a/agents_runner/tests/test_docker_e2e.py
+++ b/agents_runner/tests/test_docker_e2e.py
@@ -22,6 +22,7 @@ import os
 import subprocess
 import tempfile
 import time
+import uuid
 from dataclasses import replace
 from threading import Event
 from typing import Any
@@ -77,7 +78,7 @@ def cleanup_test_containers():
                 ["ps", "-a", "--filter", "name=agents-runner-", "--format", "{{.ID}}"],
                 timeout_s=10.0,
             )
-            container_ids = result.stdout.strip().split("\n")
+            container_ids = str(result).strip().split("\n")
             container_ids = [cid.strip() for cid in container_ids if cid.strip()]
 
             # Remove each container
@@ -132,7 +133,7 @@ def test_config(temp_state_dir, request):
     # Truncate test name to stay under Docker's 63-char limit
     # Format: agents-runner-test-{test_name}-{short_uuid}
     test_name = request.node.name[:20]  # Max 20 chars for test name
-    short_uuid = f"{int(time.time() * 1000) % 1000000:06d}"  # 6-digit time-based ID
+    short_uuid = uuid.uuid4().hex[:6]
     container_name = f"agents-runner-test-{test_name}-{short_uuid}"
 
     container_id = None
@@ -160,7 +161,7 @@ def test_config(temp_state_dir, request):
                     inspect_state(container_id)
                     # Container still exists, wait
                     time.sleep(1)
-                except subprocess.CalledProcessError:
+                except Exception:
                     # Container removed successfully
                     break
 
@@ -212,10 +213,16 @@ def test_task_lifecycle_completes_successfully(test_config):
     # Modify config to use a more robust command that avoids Docker stream race conditions
     # Add 20s sleep before echo to ensure container has time to start and report state
     # Use absolute path /bin/sh to avoid PATH resolution issues in PixelArch
+    # Force git --global to use a writable path in CI while preserving strict failure behavior.
     config = replace(
         config,
         agent_cli="/bin/sh",
         agent_cli_args=["-c", "sleep 20 && echo 'test output' && exit 0"],
+        env_vars={
+            **dict(config.env_vars or {}),
+            "HOME": "/tmp",
+            "GIT_CONFIG_GLOBAL": f"/tmp/agents-runner-{task_id}.gitconfig",
+        },
     )
 
     # Task tracking
@@ -270,7 +277,12 @@ def test_task_lifecycle_completes_successfully(test_config):
     assert done_called.wait(timeout=30), "Task did not complete in time"
 
     # Verify final state
-    assert final_exit_code == 0, f"Expected exit code 0, got {final_exit_code}"
+    recent_logs = "\n".join(logs_received[-20:])
+    assert final_exit_code == 0, (
+        f"Expected exit code 0, got {final_exit_code}; "
+        f"error={final_error}; container_id={worker.container_id}\n"
+        f"Recent logs:\n{recent_logs}"
+    )
     assert final_error is None, f"Unexpected error: {final_error}"
 
     # Verify state transitions were recorded


### PR DESCRIPTION
## Summary
- Stabilize `test_task_lifecycle_completes_successfully` without changing runtime strictness.
- Ensure test container cleanup parses `run_docker` return values correctly.
- Improve per-test container name uniqueness to reduce collision risk.
- Configure test env with writable git global config path (`HOME=/tmp`, `GIT_CONFIG_GLOBAL=...`) so strict git identity setup remains enforced but deterministic in CI.
- Expand failure assertion output with recent logs and container context for faster triage.

## Validation
- `uv run ruff check agents_runner/tests/test_docker_e2e.py`
- `PYTHONOPTIMIZE= uv run pytest -q --maxfail=1`
- `uv sync --group ci && PYTHONOPTIMIZE= uv run pytest -q --maxfail=1`

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
