### PR TITLE
Add OpenCode Web launch mode

### DIFF
--- a/agents_runner/environments/__init__.py
+++ b/agents_runner/environments/__init__.py
@@ -9,11 +9,16 @@ from agents_runner.environments.model import WORKSPACE_NONE
 from agents_runner.environments.model import GPU_OVERRIDE_MODE_DISABLED
 from agents_runner.environments.model import GPU_OVERRIDE_MODE_ENABLED
 from agents_runner.environments.model import GPU_OVERRIDE_MODE_INHERIT
+from agents_runner.environments.model import OPENCODE_INTERACTIVE_MODE_TERMINAL
+from agents_runner.environments.model import OPENCODE_INTERACTIVE_MODE_WEB
+from agents_runner.environments.model import OPENCODE_INTERACTIVE_OVERRIDE_INHERIT
 from agents_runner.environments.model import Environment
 from agents_runner.environments.github_repo import GitHubRepoContext
 from agents_runner.environments.github_repo import resolve_environment_github_repo
 from agents_runner.environments.model import PromptConfig
 from agents_runner.environments.model import normalize_gpu_override_mode
+from agents_runner.environments.model import normalize_opencode_interactive_mode
+from agents_runner.environments.model import normalize_opencode_interactive_override
 from agents_runner.environments.model import normalize_workspace_type
 from agents_runner.environments.parse import parse_env_vars_text
 from agents_runner.environments.parse import parse_mounts_text
@@ -37,6 +42,9 @@ __all__ = [
     "GPU_OVERRIDE_MODE_DISABLED",
     "GPU_OVERRIDE_MODE_ENABLED",
     "GPU_OVERRIDE_MODE_INHERIT",
+    "OPENCODE_INTERACTIVE_MODE_TERMINAL",
+    "OPENCODE_INTERACTIVE_MODE_WEB",
+    "OPENCODE_INTERACTIVE_OVERRIDE_INHERIT",
     "Environment",
     "GitHubRepoContext",
     "PromptConfig",
@@ -47,6 +55,8 @@ __all__ = [
     "managed_repo_checkout_path",
     "managed_repos_dir",
     "normalize_gpu_override_mode",
+    "normalize_opencode_interactive_mode",
+    "normalize_opencode_interactive_override",
     "normalize_workspace_type",
     "parse_env_vars_text",
     "parse_mounts_text",

--- a/agents_runner/environments/model.py
+++ b/agents_runner/environments/model.py
@@ -90,6 +90,19 @@ GPU_OVERRIDE_MODES = (
     GPU_OVERRIDE_MODE_DISABLED,
 )
 
+OPENCODE_INTERACTIVE_MODE_TERMINAL = "terminal"
+OPENCODE_INTERACTIVE_MODE_WEB = "web"
+OPENCODE_INTERACTIVE_MODES = (
+    OPENCODE_INTERACTIVE_MODE_TERMINAL,
+    OPENCODE_INTERACTIVE_MODE_WEB,
+)
+OPENCODE_INTERACTIVE_OVERRIDE_INHERIT = "inherit"
+OPENCODE_INTERACTIVE_OVERRIDE_MODES = (
+    OPENCODE_INTERACTIVE_OVERRIDE_INHERIT,
+    OPENCODE_INTERACTIVE_MODE_TERMINAL,
+    OPENCODE_INTERACTIVE_MODE_WEB,
+)
+
 
 def normalize_workspace_type(value: str) -> str:
     """Normalize workspace type to canonical values."""
@@ -156,6 +169,22 @@ def normalize_gpu_override_mode(value: str) -> str:
     return GPU_OVERRIDE_MODE_INHERIT
 
 
+def normalize_opencode_interactive_mode(value: str) -> str:
+    """Normalize global OpenCode interactive launch mode values."""
+    normalized = str(value or "").strip().lower()
+    if normalized in OPENCODE_INTERACTIVE_MODES:
+        return normalized
+    return OPENCODE_INTERACTIVE_MODE_TERMINAL
+
+
+def normalize_opencode_interactive_override(value: str) -> str:
+    """Normalize environment-level OpenCode interactive launch mode overrides."""
+    normalized = str(value or "").strip().lower()
+    if normalized in OPENCODE_INTERACTIVE_OVERRIDE_MODES:
+        return normalized
+    return OPENCODE_INTERACTIVE_OVERRIDE_INHERIT
+
+
 @dataclass
 class PromptConfig:
     enabled: bool = False
@@ -195,6 +224,7 @@ class Environment:
     max_agents_running: int = -1
     headless_desktop_enabled: bool = False
     gpu_override_mode: str = GPU_OVERRIDE_MODE_INHERIT
+    opencode_interactive_mode: str = OPENCODE_INTERACTIVE_OVERRIDE_INHERIT
     cache_desktop_build: bool = False
     container_caching_enabled: bool = False
     cache_system_preflight_enabled: bool = False

--- a/agents_runner/environments/serialize.py
+++ b/agents_runner/environments/serialize.py
@@ -14,6 +14,7 @@ from .model import normalize_agentsnova_marker_comment_mode
 from .model import normalize_gh_branch_work_mode
 from .model import normalize_gh_task_branch_custom_template
 from .model import normalize_gh_task_branch_naming_style
+from .model import normalize_opencode_interactive_override
 from .model import PromptConfig
 from .model import AgentSelection
 from .model import AgentInstance
@@ -210,6 +211,9 @@ def environment_from_payload(payload: dict[str, Any]) -> Environment | None:
     headless_desktop_enabled = bool(payload.get("headless_desktop_enabled", False))
     gpu_override_mode = normalize_gpu_override_mode(
         payload.get("gpu_override_mode", "inherit")
+    )
+    opencode_interactive_mode = normalize_opencode_interactive_override(
+        payload.get("opencode_interactive_mode", "inherit")
     )
     cache_desktop_build = bool(payload.get("cache_desktop_build", False))
     container_caching_enabled = bool(payload.get("container_caching_enabled", False))
@@ -465,6 +469,7 @@ def environment_from_payload(payload: dict[str, Any]) -> Environment | None:
         max_agents_running=max_agents_running,
         headless_desktop_enabled=headless_desktop_enabled,
         gpu_override_mode=gpu_override_mode,
+        opencode_interactive_mode=opencode_interactive_mode,
         cache_desktop_build=cache_desktop_build,
         container_caching_enabled=container_caching_enabled,
         cache_system_preflight_enabled=cache_system_preflight_enabled,
@@ -554,6 +559,9 @@ def serialize_environment(env: Environment) -> dict[str, Any]:
         ),
         "gpu_override_mode": normalize_gpu_override_mode(
             str(getattr(env, "gpu_override_mode", "inherit") or "inherit")
+        ),
+        "opencode_interactive_mode": normalize_opencode_interactive_override(
+            str(getattr(env, "opencode_interactive_mode", "inherit") or "inherit")
         ),
         "cache_desktop_build": bool(getattr(env, "cache_desktop_build", False)),
         "container_caching_enabled": bool(

--- a/agents_runner/persistence.py
+++ b/agents_runner/persistence.py
@@ -347,6 +347,7 @@ def serialize_task(task: Any) -> dict[str, Any]:
             getattr(task, "headless_desktop_enabled", False)
         ),
         "novnc_url": getattr(task, "novnc_url", ""),
+        "opencode_web_url": getattr(task, "opencode_web_url", ""),
         "artifacts": list(getattr(task, "artifacts", [])),
         "attempt_history": list(getattr(task, "attempt_history", [])),
         "finalization_state": str(
@@ -411,6 +412,7 @@ def deserialize_task(task_cls: type, data: dict[str, Any]) -> Any:
         ide_display_target=str(data.get("ide_display_target") or ""),
         headless_desktop_enabled=bool(data.get("headless_desktop_enabled") or False),
         novnc_url=str(data.get("novnc_url") or ""),
+        opencode_web_url=str(data.get("opencode_web_url") or ""),
         vnc_password="",
         artifacts=list(data.get("artifacts") or []),
         attempt_history=list(data.get("attempt_history") or []),

--- a/agents_runner/persistence.py
+++ b/agents_runner/persistence.py
@@ -347,7 +347,6 @@ def serialize_task(task: Any) -> dict[str, Any]:
             getattr(task, "headless_desktop_enabled", False)
         ),
         "novnc_url": getattr(task, "novnc_url", ""),
-        "desktop_display": getattr(task, "desktop_display", ""),
         "artifacts": list(getattr(task, "artifacts", [])),
         "attempt_history": list(getattr(task, "attempt_history", [])),
         "finalization_state": str(
@@ -413,7 +412,6 @@ def deserialize_task(task_cls: type, data: dict[str, Any]) -> Any:
         headless_desktop_enabled=bool(data.get("headless_desktop_enabled") or False),
         novnc_url=str(data.get("novnc_url") or ""),
         vnc_password="",
-        desktop_display=str(data.get("desktop_display") or ""),
         artifacts=list(data.get("artifacts") or []),
         attempt_history=list(data.get("attempt_history") or []),
         finalization_state=str(data.get("finalization_state") or "pending"),

--- a/agents_runner/ui/main_window.py
+++ b/agents_runner/ui/main_window.py
@@ -95,6 +95,7 @@ class MainWindow(
             "host_workdir": os.environ.get("CODEX_HOST_WORKDIR", os.getcwd()),
             "active_environment_id": "default",
             "interactive_terminal_id": "",
+            "opencode_interactive_mode": "terminal",
             "window_w": 1280,
             "window_h": 720,
             "max_agents_running": -1,

--- a/agents_runner/ui/main_window_persistence.py
+++ b/agents_runner/ui/main_window_persistence.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from agents_runner.agent_cli import normalize_agent
+from agents_runner.environments import normalize_opencode_interactive_mode
 from agents_runner.log_format import prettify_log_line
 from agents_runner.log_stream import normalize_log_stream_chunk
 from agents_runner.persistence import deserialize_task
@@ -163,6 +164,7 @@ class MainWindowPersistenceMixin:
             self._settings_data.pop(key, None)
         self._settings_data.setdefault("headless_desktop_enabled", False)
         self._settings_data.setdefault("gpu_enabled", False)
+        self._settings_data.setdefault("opencode_interactive_mode", "terminal")
         self._settings_data.setdefault("auto_navigate_on_run_agent_start", False)
         self._settings_data.setdefault("auto_navigate_on_run_interactive_start", False)
         self._settings_data.setdefault("spellcheck_enabled", True)
@@ -196,6 +198,11 @@ class MainWindowPersistenceMixin:
         self._settings_data.setdefault("agentsnova_review_guard_mode", "reaction")
         self._settings_data["gpu_enabled"] = bool(
             self._settings_data.get("gpu_enabled") or False
+        )
+        self._settings_data["opencode_interactive_mode"] = (
+            normalize_opencode_interactive_mode(
+                str(self._settings_data.get("opencode_interactive_mode") or "terminal")
+            )
         )
         try:
             from agents_runner.ui.graphics import normalize_ui_theme_name

--- a/agents_runner/ui/main_window_settings.py
+++ b/agents_runner/ui/main_window_settings.py
@@ -18,6 +18,8 @@ from agents_runner.ui.radio import RadioController
 from agents_runner.ui.utils import looks_like_agent_help_command
 from agents_runner.environments import Environment
 from agents_runner.environments.model import normalize_gpu_override_mode
+from agents_runner.environments.model import normalize_opencode_interactive_mode
+from agents_runner.environments.model import normalize_opencode_interactive_override
 from agents_runner.gh.automation_policy import normalize_default_marker_comment_mode
 
 logger = logging.getLogger(__name__)
@@ -147,6 +149,9 @@ class MainWindowSettingsMixin:
             merged.get("headless_desktop_enabled") or False
         )
         merged["gpu_enabled"] = bool(merged.get("gpu_enabled") or False)
+        merged["opencode_interactive_mode"] = normalize_opencode_interactive_mode(
+            str(merged.get("opencode_interactive_mode") or "terminal")
+        )
         merged["popup_theme_animation_enabled"] = bool(
             merged.get("popup_theme_animation_enabled", True)
         )
@@ -519,6 +524,25 @@ class MainWindowSettingsMixin:
         if mode == "disabled":
             return False
         return global_enabled
+
+    def _effective_opencode_interactive_mode(
+        self,
+        *,
+        env: Environment | None,
+        settings: dict[str, object] | None = None,
+    ) -> str:
+        settings_data = settings or self._settings_data
+        global_mode = normalize_opencode_interactive_mode(
+            str(settings_data.get("opencode_interactive_mode") or "terminal")
+        )
+        if env is None:
+            return global_mode
+        override = normalize_opencode_interactive_override(
+            str(getattr(env, "opencode_interactive_mode", "inherit") or "inherit")
+        )
+        if override == "inherit":
+            return global_mode
+        return override
 
     def _resolve_override_config_dir(
         self,

--- a/agents_runner/ui/main_window_task_events.py
+++ b/agents_runner/ui/main_window_task_events.py
@@ -718,9 +718,6 @@ class MainWindowTaskEventsMixin:
         novnc_url = str(state.get("NoVncUrl") or "").strip()
         if novnc_url:
             task.novnc_url = novnc_url
-        desktop_display = str(state.get("DesktopDisplay") or "").strip()
-        if desktop_display:
-            task.desktop_display = desktop_display
 
         if current not in {"done", "failed"}:
             if incoming in {"exited", "dead"} and task.exit_code is not None:

--- a/agents_runner/ui/main_window_tasks_interactive.py
+++ b/agents_runner/ui/main_window_tasks_interactive.py
@@ -245,6 +245,19 @@ class MainWindowTasksInteractiveMixin:
                 return
 
         command = self._default_interactive_command(agent_cli)
+        opencode_web_mode = bool(
+            not shell_mode
+            and str(agent_cli or "").strip().lower() == "opencode"
+            and self._effective_opencode_interactive_mode(
+                env=env,
+                settings=self._settings_data,
+            )
+            == "web"
+        )
+        if opencode_web_mode:
+            command = "opencode web --port 4096 --hostname 0.0.0.0"
+            agent_cli_args = []
+
         extra_preflight_script = str(extra_preflight_script or "")
         is_help_launch = self._is_agent_help_interactive_launch(
             prompt=prompt, command=command
@@ -260,8 +273,10 @@ class MainWindowTasksInteractiveMixin:
                 ]
             ).strip()
 
-        apply_full_prompting = bool(has_typed_prompt and not is_help_launch)
-        prompt_for_agent = str(prompt or "")
+        apply_full_prompting = bool(
+            has_typed_prompt and not is_help_launch and not opencode_web_mode
+        )
+        prompt_for_agent = "" if opencode_web_mode else str(prompt or "")
         if apply_full_prompting:
             prompt_for_agent = self._build_interactive_base_prompt(
                 prompt=prompt_for_agent,
@@ -435,6 +450,7 @@ class MainWindowTasksInteractiveMixin:
             "prep_id": prep_id,
             "shell_mode": shell_mode,
             "shell": shell,
+            "opencode_web_mode": opencode_web_mode,
             "gpu_enabled": gpu_enabled,
             "ports_for_task": list(ports_for_task),
         }
@@ -725,6 +741,7 @@ class MainWindowTasksInteractiveMixin:
                 else None,
                 shell_mode=bool(context.get("shell_mode")),
                 shell=str(context.get("shell") or "bash"),
+                opencode_web_mode=bool(context.get("opencode_web_mode")),
                 gpu_enabled=bool(context.get("gpu_enabled") or False),
                 ports_for_task=list(context.get("ports_for_task") or []),
             )

--- a/agents_runner/ui/main_window_tasks_interactive.py
+++ b/agents_runner/ui/main_window_tasks_interactive.py
@@ -255,8 +255,9 @@ class MainWindowTasksInteractiveMixin:
             == "web"
         )
         if opencode_web_mode:
-            command = "opencode web --port 4096 --hostname 0.0.0.0"
+            command = "opencode web"
             agent_cli_args = []
+        launch_mode = "opencode_web" if opencode_web_mode else "interactive_agent"
 
         extra_preflight_script = str(extra_preflight_script or "")
         is_help_launch = self._is_agent_help_interactive_launch(
@@ -336,7 +337,7 @@ class MainWindowTasksInteractiveMixin:
             agent_cli=agent_cli,
             agent_instance_id=agent_instance_id,
             agent_cli_args=" ".join(agent_cli_args),
-            launch_mode="interactive_agent",
+            launch_mode=launch_mode,
         )
         self._tasks[task_id] = task
         stain = env.color if env else None
@@ -385,7 +386,7 @@ class MainWindowTasksInteractiveMixin:
             desktop_enabled=desktop_enabled,
             settings_preflight_script=settings_preflight_script,
             extra_preflight_script=extra_preflight_script,
-            launch_mode="interactive_agent",
+            launch_mode=launch_mode,
             container_caching_enabled=bool(
                 env and getattr(env, "container_caching_enabled", False)
             ),

--- a/agents_runner/ui/main_window_tasks_interactive_docker.py
+++ b/agents_runner/ui/main_window_tasks_interactive_docker.py
@@ -10,10 +10,14 @@ import os
 import shlex
 import socket
 import tempfile
+import webbrowser
 from datetime import datetime
 from datetime import timezone
 from pathlib import Path
 
+from PySide6.QtCore import QTimer
+from PySide6.QtCore import QUrl
+from PySide6.QtGui import QDesktopServices
 from PySide6.QtWidgets import QMessageBox
 
 from agents_runner.agent_install import probe_agent_executable_in_image
@@ -37,6 +41,11 @@ from agents_runner.core.shell_templates import git_identity_clause
 from agents_runner.core.shell_templates import shell_log_statement
 from agents_runner.ui.task_model import Task
 from agents_runner.ui.utils import safe_str
+
+_OPENCODE_WEB_CONTAINER_PORT = 4096
+_OPENCODE_WEB_HOST = "127.0.0.1"
+_OPENCODE_WEB_RETRY_INTERVAL_MS = 15_000
+_OPENCODE_WEB_TIMEOUT_MS = 10 * 60 * 1000
 
 
 def _publishes_container_port(spec: str, port: int) -> bool:
@@ -121,6 +130,7 @@ def launch_docker_terminal_task(
     desktop_preflight_script_override: str | None = None,
     shell_mode: bool = False,
     shell: str = "bash",
+    opencode_web_mode: bool = False,
     gpu_enabled: bool = False,
     ports_for_task: list[str] | None = None,
 ) -> None:
@@ -171,6 +181,7 @@ def launch_docker_terminal_task(
         desktop_preflight_script_override: Optional precomputed desktop script
         shell_mode: If True, run shell instead of agent command
         shell: Shell to use when shell_mode is True (bash, sh, zsh, fish, tmux)
+        opencode_web_mode: If True, run OpenCode Web and open its host URL
         gpu_enabled: If True, request Docker GPU runtime (`--gpus all`)
         ports_for_task: Runtime publish specs for this launch (defaults to env.ports)
     """
@@ -437,8 +448,28 @@ def launch_docker_terminal_task(
                     ["-e", f"GH_TOKEN={gh_token}", "-e", f"GITHUB_TOKEN={gh_token}"]
                 )
 
-        # Allocate port for desktop mode
+        # Allocate ports for managed local services.
         port_args: list[str] = []
+        opencode_web_url = ""
+        opencode_web_host_port = 0
+        if opencode_web_mode:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            try:
+                s.bind((_OPENCODE_WEB_HOST, 0))
+                opencode_web_host_port = int(s.getsockname()[1])
+            finally:
+                s.close()
+            port_args.extend(
+                [
+                    "-p",
+                    (
+                        f"{_OPENCODE_WEB_HOST}:{opencode_web_host_port}:"
+                        f"{_OPENCODE_WEB_CONTAINER_PORT}"
+                    ),
+                ]
+            )
+            opencode_web_url = f"http://{_OPENCODE_WEB_HOST}:{opencode_web_host_port}"
+
         if desktop_enabled:
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             try:
@@ -449,7 +480,6 @@ def launch_docker_terminal_task(
             port_args = ["-p", f"127.0.0.1:{host_port}:6080"]
             env_args.extend(["-e", f"AGENTS_RUNNER_TASK_ID={task_token}"])
             task.headless_desktop_enabled = True
-            task.desktop_display = ":1"
             task.novnc_url = f"http://127.0.0.1:{host_port}/vnc.html"
             main_window._dashboard.upsert_task(task, stain=stain, spinner_color=spinner)
             main_window._details.update_task(task)
@@ -466,6 +496,10 @@ def launch_docker_terminal_task(
             if not spec:
                 continue
             if desktop_enabled and _publishes_container_port(spec, 6080):
+                continue
+            if opencode_web_mode and _publishes_container_port(
+                spec, _OPENCODE_WEB_CONTAINER_PORT
+            ):
                 continue
             port_args.extend(["-p", spec])
 
@@ -509,6 +543,11 @@ def launch_docker_terminal_task(
             else:
                 target_cmd = f"/bin/{shell}"
             verify_clause = ""
+        elif opencode_web_mode:
+            target_cmd = (
+                f"opencode web --port {_OPENCODE_WEB_CONTAINER_PORT} --hostname 0.0.0.0"
+            )
+            verify_clause = verify_cli_clause("opencode")
         else:
             target_cmd = " ".join(shlex.quote(part) for part in cmd_parts)
             verify_clause = ""
@@ -646,9 +685,21 @@ def launch_docker_terminal_task(
                 f"launched in {safe_str(getattr(terminal_opt, 'label', 'Terminal'))}",
             ),
         )
+        if opencode_web_url:
+            main_window._on_task_log(
+                task_id,
+                format_log("opencode", "web", "INFO", f"web url: {opencode_web_url}"),
+            )
 
         # Launch terminal
         launch_in_terminal(terminal_opt, host_script, cwd=host_workdir)
+        if opencode_web_url and opencode_web_host_port:
+            _schedule_open_opencode_web_url(
+                main_window=main_window,
+                task_id=task_id,
+                url=opencode_web_url,
+                host_port=opencode_web_host_port,
+            )
         main_window._maybe_auto_navigate_on_task_start(interactive=True)
         main_window._new_task.reset_for_new_run()
 
@@ -1058,6 +1109,68 @@ def _build_host_shell_script(
     )
 
     return " ; ".join(host_script_parts)
+
+
+def _schedule_open_opencode_web_url(
+    *,
+    main_window: object,
+    task_id: str,
+    url: str,
+    host_port: int,
+) -> None:
+    state = {"done": False, "elapsed_ms": 0}
+
+    def _attempt_open() -> None:
+        if bool(state.get("done", False)):
+            return
+        if _can_connect_to_local_port(host_port):
+            state["done"] = True
+            _open_url_from_host(url)
+            main_window._on_task_log(
+                task_id,
+                format_log("opencode", "web", "INFO", f"opened browser: {url}"),
+            )
+            return
+
+        state["elapsed_ms"] = int(state.get("elapsed_ms", 0)) + int(
+            _OPENCODE_WEB_RETRY_INTERVAL_MS
+        )
+        if int(state.get("elapsed_ms", 0)) >= _OPENCODE_WEB_TIMEOUT_MS:
+            state["done"] = True
+            main_window._on_task_log(
+                task_id,
+                format_log(
+                    "opencode",
+                    "web",
+                    "WARN",
+                    "web server was not ready after 10 minutes; "
+                    f"stopped browser open retry: {url}",
+                ),
+            )
+            return
+
+        QTimer.singleShot(_OPENCODE_WEB_RETRY_INTERVAL_MS, _attempt_open)
+
+    QTimer.singleShot(_OPENCODE_WEB_RETRY_INTERVAL_MS, _attempt_open)
+
+
+def _can_connect_to_local_port(port: int) -> bool:
+    try:
+        with socket.create_connection((_OPENCODE_WEB_HOST, int(port)), timeout=0.25):
+            return True
+    except OSError:
+        return False
+
+
+def _open_url_from_host(url: str) -> None:
+    qurl = QUrl(str(url or "").strip())
+    opened = False
+    try:
+        opened = bool(QDesktopServices.openUrl(qurl))
+    except Exception:
+        opened = False
+    if not opened:
+        webbrowser.open(str(url or "").strip())
 
 
 def _cleanup_temp_files(tmp_paths: dict[str, str]) -> None:

--- a/agents_runner/ui/main_window_tasks_interactive_docker.py
+++ b/agents_runner/ui/main_window_tasks_interactive_docker.py
@@ -8,16 +8,11 @@ from __future__ import annotations
 
 import os
 import shlex
-import socket
 import tempfile
-import webbrowser
 from datetime import datetime
 from datetime import timezone
 from pathlib import Path
 
-from PySide6.QtCore import QTimer
-from PySide6.QtCore import QUrl
-from PySide6.QtGui import QDesktopServices
 from PySide6.QtWidgets import QMessageBox
 
 from agents_runner.agent_install import probe_agent_executable_in_image
@@ -39,33 +34,14 @@ from agents_runner.log_format import format_log
 from agents_runner.terminal_apps import launch_in_terminal
 from agents_runner.core.shell_templates import git_identity_clause
 from agents_runner.core.shell_templates import shell_log_statement
+from agents_runner.ui.opencode_web import OPENCODE_WEB_CONTAINER_PORT
+from agents_runner.ui.opencode_web import OPENCODE_WEB_HOST
+from agents_runner.ui.opencode_web import allocate_localhost_port
+from agents_runner.ui.opencode_web import publishes_container_port
+from agents_runner.ui.opencode_web import schedule_open_opencode_web_url
+from agents_runner.ui.opencode_web import select_opencode_web_container_port
 from agents_runner.ui.task_model import Task
 from agents_runner.ui.utils import safe_str
-
-_OPENCODE_WEB_CONTAINER_PORT = 4096
-_OPENCODE_WEB_HOST = "127.0.0.1"
-_OPENCODE_WEB_RETRY_INTERVAL_MS = 15_000
-_OPENCODE_WEB_TIMEOUT_MS = 10 * 60 * 1000
-
-
-def _publishes_container_port(spec: str, port: int) -> bool:
-    base = str(spec or "").strip()
-    if not base:
-        return False
-    base = base.split("/", 1)[0]
-    container_part = base.rsplit(":", 1)[-1].strip()
-    if not container_part:
-        return False
-    if container_part.isdigit():
-        return int(container_part) == int(port)
-    if "-" in container_part:
-        left, right = (p.strip() for p in container_part.split("-", 1))
-        if left.isdigit() and right.isdigit():
-            start = int(left)
-            end = int(right)
-            p = int(port)
-            return start <= p <= end
-    return False
 
 
 def _redact_env_assignment(value: str) -> str:
@@ -448,36 +424,53 @@ def launch_docker_terminal_task(
                     ["-e", f"GH_TOKEN={gh_token}", "-e", f"GITHUB_TOKEN={gh_token}"]
                 )
 
+        ports_source = (
+            list(ports_for_task or [])
+            if ports_for_task is not None
+            else list((getattr(env, "ports", None) or []) if env else [])
+        )
+
         # Allocate ports for managed local services.
         port_args: list[str] = []
         opencode_web_url = ""
         opencode_web_host_port = 0
+        opencode_web_container_port = OPENCODE_WEB_CONTAINER_PORT
         if opencode_web_mode:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            try:
-                s.bind((_OPENCODE_WEB_HOST, 0))
-                opencode_web_host_port = int(s.getsockname()[1])
-            finally:
-                s.close()
+            opencode_web_container_port = select_opencode_web_container_port(
+                ports_source
+            )
+            opencode_web_host_port = allocate_localhost_port()
             port_args.extend(
                 [
                     "-p",
                     (
-                        f"{_OPENCODE_WEB_HOST}:{opencode_web_host_port}:"
-                        f"{_OPENCODE_WEB_CONTAINER_PORT}"
+                        f"{OPENCODE_WEB_HOST}:{opencode_web_host_port}:"
+                        f"{opencode_web_container_port}"
                     ),
                 ]
             )
-            opencode_web_url = f"http://{_OPENCODE_WEB_HOST}:{opencode_web_host_port}"
+            opencode_web_url = f"http://{OPENCODE_WEB_HOST}:{opencode_web_host_port}"
+            task.opencode_web_url = opencode_web_url
+            main_window._on_task_log(
+                task_id,
+                format_log(
+                    "opencode",
+                    "web",
+                    "INFO",
+                    (
+                        "mapped web ui: "
+                        f"{OPENCODE_WEB_HOST}:{opencode_web_host_port} -> "
+                        f"container port {opencode_web_container_port}"
+                    ),
+                ),
+            )
+            main_window._dashboard.upsert_task(task, stain=stain, spinner_color=spinner)
+            main_window._details.update_task(task)
+            main_window._schedule_save()
 
         if desktop_enabled:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            try:
-                s.bind(("127.0.0.1", 0))
-                host_port = int(s.getsockname()[1])
-            finally:
-                s.close()
-            port_args = ["-p", f"127.0.0.1:{host_port}:6080"]
+            host_port = allocate_localhost_port()
+            port_args.extend(["-p", f"127.0.0.1:{host_port}:6080"])
             env_args.extend(["-e", f"AGENTS_RUNNER_TASK_ID={task_token}"])
             task.headless_desktop_enabled = True
             task.novnc_url = f"http://127.0.0.1:{host_port}/vnc.html"
@@ -486,19 +479,14 @@ def launch_docker_terminal_task(
             main_window._schedule_save()
 
         # Apply environment-specified ports (or task runtime overrides)
-        ports_source = (
-            list(ports_for_task or [])
-            if ports_for_task is not None
-            else list((getattr(env, "ports", None) or []) if env else [])
-        )
         for port_spec in ports_source:
             spec = str(port_spec or "").strip()
             if not spec:
                 continue
-            if desktop_enabled and _publishes_container_port(spec, 6080):
+            if desktop_enabled and publishes_container_port(spec, 6080):
                 continue
-            if opencode_web_mode and _publishes_container_port(
-                spec, _OPENCODE_WEB_CONTAINER_PORT
+            if opencode_web_mode and publishes_container_port(
+                spec, opencode_web_container_port
             ):
                 continue
             port_args.extend(["-p", spec])
@@ -545,7 +533,7 @@ def launch_docker_terminal_task(
             verify_clause = ""
         elif opencode_web_mode:
             target_cmd = (
-                f"opencode web --port {_OPENCODE_WEB_CONTAINER_PORT} --hostname 0.0.0.0"
+                f"opencode web --port {opencode_web_container_port} --hostname 0.0.0.0"
             )
             verify_clause = verify_cli_clause("opencode")
         else:
@@ -694,7 +682,7 @@ def launch_docker_terminal_task(
         # Launch terminal
         launch_in_terminal(terminal_opt, host_script, cwd=host_workdir)
         if opencode_web_url and opencode_web_host_port:
-            _schedule_open_opencode_web_url(
+            schedule_open_opencode_web_url(
                 main_window=main_window,
                 task_id=task_id,
                 url=opencode_web_url,
@@ -1109,68 +1097,6 @@ def _build_host_shell_script(
     )
 
     return " ; ".join(host_script_parts)
-
-
-def _schedule_open_opencode_web_url(
-    *,
-    main_window: object,
-    task_id: str,
-    url: str,
-    host_port: int,
-) -> None:
-    state = {"done": False, "elapsed_ms": 0}
-
-    def _attempt_open() -> None:
-        if bool(state.get("done", False)):
-            return
-        if _can_connect_to_local_port(host_port):
-            state["done"] = True
-            _open_url_from_host(url)
-            main_window._on_task_log(
-                task_id,
-                format_log("opencode", "web", "INFO", f"opened browser: {url}"),
-            )
-            return
-
-        state["elapsed_ms"] = int(state.get("elapsed_ms", 0)) + int(
-            _OPENCODE_WEB_RETRY_INTERVAL_MS
-        )
-        if int(state.get("elapsed_ms", 0)) >= _OPENCODE_WEB_TIMEOUT_MS:
-            state["done"] = True
-            main_window._on_task_log(
-                task_id,
-                format_log(
-                    "opencode",
-                    "web",
-                    "WARN",
-                    "web server was not ready after 10 minutes; "
-                    f"stopped browser open retry: {url}",
-                ),
-            )
-            return
-
-        QTimer.singleShot(_OPENCODE_WEB_RETRY_INTERVAL_MS, _attempt_open)
-
-    QTimer.singleShot(_OPENCODE_WEB_RETRY_INTERVAL_MS, _attempt_open)
-
-
-def _can_connect_to_local_port(port: int) -> bool:
-    try:
-        with socket.create_connection((_OPENCODE_WEB_HOST, int(port)), timeout=0.25):
-            return True
-    except OSError:
-        return False
-
-
-def _open_url_from_host(url: str) -> None:
-    qurl = QUrl(str(url or "").strip())
-    opened = False
-    try:
-        opened = bool(QDesktopServices.openUrl(qurl))
-    except Exception:
-        opened = False
-    if not opened:
-        webbrowser.open(str(url or "").strip())
 
 
 def _cleanup_temp_files(tmp_paths: dict[str, str]) -> None:

--- a/agents_runner/ui/opencode_web.py
+++ b/agents_runner/ui/opencode_web.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import random
 import socket
 import time
+import urllib.error
+import urllib.request
 
 from PySide6.QtCore import QTimer
 
@@ -13,8 +15,9 @@ OPENCODE_WEB_CONTAINER_PORT = 4096
 OPENCODE_WEB_ALT_CONTAINER_PORT_MIN = 20_000
 OPENCODE_WEB_ALT_CONTAINER_PORT_MAX = 60_999
 OPENCODE_WEB_HOST = "127.0.0.1"
-OPENCODE_WEB_RETRY_INTERVAL_MS = 15_000
+OPENCODE_WEB_RETRY_INTERVAL_MS = 500
 OPENCODE_WEB_TIMEOUT_MS = 10 * 60 * 1000
+OPENCODE_WEB_HTTP_TIMEOUT_S = 0.75
 
 
 def publishes_container_port(spec: str, port: int) -> bool:
@@ -74,12 +77,32 @@ def schedule_open_opencode_web_url(
 ) -> None:
     state = {"done": False}
     deadline_s = time.monotonic() + (OPENCODE_WEB_TIMEOUT_MS / 1000.0)
+    readiness_url = f"http://{OPENCODE_WEB_HOST}:{int(host_port)}/"
+    main_window._on_task_log(
+        task_id,
+        format_log(
+            "opencode",
+            "web",
+            "INFO",
+            f"waiting for HTTP readiness: {readiness_url}",
+        ),
+    )
 
     def _attempt_open() -> None:
         if bool(state.get("done", False)):
             return
-        if _can_connect_to_local_port(host_port):
+        status_code = _http_status_code(readiness_url)
+        if status_code is not None:
             state["done"] = True
+            main_window._on_task_log(
+                task_id,
+                format_log(
+                    "opencode",
+                    "web",
+                    "INFO",
+                    f"HTTP readiness returned {status_code}: {readiness_url}",
+                ),
+            )
             opened = open_external_url(url)
             log_level = "INFO" if opened else "WARN"
             log_message = (
@@ -101,7 +124,7 @@ def schedule_open_opencode_web_url(
                     "opencode",
                     "web",
                     "WARN",
-                    "web server was not ready after 10 minutes; "
+                    "web server never returned an HTTP status after 10 minutes; "
                     f"stopped browser open retry: {url}",
                 ),
             )
@@ -116,9 +139,23 @@ def _port_specs_publish_container_port(port_specs: list[str], port: int) -> bool
     return any(publishes_container_port(spec, port) for spec in port_specs)
 
 
-def _can_connect_to_local_port(port: int) -> bool:
+def _http_status_code(url: str) -> int | None:
+    request = urllib.request.Request(
+        str(url),
+        method="GET",
+        headers={"User-Agent": "agents-runner-opencode-readiness"},
+    )
     try:
-        with socket.create_connection((OPENCODE_WEB_HOST, int(port)), timeout=0.25):
-            return True
-    except OSError:
-        return False
+        with urllib.request.urlopen(  # noqa: S310
+            request,
+            timeout=OPENCODE_WEB_HTTP_TIMEOUT_S,
+        ) as response:
+            status = int(response.status)
+    except urllib.error.HTTPError as exc:
+        status = int(exc.code)
+    except (OSError, ValueError):
+        return None
+
+    if 100 <= status <= 599:
+        return status
+    return None

--- a/agents_runner/ui/opencode_web.py
+++ b/agents_runner/ui/opencode_web.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import random
+import socket
+import time
+
+from PySide6.QtCore import QTimer
+
+from agents_runner.log_format import format_log
+from agents_runner.ui.url_open import open_external_url
+
+OPENCODE_WEB_CONTAINER_PORT = 4096
+OPENCODE_WEB_ALT_CONTAINER_PORT_MIN = 20_000
+OPENCODE_WEB_ALT_CONTAINER_PORT_MAX = 60_999
+OPENCODE_WEB_HOST = "127.0.0.1"
+OPENCODE_WEB_RETRY_INTERVAL_MS = 15_000
+OPENCODE_WEB_TIMEOUT_MS = 10 * 60 * 1000
+
+
+def publishes_container_port(spec: str, port: int) -> bool:
+    base = str(spec or "").strip()
+    if not base:
+        return False
+    base = base.split("/", 1)[0]
+    container_part = base.rsplit(":", 1)[-1].strip()
+    if not container_part:
+        return False
+    if container_part.isdigit():
+        return int(container_part) == int(port)
+    if "-" in container_part:
+        left, right = (p.strip() for p in container_part.split("-", 1))
+        if left.isdigit() and right.isdigit():
+            start = int(left)
+            end = int(right)
+            p = int(port)
+            return start <= p <= end
+    return False
+
+
+def select_opencode_web_container_port(port_specs: list[str]) -> int:
+    if not _port_specs_publish_container_port(port_specs, OPENCODE_WEB_CONTAINER_PORT):
+        return OPENCODE_WEB_CONTAINER_PORT
+
+    for _ in range(128):
+        candidate = random.randint(
+            OPENCODE_WEB_ALT_CONTAINER_PORT_MIN,
+            OPENCODE_WEB_ALT_CONTAINER_PORT_MAX,
+        )
+        if not _port_specs_publish_container_port(port_specs, candidate):
+            return candidate
+
+    for candidate in range(
+        OPENCODE_WEB_ALT_CONTAINER_PORT_MIN,
+        OPENCODE_WEB_ALT_CONTAINER_PORT_MAX + 1,
+    ):
+        if not _port_specs_publish_container_port(port_specs, candidate):
+            return candidate
+
+    raise RuntimeError("Could not find an unused container port for OpenCode Web.")
+
+
+def allocate_localhost_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((OPENCODE_WEB_HOST, 0))
+        return int(sock.getsockname()[1])
+
+
+def schedule_open_opencode_web_url(
+    *,
+    main_window: object,
+    task_id: str,
+    url: str,
+    host_port: int,
+) -> None:
+    state = {"done": False}
+    deadline_s = time.monotonic() + (OPENCODE_WEB_TIMEOUT_MS / 1000.0)
+
+    def _attempt_open() -> None:
+        if bool(state.get("done", False)):
+            return
+        if _can_connect_to_local_port(host_port):
+            state["done"] = True
+            opened = open_external_url(url)
+            log_level = "INFO" if opened else "WARN"
+            log_message = (
+                f"opened browser: {url}"
+                if opened
+                else f"web server is ready but host opener did not report success: {url}"
+            )
+            main_window._on_task_log(
+                task_id,
+                format_log("opencode", "web", log_level, log_message),
+            )
+            return
+
+        if time.monotonic() >= deadline_s:
+            state["done"] = True
+            main_window._on_task_log(
+                task_id,
+                format_log(
+                    "opencode",
+                    "web",
+                    "WARN",
+                    "web server was not ready after 10 minutes; "
+                    f"stopped browser open retry: {url}",
+                ),
+            )
+            return
+
+        QTimer.singleShot(OPENCODE_WEB_RETRY_INTERVAL_MS, _attempt_open)
+
+    _attempt_open()
+
+
+def _port_specs_publish_container_port(port_specs: list[str], port: int) -> bool:
+    return any(publishes_container_port(spec, port) for spec in port_specs)
+
+
+def _can_connect_to_local_port(port: int) -> bool:
+    try:
+        with socket.create_connection((OPENCODE_WEB_HOST, int(port)), timeout=0.25):
+            return True
+    except OSError:
+        return False

--- a/agents_runner/ui/pages/environments.py
+++ b/agents_runner/ui/pages/environments.py
@@ -30,6 +30,7 @@ from agents_runner.environments.model import (
     normalize_gh_branch_work_mode,
     normalize_gh_task_branch_custom_template,
     normalize_gh_task_branch_naming_style,
+    normalize_opencode_interactive_override,
 )
 from agents_runner.gh_management import is_gh_available
 from agents_runner.persistence import default_state_path
@@ -364,6 +365,11 @@ class EnvironmentsPage(
                     gpu_mode_idx = 0
                 if gpu_mode_idx >= 0:
                     self._gpu_override_mode.setCurrentIndex(gpu_mode_idx)
+                opencode_mode_idx = self._opencode_interactive_mode.findData("inherit")
+                if opencode_mode_idx < 0:
+                    opencode_mode_idx = 0
+                if opencode_mode_idx >= 0:
+                    self._opencode_interactive_mode.setCurrentIndex(opencode_mode_idx)
                 self._cache_desktop_build.setChecked(False)
                 self._cache_desktop_build.setEnabled(False)
                 self._container_caching_enabled.setChecked(False)
@@ -476,6 +482,16 @@ class EnvironmentsPage(
                 gpu_mode_idx = 0
             if gpu_mode_idx >= 0:
                 self._gpu_override_mode.setCurrentIndex(gpu_mode_idx)
+            opencode_mode = normalize_opencode_interactive_override(
+                getattr(env, "opencode_interactive_mode", "inherit")
+            )
+            opencode_mode_idx = self._opencode_interactive_mode.findData(opencode_mode)
+            if opencode_mode_idx < 0:
+                opencode_mode_idx = self._opencode_interactive_mode.findData("inherit")
+            if opencode_mode_idx < 0:
+                opencode_mode_idx = 0
+            if opencode_mode_idx >= 0:
+                self._opencode_interactive_mode.setCurrentIndex(opencode_mode_idx)
             self._ports_tab.set_desktop_effective_enabled(
                 self._effective_desktop_enabled()
             )

--- a/agents_runner/ui/pages/environments_actions.py
+++ b/agents_runner/ui/pages/environments_actions.py
@@ -20,6 +20,7 @@ from agents_runner.environments.model import (
     normalize_gh_branch_work_mode,
     normalize_gh_task_branch_custom_template,
     normalize_gh_task_branch_naming_style,
+    normalize_opencode_interactive_override,
 )
 from agents_runner.gh_management import is_gh_available
 from agents_runner.ui.dialogs.new_environment_wizard import NewEnvironmentWizard
@@ -136,6 +137,9 @@ class EnvironmentsPageActionsMixin:
             ),
             "gpu_override_mode": normalize_gpu_override_mode(
                 str(self._gpu_override_mode.currentData() or "inherit")
+            ),
+            "opencode_interactive_mode": normalize_opencode_interactive_override(
+                str(self._opencode_interactive_mode.currentData() or "inherit")
             ),
         }
 

--- a/agents_runner/ui/pages/environments_form.py
+++ b/agents_runner/ui/pages/environments_form.py
@@ -153,6 +153,13 @@ class EnvironmentsFormMixin:
         self._gpu_override_mode.setToolTip(
             "Override the global GPU runtime setting for this environment."
         )
+        self._opencode_interactive_mode = QComboBox()
+        self._opencode_interactive_mode.addItem("Inherit global setting", "inherit")
+        self._opencode_interactive_mode.addItem("Terminal", "terminal")
+        self._opencode_interactive_mode.addItem("Web", "web")
+        self._opencode_interactive_mode.setToolTip(
+            "Override the global OpenCode Run Interactive launch mode."
+        )
 
         self._cache_desktop_build = QCheckBox("Cache desktop build")
         self._cache_desktop_build.setToolTip(
@@ -408,7 +415,13 @@ class EnvironmentsFormMixin:
         add_grid_row(grid, 3, QLabel("Max agents running"), max_agents_row)
         add_grid_row(grid, 4, self._headless_desktop_label, self._headless_desktop_row)
         add_grid_row(grid, 5, QLabel("GPU runtime"), self._gpu_override_mode)
-        add_grid_row(grid, 6, QLabel("Cross agents"), cross_agents_row)
+        add_grid_row(
+            grid,
+            6,
+            QLabel("OpenCode interactive"),
+            self._opencode_interactive_mode,
+        )
+        add_grid_row(grid, 7, QLabel("Cross agents"), cross_agents_row)
 
         general_body.addLayout(grid)
         general_body.addStretch(1)

--- a/agents_runner/ui/pages/environments_navigation.py
+++ b/agents_runner/ui/pages/environments_navigation.py
@@ -23,6 +23,7 @@ class EnvironmentsNavigationMixin:
             self._color,
             self._workspace_type_combo,
             self._gpu_override_mode,
+            self._opencode_interactive_mode,
             self._agentsnova_trusted_mode,
             self._agentsnova_auto_review_mode,
             self._agentsnova_auto_reactions_mode,

--- a/agents_runner/ui/pages/settings.py
+++ b/agents_runner/ui/pages/settings.py
@@ -142,6 +142,7 @@ class SettingsPage(QWidget, SettingsFormMixin):
         for combo in (
             self._use,
             self._shell,
+            self._opencode_interactive_mode,
             self._interactive_terminal,
             self._ui_theme,
             self._radio_channel,

--- a/agents_runner/ui/pages/settings_form.py
+++ b/agents_runner/ui/pages/settings_form.py
@@ -27,6 +27,7 @@ from agents_runner.agent_labels import format_agent_ui_label
 from agents_runner.agent_systems import available_agent_system_names
 from agents_runner.agent_systems import get_default_agent_system_name
 from agents_runner.environments import load_environments
+from agents_runner.environments import normalize_opencode_interactive_mode
 from agents_runner.terminal_apps import detect_terminal_options
 from agents_runner.ui.pages.github_trust import (
     collect_seed_usernames_for_cloned_environments,
@@ -145,6 +146,13 @@ class SettingsFormMixin:
         self._refresh_interactive_terminal.setToolButtonStyle(Qt.ToolButtonTextOnly)
         self._refresh_interactive_terminal.clicked.connect(
             self._on_refresh_terminal_options_clicked
+        )
+
+        self._opencode_interactive_mode = QComboBox()
+        self._opencode_interactive_mode.addItem("Terminal", "terminal")
+        self._opencode_interactive_mode.addItem("Web", "web")
+        self._opencode_interactive_mode.setToolTip(
+            "Default OpenCode launch mode for Run Interactive."
         )
 
         self._ui_theme = QComboBox()
@@ -449,6 +457,12 @@ class SettingsFormMixin:
         configure_form_grid(agent_grid)
         add_grid_row(agent_grid, 0, QLabel("Agent CLI"), self._use)
         add_grid_row(agent_grid, 1, QLabel("Agent Shell"), self._shell)
+        add_grid_row(
+            agent_grid,
+            2,
+            QLabel("OpenCode interactive"),
+            self._opencode_interactive_mode,
+        )
         agent_body.addLayout(agent_grid)
         agent_body.addStretch(1)
         self._register_page("agent_defaults", agent_page)
@@ -868,6 +882,13 @@ class SettingsFormMixin:
 
             shell_value = str(settings.get("shell") or "bash").strip().lower()
             self._set_combo_value(self._shell, shell_value, fallback="bash")
+            self._set_combo_value(
+                self._opencode_interactive_mode,
+                normalize_opencode_interactive_mode(
+                    str(settings.get("opencode_interactive_mode") or "terminal")
+                ),
+                fallback="terminal",
+            )
             self._refresh_terminal_options(
                 selected_terminal_id=str(
                     settings.get("interactive_terminal_id") or ""
@@ -1094,6 +1115,9 @@ class SettingsFormMixin:
         return {
             "use": str(self._use.currentData() or get_default_agent_system_name()),
             "shell": str(self._shell.currentData() or "bash"),
+            "opencode_interactive_mode": normalize_opencode_interactive_mode(
+                str(self._opencode_interactive_mode.currentData() or "terminal")
+            ),
             "interactive_terminal_id": str(
                 self._interactive_terminal.currentData() or ""
             ),

--- a/agents_runner/ui/pages/task_details.py
+++ b/agents_runner/ui/pages/task_details.py
@@ -91,9 +91,7 @@ class TaskDetailsPage(QWidget):
 
         self._opencode_web_btn = QToolButton()
         self._opencode_web_btn.setText("OpenCode Web")
-        self._opencode_web_btn.setIcon(lucide_icon("globe"))
-        self._opencode_web_btn.setIconSize(QSize(16, 16))
-        self._opencode_web_btn.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        self._opencode_web_btn.setToolButtonStyle(Qt.ToolButtonTextOnly)
         self._opencode_web_btn.clicked.connect(self._launch_opencode_web)
         self._opencode_web_btn.setVisible(False)
 

--- a/agents_runner/ui/pages/task_details.py
+++ b/agents_runner/ui/pages/task_details.py
@@ -24,6 +24,7 @@ from PySide6.QtWidgets import QWidget
 from agents_runner.ui.pages.artifacts_tab import ArtifactsTab
 
 from agents_runner.artifacts import get_artifact_info
+from agents_runner.agent_display import get_agent_display_name
 from agents_runner.environments import WORKSPACE_CLONED
 from agents_runner.ui.lucide_icons import lucide_icon
 from agents_runner.ui.task_model import Task
@@ -215,9 +216,9 @@ class TaskDetailsPage(QWidget):
 
         prompt_title_row = QHBoxLayout()
         prompt_title_row.setSpacing(8)
-        prompt_title = QLabel("Prompt")
-        prompt_title.setStyleSheet("font-size: 14px; font-weight: 650;")
-        prompt_title_row.addWidget(prompt_title)
+        self._prompt_title = QLabel("Prompt")
+        self._prompt_title.setStyleSheet("font-size: 14px; font-weight: 650;")
+        prompt_title_row.addWidget(self._prompt_title)
         prompt_title_row.addStretch(1)
 
         self._btn_copy_prompt = QToolButton()
@@ -243,8 +244,8 @@ class TaskDetailsPage(QWidget):
 
         self._novnc_url = QLabel("—")
         self._novnc_url.setTextInteractionFlags(Qt.TextSelectableByMouse)
-        self._desktop_display = QLabel("—")
-        self._desktop_display.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self._agent_system = QLabel("—")
+        self._agent_system.setTextInteractionFlags(Qt.TextSelectableByMouse)
 
         self._workdir_row = 0
         cfg.addWidget(self._workdir_label, self._workdir_row, 0)
@@ -255,9 +256,9 @@ class TaskDetailsPage(QWidget):
         self._novnc_row = 2
         cfg.addWidget(QLabel("noVNC URL"), self._novnc_row, 0)
         cfg.addWidget(self._novnc_url, self._novnc_row, 1)
-        self._display_row = 3
-        cfg.addWidget(QLabel("DISPLAY"), self._display_row, 0)
-        cfg.addWidget(self._desktop_display, self._display_row, 1)
+        self._agent_system_row = 3
+        cfg.addWidget(QLabel("Agent System"), self._agent_system_row, 0)
+        cfg.addWidget(self._agent_system, self._agent_system_row, 1)
 
         prompt_layout.addLayout(prompt_title_row)
         prompt_layout.addWidget(self._prompt, 1)
@@ -557,6 +558,10 @@ class TaskDetailsPage(QWidget):
         self._title.setText(f"Task {task.task_id}")
         self._subtitle.setText(task.prompt_one_line())
         self._prompt.setPlainText(task.prompt)
+        has_prompt = bool(str(task.prompt or "").strip())
+        self._prompt_title.setText("Prompt" if has_prompt else "Runtime Details")
+        self._btn_copy_prompt.setVisible(has_prompt)
+        self._prompt.setVisible(has_prompt)
 
         # Show/hide Host Workdir based on workspace type
         is_cloned = task.workspace_type == WORKSPACE_CLONED
@@ -566,6 +571,8 @@ class TaskDetailsPage(QWidget):
             self._workdir.setText(task.host_workdir)
 
         self._container.setText(task.container_id or "—")
+        agent_label = get_agent_display_name(str(task.agent_cli or "").strip())
+        self._agent_system.setText(agent_label if agent_label.strip() else "—")
         self._tabs.setCurrentIndex(self._task_tab_index)
         self._sync_desktop_button(task)
         self._sync_artifacts(task)
@@ -609,6 +616,8 @@ class TaskDetailsPage(QWidget):
             return
         self._last_task = task
         self._container.setText(task.container_id or "—")
+        agent_label = get_agent_display_name(str(task.agent_cli or "").strip())
+        self._agent_system.setText(agent_label if agent_label.strip() else "—")
         self._sync_desktop_button(task)
         self._sync_artifacts(task)
         self._sync_container_actions(task)
@@ -630,7 +639,6 @@ class TaskDetailsPage(QWidget):
 
         self._desktop_btn.setVisible(should_show)
         self._novnc_url.setText(url if url else "—")
-        self._desktop_display.setText(str(task.desktop_display or ":1") if url else "—")
 
     def _sync_artifacts(self, task: Task) -> None:
         """

--- a/agents_runner/ui/pages/task_details.py
+++ b/agents_runner/ui/pages/task_details.py
@@ -16,6 +16,7 @@ from PySide6.QtWidgets import QHBoxLayout
 from PySide6.QtWidgets import QLabel
 from PySide6.QtWidgets import QMessageBox
 from PySide6.QtWidgets import QPlainTextEdit
+from PySide6.QtWidgets import QSizePolicy
 from PySide6.QtWidgets import QTabWidget
 from PySide6.QtWidgets import QToolButton
 from PySide6.QtWidgets import QVBoxLayout
@@ -29,6 +30,7 @@ from agents_runner.environments import WORKSPACE_CLONED
 from agents_runner.ui.lucide_icons import lucide_icon
 from agents_runner.ui.task_model import Task
 from agents_runner.ui.task_model import task_display_status
+from agents_runner.ui.url_open import open_external_url
 from agents_runner.ui.utils import format_duration
 from agents_runner.ui.utils import rgba
 from agents_runner.ui.utils import status_color
@@ -87,9 +89,18 @@ class TaskDetailsPage(QWidget):
         self._desktop_btn.clicked.connect(self._launch_desktop_viewer)
         self._desktop_btn.setVisible(False)
 
+        self._opencode_web_btn = QToolButton()
+        self._opencode_web_btn.setText("OpenCode Web")
+        self._opencode_web_btn.setIcon(lucide_icon("globe"))
+        self._opencode_web_btn.setIconSize(QSize(16, 16))
+        self._opencode_web_btn.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        self._opencode_web_btn.clicked.connect(self._launch_opencode_web)
+        self._opencode_web_btn.setVisible(False)
+
         header_layout.addWidget(self._title)
         header_layout.addWidget(self._subtitle, 1)
         header_layout.addWidget(self._review, 0, Qt.AlignRight)
+        header_layout.addWidget(self._opencode_web_btn, 0, Qt.AlignRight)
         header_layout.addWidget(self._desktop_btn, 0, Qt.AlignRight)
         layout.addWidget(header)
 
@@ -128,6 +139,7 @@ class TaskDetailsPage(QWidget):
         # Right side: Container state + Prompt cards stacked vertically
         right_column = QVBoxLayout()
         right_column.setSpacing(14)
+        self._right_column = right_column
 
         # Container state card (top-right)
         state_card = GlassCard()
@@ -210,6 +222,7 @@ class TaskDetailsPage(QWidget):
 
         # Prompt card (bottom-right)
         prompt_card = GlassCard()
+        self._prompt_card = prompt_card
         prompt_layout = QVBoxLayout(prompt_card)
         prompt_layout.setContentsMargins(18, 16, 18, 16)
         prompt_layout.setSpacing(10)
@@ -231,6 +244,10 @@ class TaskDetailsPage(QWidget):
         self._prompt = QPlainTextEdit()
         self._prompt.setReadOnly(True)
         self._prompt.setMaximumBlockCount(2000)
+        self._prompt.setSizePolicy(
+            QSizePolicy.Policy.Expanding,
+            QSizePolicy.Policy.Expanding,
+        )
 
         cfg = QGridLayout()
         cfg.setHorizontalSpacing(10)
@@ -242,8 +259,12 @@ class TaskDetailsPage(QWidget):
         self._container.setTextInteractionFlags(Qt.TextSelectableByMouse)
         self._workdir.setTextInteractionFlags(Qt.TextSelectableByMouse)
 
+        self._novnc_label = QLabel("noVNC URL")
         self._novnc_url = QLabel("—")
         self._novnc_url.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self._opencode_web_url_label = QLabel("OpenCode Web URL")
+        self._opencode_web_url = QLabel("—")
+        self._opencode_web_url.setTextInteractionFlags(Qt.TextSelectableByMouse)
         self._agent_system = QLabel("—")
         self._agent_system.setTextInteractionFlags(Qt.TextSelectableByMouse)
 
@@ -254,16 +275,19 @@ class TaskDetailsPage(QWidget):
         cfg.addWidget(QLabel("Container ID"), self._container_row, 0)
         cfg.addWidget(self._container, self._container_row, 1)
         self._novnc_row = 2
-        cfg.addWidget(QLabel("noVNC URL"), self._novnc_row, 0)
+        cfg.addWidget(self._novnc_label, self._novnc_row, 0)
         cfg.addWidget(self._novnc_url, self._novnc_row, 1)
-        self._agent_system_row = 3
+        self._opencode_web_url_row = 3
+        cfg.addWidget(self._opencode_web_url_label, self._opencode_web_url_row, 0)
+        cfg.addWidget(self._opencode_web_url, self._opencode_web_url_row, 1)
+        self._agent_system_row = 4
         cfg.addWidget(QLabel("Agent System"), self._agent_system_row, 0)
         cfg.addWidget(self._agent_system, self._agent_system_row, 1)
 
         prompt_layout.addLayout(prompt_title_row)
         prompt_layout.addWidget(self._prompt, 1)
         prompt_layout.addLayout(cfg)
-        right_column.addWidget(prompt_card, 1)
+        right_column.addWidget(prompt_card)
 
         mid.addLayout(right_column, 2)
 
@@ -387,6 +411,14 @@ class TaskDetailsPage(QWidget):
         url = str(self._last_task.novnc_url or "").strip()
         task_id = str(self._last_task.task_id or self._current_task_id or "")
         self.launch_desktop_viewer_for_task(task_id=task_id, url=url)
+
+    def _launch_opencode_web(self) -> None:
+        """Open the stored OpenCode Web URL for the current task."""
+        if not self._last_task:
+            return
+        url = str(self._last_task.opencode_web_url or "").strip()
+        if url:
+            open_external_url(url)
 
     def launch_desktop_viewer_for_task(self, *, task_id: str, url: str) -> bool:
         """Launch viewer for a specific task noVNC URL."""
@@ -559,9 +591,7 @@ class TaskDetailsPage(QWidget):
         self._subtitle.setText(task.prompt_one_line())
         self._prompt.setPlainText(task.prompt)
         has_prompt = bool(str(task.prompt or "").strip())
-        self._prompt_title.setText("Prompt" if has_prompt else "Runtime Details")
-        self._btn_copy_prompt.setVisible(has_prompt)
-        self._prompt.setVisible(has_prompt)
+        self._sync_prompt_runtime_layout(has_prompt=has_prompt)
 
         # Show/hide Host Workdir based on workspace type
         is_cloned = task.workspace_type == WORKSPACE_CLONED
@@ -571,10 +601,10 @@ class TaskDetailsPage(QWidget):
             self._workdir.setText(task.host_workdir)
 
         self._container.setText(task.container_id or "—")
-        agent_label = get_agent_display_name(str(task.agent_cli or "").strip())
-        self._agent_system.setText(agent_label if agent_label.strip() else "—")
+        self._agent_system.setText(self._agent_system_label(task))
         self._tabs.setCurrentIndex(self._task_tab_index)
         self._sync_desktop_button(task)
+        self._sync_opencode_web_button(task)
         self._sync_artifacts(task)
         self._sync_container_actions(task)
         self._pending_log_lines.clear()
@@ -616,9 +646,9 @@ class TaskDetailsPage(QWidget):
             return
         self._last_task = task
         self._container.setText(task.container_id or "—")
-        agent_label = get_agent_display_name(str(task.agent_cli or "").strip())
-        self._agent_system.setText(agent_label if agent_label.strip() else "—")
+        self._agent_system.setText(self._agent_system_label(task))
         self._sync_desktop_button(task)
+        self._sync_opencode_web_button(task)
         self._sync_artifacts(task)
         self._sync_container_actions(task)
         self._exit.setText("—" if task.exit_code is None else str(task.exit_code))
@@ -639,6 +669,39 @@ class TaskDetailsPage(QWidget):
 
         self._desktop_btn.setVisible(should_show)
         self._novnc_url.setText(url if url else "—")
+        self._novnc_label.setVisible(bool(url))
+        self._novnc_url.setVisible(bool(url))
+
+    def _sync_opencode_web_button(self, task: Task) -> None:
+        url = str(task.opencode_web_url or "").strip()
+        self._opencode_web_btn.setVisible(bool(task.is_active() and url))
+        self._opencode_web_url.setText(url if url else "—")
+        self._opencode_web_url_label.setVisible(bool(url))
+        self._opencode_web_url.setVisible(bool(url))
+
+    def _sync_prompt_runtime_layout(self, *, has_prompt: bool) -> None:
+        self._prompt_title.setText("Prompt" if has_prompt else "Runtime Details")
+        self._btn_copy_prompt.setVisible(has_prompt)
+        self._prompt.setVisible(has_prompt)
+        if has_prompt:
+            self._prompt_card.setSizePolicy(
+                QSizePolicy.Policy.Expanding,
+                QSizePolicy.Policy.Expanding,
+            )
+            self._right_column.setStretch(1, 1)
+        else:
+            self._prompt_card.setSizePolicy(
+                QSizePolicy.Policy.Expanding,
+                QSizePolicy.Policy.Preferred,
+            )
+            self._right_column.setStretch(1, 0)
+        self._prompt_card.updateGeometry()
+
+    def _agent_system_label(self, task: Task) -> str:
+        if task.is_opencode_web_run():
+            return "OpenCode Web"
+        agent_label = get_agent_display_name(str(task.agent_cli or "").strip())
+        return agent_label if agent_label.strip() else "—"
 
     def _sync_artifacts(self, task: Task) -> None:
         """

--- a/agents_runner/ui/task_model.py
+++ b/agents_runner/ui/task_model.py
@@ -43,6 +43,7 @@ class Task:
     ide_display_target: str = ""
     headless_desktop_enabled: bool = False
     novnc_url: str = ""
+    opencode_web_url: str = ""
     vnc_password: str = ""
     artifacts: list[str] = field(default_factory=list)
     attempt_history: list[dict[str, object]] = field(default_factory=list)
@@ -78,9 +79,18 @@ class Task:
             end_s = float(now_s if now_s is not None else time.time())
         return max(0.0, end_s - created_s)
 
+    def is_opencode_web_run(self) -> bool:
+        launch_mode = str(self.launch_mode or "").strip().lower()
+        if launch_mode == "opencode_web":
+            return True
+        agent_cli = str(self.agent_cli or "").strip().lower()
+        return bool(
+            agent_cli == "opencode" and str(self.opencode_web_url or "").strip()
+        )
+
     def is_interactive_run(self) -> bool:
         launch_mode = str(self.launch_mode or "").strip().lower()
-        if launch_mode in {"interactive_agent", "interactive"}:
+        if launch_mode in {"interactive_agent", "interactive", "opencode_web"}:
             return True
         container_id = str(self.container_id or "")
         if container_id.startswith("agents-runner-tui-it-"):
@@ -96,6 +106,8 @@ class Task:
             return line
         if str(self.launch_mode or "").strip().lower() == "ide":
             return "Run IDE"
+        if self.is_opencode_web_run():
+            return "OpenCode Web"
         if self.is_interactive_run():
             return "Interactive"
         return "(empty prompt)"

--- a/agents_runner/ui/task_model.py
+++ b/agents_runner/ui/task_model.py
@@ -44,7 +44,6 @@ class Task:
     headless_desktop_enabled: bool = False
     novnc_url: str = ""
     vnc_password: str = ""
-    desktop_display: str = ""
     artifacts: list[str] = field(default_factory=list)
     attempt_history: list[dict[str, object]] = field(default_factory=list)
     finalization_state: str = "pending"
@@ -91,7 +90,8 @@ class Task:
         return False
 
     def prompt_one_line(self) -> str:
-        line = (self.prompt or "").strip().splitlines()[0] if self.prompt else ""
+        prompt_lines = (self.prompt or "").strip().splitlines()
+        line = prompt_lines[0] if prompt_lines else ""
         if line:
             return line
         if str(self.launch_mode or "").strip().lower() == "ide":

--- a/agents_runner/ui/url_open.py
+++ b/agents_runner/ui/url_open.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import webbrowser
+
+from PySide6.QtCore import QUrl
+from PySide6.QtGui import QDesktopServices
+
+
+def open_external_url(url: str) -> bool:
+    """Open a URL with Qt first, then platform fallbacks."""
+    target = str(url or "").strip()
+    if not target:
+        return False
+
+    try:
+        if QDesktopServices.openUrl(QUrl(target)):
+            return True
+    except Exception:
+        pass
+
+    try:
+        if webbrowser.open(target):
+            return True
+    except Exception:
+        pass
+
+    opener = ""
+    if sys.platform == "darwin":
+        opener = shutil.which("open") or ""
+    elif sys.platform.startswith("linux"):
+        opener = shutil.which("xdg-open") or ""
+    if not opener:
+        return False
+
+    try:
+        subprocess.Popen(
+            [opener, target],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except Exception:
+        return False
+    return True


### PR DESCRIPTION
## Summary

- add OpenCode interactive mode settings at the global and environment levels
- launch OpenCode Web through Docker with a managed localhost port mapping
- wait for the OpenCode Web port before opening the browser, retrying every 15 seconds and stopping after 10 minutes
- update Task Details so blank-prompt tasks show runtime details instead of an empty prompt editor
- replace the Task Details `DISPLAY` row with an `Agent System` row and remove task-level `desktop_display` persistence

## Verification

- `uv run ruff format .`
- `uv run ruff check .`
- touched-file compile checks
- OpenCode Web retry smoke checks
- Task Details blank/nonblank prompt smoke checks

## Notes

- Follow-up UI polish is still needed before this feels complete.
- Opening the OpenCode Web UI is not working yet in the live app, even though the readiness/open retry helper is now constrained to readiness and timeout behavior.
- Consider adding an OpenCode Web button next to the existing Desktop button when a task is launched in OpenCode Web mode.
- Task Details currently shows `OpenCode` for the agent system even when the task is using OpenCode Web; it should probably distinguish `OpenCode Web` in that mode.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
