### PR TITLE
[FIX] Repair OpenCode Web launch readiness and task UI

### DIFF
--- a/agents_runner/persistence.py
+++ b/agents_runner/persistence.py
@@ -347,6 +347,7 @@ def serialize_task(task: Any) -> dict[str, Any]:
             getattr(task, "headless_desktop_enabled", False)
         ),
         "novnc_url": getattr(task, "novnc_url", ""),
+        "opencode_web_url": getattr(task, "opencode_web_url", ""),
         "artifacts": list(getattr(task, "artifacts", [])),
         "attempt_history": list(getattr(task, "attempt_history", [])),
         "finalization_state": str(
@@ -411,6 +412,7 @@ def deserialize_task(task_cls: type, data: dict[str, Any]) -> Any:
         ide_display_target=str(data.get("ide_display_target") or ""),
         headless_desktop_enabled=bool(data.get("headless_desktop_enabled") or False),
         novnc_url=str(data.get("novnc_url") or ""),
+        opencode_web_url=str(data.get("opencode_web_url") or ""),
         vnc_password="",
         artifacts=list(data.get("artifacts") or []),
         attempt_history=list(data.get("attempt_history") or []),

--- a/agents_runner/ui/main_window_tasks_interactive.py
+++ b/agents_runner/ui/main_window_tasks_interactive.py
@@ -255,8 +255,9 @@ class MainWindowTasksInteractiveMixin:
             == "web"
         )
         if opencode_web_mode:
-            command = "opencode web --port 4096 --hostname 0.0.0.0"
+            command = "opencode web"
             agent_cli_args = []
+        launch_mode = "opencode_web" if opencode_web_mode else "interactive_agent"
 
         extra_preflight_script = str(extra_preflight_script or "")
         is_help_launch = self._is_agent_help_interactive_launch(
@@ -336,7 +337,7 @@ class MainWindowTasksInteractiveMixin:
             agent_cli=agent_cli,
             agent_instance_id=agent_instance_id,
             agent_cli_args=" ".join(agent_cli_args),
-            launch_mode="interactive_agent",
+            launch_mode=launch_mode,
         )
         self._tasks[task_id] = task
         stain = env.color if env else None
@@ -385,7 +386,7 @@ class MainWindowTasksInteractiveMixin:
             desktop_enabled=desktop_enabled,
             settings_preflight_script=settings_preflight_script,
             extra_preflight_script=extra_preflight_script,
-            launch_mode="interactive_agent",
+            launch_mode=launch_mode,
             container_caching_enabled=bool(
                 env and getattr(env, "container_caching_enabled", False)
             ),

--- a/agents_runner/ui/main_window_tasks_interactive_docker.py
+++ b/agents_runner/ui/main_window_tasks_interactive_docker.py
@@ -8,16 +8,11 @@ from __future__ import annotations
 
 import os
 import shlex
-import socket
 import tempfile
-import webbrowser
 from datetime import datetime
 from datetime import timezone
 from pathlib import Path
 
-from PySide6.QtCore import QTimer
-from PySide6.QtCore import QUrl
-from PySide6.QtGui import QDesktopServices
 from PySide6.QtWidgets import QMessageBox
 
 from agents_runner.agent_install import probe_agent_executable_in_image
@@ -39,33 +34,14 @@ from agents_runner.log_format import format_log
 from agents_runner.terminal_apps import launch_in_terminal
 from agents_runner.core.shell_templates import git_identity_clause
 from agents_runner.core.shell_templates import shell_log_statement
+from agents_runner.ui.opencode_web import OPENCODE_WEB_CONTAINER_PORT
+from agents_runner.ui.opencode_web import OPENCODE_WEB_HOST
+from agents_runner.ui.opencode_web import allocate_localhost_port
+from agents_runner.ui.opencode_web import publishes_container_port
+from agents_runner.ui.opencode_web import schedule_open_opencode_web_url
+from agents_runner.ui.opencode_web import select_opencode_web_container_port
 from agents_runner.ui.task_model import Task
 from agents_runner.ui.utils import safe_str
-
-_OPENCODE_WEB_CONTAINER_PORT = 4096
-_OPENCODE_WEB_HOST = "127.0.0.1"
-_OPENCODE_WEB_RETRY_INTERVAL_MS = 15_000
-_OPENCODE_WEB_TIMEOUT_MS = 10 * 60 * 1000
-
-
-def _publishes_container_port(spec: str, port: int) -> bool:
-    base = str(spec or "").strip()
-    if not base:
-        return False
-    base = base.split("/", 1)[0]
-    container_part = base.rsplit(":", 1)[-1].strip()
-    if not container_part:
-        return False
-    if container_part.isdigit():
-        return int(container_part) == int(port)
-    if "-" in container_part:
-        left, right = (p.strip() for p in container_part.split("-", 1))
-        if left.isdigit() and right.isdigit():
-            start = int(left)
-            end = int(right)
-            p = int(port)
-            return start <= p <= end
-    return False
 
 
 def _redact_env_assignment(value: str) -> str:
@@ -448,36 +424,53 @@ def launch_docker_terminal_task(
                     ["-e", f"GH_TOKEN={gh_token}", "-e", f"GITHUB_TOKEN={gh_token}"]
                 )
 
+        ports_source = (
+            list(ports_for_task or [])
+            if ports_for_task is not None
+            else list((getattr(env, "ports", None) or []) if env else [])
+        )
+
         # Allocate ports for managed local services.
         port_args: list[str] = []
         opencode_web_url = ""
         opencode_web_host_port = 0
+        opencode_web_container_port = OPENCODE_WEB_CONTAINER_PORT
         if opencode_web_mode:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            try:
-                s.bind((_OPENCODE_WEB_HOST, 0))
-                opencode_web_host_port = int(s.getsockname()[1])
-            finally:
-                s.close()
+            opencode_web_container_port = select_opencode_web_container_port(
+                ports_source
+            )
+            opencode_web_host_port = allocate_localhost_port()
             port_args.extend(
                 [
                     "-p",
                     (
-                        f"{_OPENCODE_WEB_HOST}:{opencode_web_host_port}:"
-                        f"{_OPENCODE_WEB_CONTAINER_PORT}"
+                        f"{OPENCODE_WEB_HOST}:{opencode_web_host_port}:"
+                        f"{opencode_web_container_port}"
                     ),
                 ]
             )
-            opencode_web_url = f"http://{_OPENCODE_WEB_HOST}:{opencode_web_host_port}"
+            opencode_web_url = f"http://{OPENCODE_WEB_HOST}:{opencode_web_host_port}"
+            task.opencode_web_url = opencode_web_url
+            main_window._on_task_log(
+                task_id,
+                format_log(
+                    "opencode",
+                    "web",
+                    "INFO",
+                    (
+                        "mapped web ui: "
+                        f"{OPENCODE_WEB_HOST}:{opencode_web_host_port} -> "
+                        f"container port {opencode_web_container_port}"
+                    ),
+                ),
+            )
+            main_window._dashboard.upsert_task(task, stain=stain, spinner_color=spinner)
+            main_window._details.update_task(task)
+            main_window._schedule_save()
 
         if desktop_enabled:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            try:
-                s.bind(("127.0.0.1", 0))
-                host_port = int(s.getsockname()[1])
-            finally:
-                s.close()
-            port_args = ["-p", f"127.0.0.1:{host_port}:6080"]
+            host_port = allocate_localhost_port()
+            port_args.extend(["-p", f"127.0.0.1:{host_port}:6080"])
             env_args.extend(["-e", f"AGENTS_RUNNER_TASK_ID={task_token}"])
             task.headless_desktop_enabled = True
             task.novnc_url = f"http://127.0.0.1:{host_port}/vnc.html"
@@ -486,19 +479,14 @@ def launch_docker_terminal_task(
             main_window._schedule_save()
 
         # Apply environment-specified ports (or task runtime overrides)
-        ports_source = (
-            list(ports_for_task or [])
-            if ports_for_task is not None
-            else list((getattr(env, "ports", None) or []) if env else [])
-        )
         for port_spec in ports_source:
             spec = str(port_spec or "").strip()
             if not spec:
                 continue
-            if desktop_enabled and _publishes_container_port(spec, 6080):
+            if desktop_enabled and publishes_container_port(spec, 6080):
                 continue
-            if opencode_web_mode and _publishes_container_port(
-                spec, _OPENCODE_WEB_CONTAINER_PORT
+            if opencode_web_mode and publishes_container_port(
+                spec, opencode_web_container_port
             ):
                 continue
             port_args.extend(["-p", spec])
@@ -545,7 +533,7 @@ def launch_docker_terminal_task(
             verify_clause = ""
         elif opencode_web_mode:
             target_cmd = (
-                f"opencode web --port {_OPENCODE_WEB_CONTAINER_PORT} --hostname 0.0.0.0"
+                f"opencode web --port {opencode_web_container_port} --hostname 0.0.0.0"
             )
             verify_clause = verify_cli_clause("opencode")
         else:
@@ -694,7 +682,7 @@ def launch_docker_terminal_task(
         # Launch terminal
         launch_in_terminal(terminal_opt, host_script, cwd=host_workdir)
         if opencode_web_url and opencode_web_host_port:
-            _schedule_open_opencode_web_url(
+            schedule_open_opencode_web_url(
                 main_window=main_window,
                 task_id=task_id,
                 url=opencode_web_url,
@@ -1109,68 +1097,6 @@ def _build_host_shell_script(
     )
 
     return " ; ".join(host_script_parts)
-
-
-def _schedule_open_opencode_web_url(
-    *,
-    main_window: object,
-    task_id: str,
-    url: str,
-    host_port: int,
-) -> None:
-    state = {"done": False, "elapsed_ms": 0}
-
-    def _attempt_open() -> None:
-        if bool(state.get("done", False)):
-            return
-        if _can_connect_to_local_port(host_port):
-            state["done"] = True
-            _open_url_from_host(url)
-            main_window._on_task_log(
-                task_id,
-                format_log("opencode", "web", "INFO", f"opened browser: {url}"),
-            )
-            return
-
-        state["elapsed_ms"] = int(state.get("elapsed_ms", 0)) + int(
-            _OPENCODE_WEB_RETRY_INTERVAL_MS
-        )
-        if int(state.get("elapsed_ms", 0)) >= _OPENCODE_WEB_TIMEOUT_MS:
-            state["done"] = True
-            main_window._on_task_log(
-                task_id,
-                format_log(
-                    "opencode",
-                    "web",
-                    "WARN",
-                    "web server was not ready after 10 minutes; "
-                    f"stopped browser open retry: {url}",
-                ),
-            )
-            return
-
-        QTimer.singleShot(_OPENCODE_WEB_RETRY_INTERVAL_MS, _attempt_open)
-
-    QTimer.singleShot(_OPENCODE_WEB_RETRY_INTERVAL_MS, _attempt_open)
-
-
-def _can_connect_to_local_port(port: int) -> bool:
-    try:
-        with socket.create_connection((_OPENCODE_WEB_HOST, int(port)), timeout=0.25):
-            return True
-    except OSError:
-        return False
-
-
-def _open_url_from_host(url: str) -> None:
-    qurl = QUrl(str(url or "").strip())
-    opened = False
-    try:
-        opened = bool(QDesktopServices.openUrl(qurl))
-    except Exception:
-        opened = False
-    if not opened:
-        webbrowser.open(str(url or "").strip())
 
 
 def _cleanup_temp_files(tmp_paths: dict[str, str]) -> None:

--- a/agents_runner/ui/opencode_web.py
+++ b/agents_runner/ui/opencode_web.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import random
 import socket
 import time
+import urllib.error
+import urllib.request
 
 from PySide6.QtCore import QTimer
 
@@ -13,8 +15,9 @@ OPENCODE_WEB_CONTAINER_PORT = 4096
 OPENCODE_WEB_ALT_CONTAINER_PORT_MIN = 20_000
 OPENCODE_WEB_ALT_CONTAINER_PORT_MAX = 60_999
 OPENCODE_WEB_HOST = "127.0.0.1"
-OPENCODE_WEB_RETRY_INTERVAL_MS = 15_000
+OPENCODE_WEB_RETRY_INTERVAL_MS = 500
 OPENCODE_WEB_TIMEOUT_MS = 10 * 60 * 1000
+OPENCODE_WEB_HTTP_TIMEOUT_S = 0.75
 
 
 def publishes_container_port(spec: str, port: int) -> bool:
@@ -74,12 +77,32 @@ def schedule_open_opencode_web_url(
 ) -> None:
     state = {"done": False}
     deadline_s = time.monotonic() + (OPENCODE_WEB_TIMEOUT_MS / 1000.0)
+    readiness_url = f"http://{OPENCODE_WEB_HOST}:{int(host_port)}/"
+    main_window._on_task_log(
+        task_id,
+        format_log(
+            "opencode",
+            "web",
+            "INFO",
+            f"waiting for HTTP readiness: {readiness_url}",
+        ),
+    )
 
     def _attempt_open() -> None:
         if bool(state.get("done", False)):
             return
-        if _can_connect_to_local_port(host_port):
+        status_code = _http_status_code(readiness_url)
+        if status_code is not None:
             state["done"] = True
+            main_window._on_task_log(
+                task_id,
+                format_log(
+                    "opencode",
+                    "web",
+                    "INFO",
+                    f"HTTP readiness returned {status_code}: {readiness_url}",
+                ),
+            )
             opened = open_external_url(url)
             log_level = "INFO" if opened else "WARN"
             log_message = (
@@ -101,7 +124,7 @@ def schedule_open_opencode_web_url(
                     "opencode",
                     "web",
                     "WARN",
-                    "web server was not ready after 10 minutes; "
+                    "web server never returned an HTTP status after 10 minutes; "
                     f"stopped browser open retry: {url}",
                 ),
             )
@@ -116,9 +139,23 @@ def _port_specs_publish_container_port(port_specs: list[str], port: int) -> bool
     return any(publishes_container_port(spec, port) for spec in port_specs)
 
 
-def _can_connect_to_local_port(port: int) -> bool:
+def _http_status_code(url: str) -> int | None:
+    request = urllib.request.Request(
+        str(url),
+        method="GET",
+        headers={"User-Agent": "agents-runner-opencode-readiness"},
+    )
     try:
-        with socket.create_connection((OPENCODE_WEB_HOST, int(port)), timeout=0.25):
-            return True
-    except OSError:
-        return False
+        with urllib.request.urlopen(  # noqa: S310
+            request,
+            timeout=OPENCODE_WEB_HTTP_TIMEOUT_S,
+        ) as response:
+            status = int(response.status)
+    except urllib.error.HTTPError as exc:
+        status = int(exc.code)
+    except (OSError, ValueError):
+        return None
+
+    if 100 <= status <= 599:
+        return status
+    return None

--- a/agents_runner/ui/opencode_web.py
+++ b/agents_runner/ui/opencode_web.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import random
+import socket
+import time
+
+from PySide6.QtCore import QTimer
+
+from agents_runner.log_format import format_log
+from agents_runner.ui.url_open import open_external_url
+
+OPENCODE_WEB_CONTAINER_PORT = 4096
+OPENCODE_WEB_ALT_CONTAINER_PORT_MIN = 20_000
+OPENCODE_WEB_ALT_CONTAINER_PORT_MAX = 60_999
+OPENCODE_WEB_HOST = "127.0.0.1"
+OPENCODE_WEB_RETRY_INTERVAL_MS = 15_000
+OPENCODE_WEB_TIMEOUT_MS = 10 * 60 * 1000
+
+
+def publishes_container_port(spec: str, port: int) -> bool:
+    base = str(spec or "").strip()
+    if not base:
+        return False
+    base = base.split("/", 1)[0]
+    container_part = base.rsplit(":", 1)[-1].strip()
+    if not container_part:
+        return False
+    if container_part.isdigit():
+        return int(container_part) == int(port)
+    if "-" in container_part:
+        left, right = (p.strip() for p in container_part.split("-", 1))
+        if left.isdigit() and right.isdigit():
+            start = int(left)
+            end = int(right)
+            p = int(port)
+            return start <= p <= end
+    return False
+
+
+def select_opencode_web_container_port(port_specs: list[str]) -> int:
+    if not _port_specs_publish_container_port(port_specs, OPENCODE_WEB_CONTAINER_PORT):
+        return OPENCODE_WEB_CONTAINER_PORT
+
+    for _ in range(128):
+        candidate = random.randint(
+            OPENCODE_WEB_ALT_CONTAINER_PORT_MIN,
+            OPENCODE_WEB_ALT_CONTAINER_PORT_MAX,
+        )
+        if not _port_specs_publish_container_port(port_specs, candidate):
+            return candidate
+
+    for candidate in range(
+        OPENCODE_WEB_ALT_CONTAINER_PORT_MIN,
+        OPENCODE_WEB_ALT_CONTAINER_PORT_MAX + 1,
+    ):
+        if not _port_specs_publish_container_port(port_specs, candidate):
+            return candidate
+
+    raise RuntimeError("Could not find an unused container port for OpenCode Web.")
+
+
+def allocate_localhost_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((OPENCODE_WEB_HOST, 0))
+        return int(sock.getsockname()[1])
+
+
+def schedule_open_opencode_web_url(
+    *,
+    main_window: object,
+    task_id: str,
+    url: str,
+    host_port: int,
+) -> None:
+    state = {"done": False}
+    deadline_s = time.monotonic() + (OPENCODE_WEB_TIMEOUT_MS / 1000.0)
+
+    def _attempt_open() -> None:
+        if bool(state.get("done", False)):
+            return
+        if _can_connect_to_local_port(host_port):
+            state["done"] = True
+            opened = open_external_url(url)
+            log_level = "INFO" if opened else "WARN"
+            log_message = (
+                f"opened browser: {url}"
+                if opened
+                else f"web server is ready but host opener did not report success: {url}"
+            )
+            main_window._on_task_log(
+                task_id,
+                format_log("opencode", "web", log_level, log_message),
+            )
+            return
+
+        if time.monotonic() >= deadline_s:
+            state["done"] = True
+            main_window._on_task_log(
+                task_id,
+                format_log(
+                    "opencode",
+                    "web",
+                    "WARN",
+                    "web server was not ready after 10 minutes; "
+                    f"stopped browser open retry: {url}",
+                ),
+            )
+            return
+
+        QTimer.singleShot(OPENCODE_WEB_RETRY_INTERVAL_MS, _attempt_open)
+
+    _attempt_open()
+
+
+def _port_specs_publish_container_port(port_specs: list[str], port: int) -> bool:
+    return any(publishes_container_port(spec, port) for spec in port_specs)
+
+
+def _can_connect_to_local_port(port: int) -> bool:
+    try:
+        with socket.create_connection((OPENCODE_WEB_HOST, int(port)), timeout=0.25):
+            return True
+    except OSError:
+        return False

--- a/agents_runner/ui/pages/task_details.py
+++ b/agents_runner/ui/pages/task_details.py
@@ -91,9 +91,7 @@ class TaskDetailsPage(QWidget):
 
         self._opencode_web_btn = QToolButton()
         self._opencode_web_btn.setText("OpenCode Web")
-        self._opencode_web_btn.setIcon(lucide_icon("globe"))
-        self._opencode_web_btn.setIconSize(QSize(16, 16))
-        self._opencode_web_btn.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        self._opencode_web_btn.setToolButtonStyle(Qt.ToolButtonTextOnly)
         self._opencode_web_btn.clicked.connect(self._launch_opencode_web)
         self._opencode_web_btn.setVisible(False)
 

--- a/agents_runner/ui/pages/task_details.py
+++ b/agents_runner/ui/pages/task_details.py
@@ -16,6 +16,7 @@ from PySide6.QtWidgets import QHBoxLayout
 from PySide6.QtWidgets import QLabel
 from PySide6.QtWidgets import QMessageBox
 from PySide6.QtWidgets import QPlainTextEdit
+from PySide6.QtWidgets import QSizePolicy
 from PySide6.QtWidgets import QTabWidget
 from PySide6.QtWidgets import QToolButton
 from PySide6.QtWidgets import QVBoxLayout
@@ -29,6 +30,7 @@ from agents_runner.environments import WORKSPACE_CLONED
 from agents_runner.ui.lucide_icons import lucide_icon
 from agents_runner.ui.task_model import Task
 from agents_runner.ui.task_model import task_display_status
+from agents_runner.ui.url_open import open_external_url
 from agents_runner.ui.utils import format_duration
 from agents_runner.ui.utils import rgba
 from agents_runner.ui.utils import status_color
@@ -87,9 +89,18 @@ class TaskDetailsPage(QWidget):
         self._desktop_btn.clicked.connect(self._launch_desktop_viewer)
         self._desktop_btn.setVisible(False)
 
+        self._opencode_web_btn = QToolButton()
+        self._opencode_web_btn.setText("OpenCode Web")
+        self._opencode_web_btn.setIcon(lucide_icon("globe"))
+        self._opencode_web_btn.setIconSize(QSize(16, 16))
+        self._opencode_web_btn.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        self._opencode_web_btn.clicked.connect(self._launch_opencode_web)
+        self._opencode_web_btn.setVisible(False)
+
         header_layout.addWidget(self._title)
         header_layout.addWidget(self._subtitle, 1)
         header_layout.addWidget(self._review, 0, Qt.AlignRight)
+        header_layout.addWidget(self._opencode_web_btn, 0, Qt.AlignRight)
         header_layout.addWidget(self._desktop_btn, 0, Qt.AlignRight)
         layout.addWidget(header)
 
@@ -128,6 +139,7 @@ class TaskDetailsPage(QWidget):
         # Right side: Container state + Prompt cards stacked vertically
         right_column = QVBoxLayout()
         right_column.setSpacing(14)
+        self._right_column = right_column
 
         # Container state card (top-right)
         state_card = GlassCard()
@@ -210,6 +222,7 @@ class TaskDetailsPage(QWidget):
 
         # Prompt card (bottom-right)
         prompt_card = GlassCard()
+        self._prompt_card = prompt_card
         prompt_layout = QVBoxLayout(prompt_card)
         prompt_layout.setContentsMargins(18, 16, 18, 16)
         prompt_layout.setSpacing(10)
@@ -231,6 +244,10 @@ class TaskDetailsPage(QWidget):
         self._prompt = QPlainTextEdit()
         self._prompt.setReadOnly(True)
         self._prompt.setMaximumBlockCount(2000)
+        self._prompt.setSizePolicy(
+            QSizePolicy.Policy.Expanding,
+            QSizePolicy.Policy.Expanding,
+        )
 
         cfg = QGridLayout()
         cfg.setHorizontalSpacing(10)
@@ -242,8 +259,12 @@ class TaskDetailsPage(QWidget):
         self._container.setTextInteractionFlags(Qt.TextSelectableByMouse)
         self._workdir.setTextInteractionFlags(Qt.TextSelectableByMouse)
 
+        self._novnc_label = QLabel("noVNC URL")
         self._novnc_url = QLabel("—")
         self._novnc_url.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self._opencode_web_url_label = QLabel("OpenCode Web URL")
+        self._opencode_web_url = QLabel("—")
+        self._opencode_web_url.setTextInteractionFlags(Qt.TextSelectableByMouse)
         self._agent_system = QLabel("—")
         self._agent_system.setTextInteractionFlags(Qt.TextSelectableByMouse)
 
@@ -254,16 +275,19 @@ class TaskDetailsPage(QWidget):
         cfg.addWidget(QLabel("Container ID"), self._container_row, 0)
         cfg.addWidget(self._container, self._container_row, 1)
         self._novnc_row = 2
-        cfg.addWidget(QLabel("noVNC URL"), self._novnc_row, 0)
+        cfg.addWidget(self._novnc_label, self._novnc_row, 0)
         cfg.addWidget(self._novnc_url, self._novnc_row, 1)
-        self._agent_system_row = 3
+        self._opencode_web_url_row = 3
+        cfg.addWidget(self._opencode_web_url_label, self._opencode_web_url_row, 0)
+        cfg.addWidget(self._opencode_web_url, self._opencode_web_url_row, 1)
+        self._agent_system_row = 4
         cfg.addWidget(QLabel("Agent System"), self._agent_system_row, 0)
         cfg.addWidget(self._agent_system, self._agent_system_row, 1)
 
         prompt_layout.addLayout(prompt_title_row)
         prompt_layout.addWidget(self._prompt, 1)
         prompt_layout.addLayout(cfg)
-        right_column.addWidget(prompt_card, 1)
+        right_column.addWidget(prompt_card)
 
         mid.addLayout(right_column, 2)
 
@@ -387,6 +411,14 @@ class TaskDetailsPage(QWidget):
         url = str(self._last_task.novnc_url or "").strip()
         task_id = str(self._last_task.task_id or self._current_task_id or "")
         self.launch_desktop_viewer_for_task(task_id=task_id, url=url)
+
+    def _launch_opencode_web(self) -> None:
+        """Open the stored OpenCode Web URL for the current task."""
+        if not self._last_task:
+            return
+        url = str(self._last_task.opencode_web_url or "").strip()
+        if url:
+            open_external_url(url)
 
     def launch_desktop_viewer_for_task(self, *, task_id: str, url: str) -> bool:
         """Launch viewer for a specific task noVNC URL."""
@@ -559,9 +591,7 @@ class TaskDetailsPage(QWidget):
         self._subtitle.setText(task.prompt_one_line())
         self._prompt.setPlainText(task.prompt)
         has_prompt = bool(str(task.prompt or "").strip())
-        self._prompt_title.setText("Prompt" if has_prompt else "Runtime Details")
-        self._btn_copy_prompt.setVisible(has_prompt)
-        self._prompt.setVisible(has_prompt)
+        self._sync_prompt_runtime_layout(has_prompt=has_prompt)
 
         # Show/hide Host Workdir based on workspace type
         is_cloned = task.workspace_type == WORKSPACE_CLONED
@@ -571,10 +601,10 @@ class TaskDetailsPage(QWidget):
             self._workdir.setText(task.host_workdir)
 
         self._container.setText(task.container_id or "—")
-        agent_label = get_agent_display_name(str(task.agent_cli or "").strip())
-        self._agent_system.setText(agent_label if agent_label.strip() else "—")
+        self._agent_system.setText(self._agent_system_label(task))
         self._tabs.setCurrentIndex(self._task_tab_index)
         self._sync_desktop_button(task)
+        self._sync_opencode_web_button(task)
         self._sync_artifacts(task)
         self._sync_container_actions(task)
         self._pending_log_lines.clear()
@@ -616,9 +646,9 @@ class TaskDetailsPage(QWidget):
             return
         self._last_task = task
         self._container.setText(task.container_id or "—")
-        agent_label = get_agent_display_name(str(task.agent_cli or "").strip())
-        self._agent_system.setText(agent_label if agent_label.strip() else "—")
+        self._agent_system.setText(self._agent_system_label(task))
         self._sync_desktop_button(task)
+        self._sync_opencode_web_button(task)
         self._sync_artifacts(task)
         self._sync_container_actions(task)
         self._exit.setText("—" if task.exit_code is None else str(task.exit_code))
@@ -639,6 +669,39 @@ class TaskDetailsPage(QWidget):
 
         self._desktop_btn.setVisible(should_show)
         self._novnc_url.setText(url if url else "—")
+        self._novnc_label.setVisible(bool(url))
+        self._novnc_url.setVisible(bool(url))
+
+    def _sync_opencode_web_button(self, task: Task) -> None:
+        url = str(task.opencode_web_url or "").strip()
+        self._opencode_web_btn.setVisible(bool(task.is_active() and url))
+        self._opencode_web_url.setText(url if url else "—")
+        self._opencode_web_url_label.setVisible(bool(url))
+        self._opencode_web_url.setVisible(bool(url))
+
+    def _sync_prompt_runtime_layout(self, *, has_prompt: bool) -> None:
+        self._prompt_title.setText("Prompt" if has_prompt else "Runtime Details")
+        self._btn_copy_prompt.setVisible(has_prompt)
+        self._prompt.setVisible(has_prompt)
+        if has_prompt:
+            self._prompt_card.setSizePolicy(
+                QSizePolicy.Policy.Expanding,
+                QSizePolicy.Policy.Expanding,
+            )
+            self._right_column.setStretch(1, 1)
+        else:
+            self._prompt_card.setSizePolicy(
+                QSizePolicy.Policy.Expanding,
+                QSizePolicy.Policy.Preferred,
+            )
+            self._right_column.setStretch(1, 0)
+        self._prompt_card.updateGeometry()
+
+    def _agent_system_label(self, task: Task) -> str:
+        if task.is_opencode_web_run():
+            return "OpenCode Web"
+        agent_label = get_agent_display_name(str(task.agent_cli or "").strip())
+        return agent_label if agent_label.strip() else "—"
 
     def _sync_artifacts(self, task: Task) -> None:
         """

--- a/agents_runner/ui/task_model.py
+++ b/agents_runner/ui/task_model.py
@@ -43,6 +43,7 @@ class Task:
     ide_display_target: str = ""
     headless_desktop_enabled: bool = False
     novnc_url: str = ""
+    opencode_web_url: str = ""
     vnc_password: str = ""
     artifacts: list[str] = field(default_factory=list)
     attempt_history: list[dict[str, object]] = field(default_factory=list)
@@ -78,9 +79,18 @@ class Task:
             end_s = float(now_s if now_s is not None else time.time())
         return max(0.0, end_s - created_s)
 
+    def is_opencode_web_run(self) -> bool:
+        launch_mode = str(self.launch_mode or "").strip().lower()
+        if launch_mode == "opencode_web":
+            return True
+        agent_cli = str(self.agent_cli or "").strip().lower()
+        return bool(
+            agent_cli == "opencode" and str(self.opencode_web_url or "").strip()
+        )
+
     def is_interactive_run(self) -> bool:
         launch_mode = str(self.launch_mode or "").strip().lower()
-        if launch_mode in {"interactive_agent", "interactive"}:
+        if launch_mode in {"interactive_agent", "interactive", "opencode_web"}:
             return True
         container_id = str(self.container_id or "")
         if container_id.startswith("agents-runner-tui-it-"):
@@ -96,6 +106,8 @@ class Task:
             return line
         if str(self.launch_mode or "").strip().lower() == "ide":
             return "Run IDE"
+        if self.is_opencode_web_run():
+            return "OpenCode Web"
         if self.is_interactive_run():
             return "Interactive"
         return "(empty prompt)"

--- a/agents_runner/ui/url_open.py
+++ b/agents_runner/ui/url_open.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import webbrowser
+
+from PySide6.QtCore import QUrl
+from PySide6.QtGui import QDesktopServices
+
+
+def open_external_url(url: str) -> bool:
+    """Open a URL with Qt first, then platform fallbacks."""
+    target = str(url or "").strip()
+    if not target:
+        return False
+
+    try:
+        if QDesktopServices.openUrl(QUrl(target)):
+            return True
+    except Exception:
+        pass
+
+    try:
+        if webbrowser.open(target):
+            return True
+    except Exception:
+        pass
+
+    opener = ""
+    if sys.platform == "darwin":
+        opener = shutil.which("open") or ""
+    elif sys.platform.startswith("linux"):
+        opener = shutil.which("xdg-open") or ""
+    if not opener:
+        return False
+
+    try:
+        subprocess.Popen(
+            [opener, target],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except Exception:
+        return False
+    return True


### PR DESCRIPTION
## Summary

This PR repairs the OpenCode Web interactive launch path so the task UI keeps enough state to reopen the web interface, avoids port collisions with user-configured publish specs, and waits for OpenCode Web to serve an actual HTTP response before opening the browser.

It also cleans up the Task Details OpenCode Web control by making the button text-only, matching the existing Desktop button. The Task Details UI is still visually a bit rough, but this keeps the functional cleanup focused on launch state, readiness, and the button treatment.

## What changed

- Added persisted `opencode_web_url` task state in `agents_runner/persistence.py`.
  - `serialize_task()` now writes the stored OpenCode Web URL.
  - `deserialize_task()` restores the URL so reopened/reloaded task details can still show and launch the web route.

- Taught task metadata to identify OpenCode Web runs in `agents_runner/ui/task_model.py`.
  - Added `Task.opencode_web_url`.
  - Added `Task.is_opencode_web_run()`.
  - Treats `launch_mode = "opencode_web"` as interactive.
  - Displays empty-prompt OpenCode Web runs as `OpenCode Web` instead of falling back to generic interactive/empty prompt text.

- Updated interactive launch setup in `agents_runner/ui/main_window_tasks_interactive.py`.
  - OpenCode Web launches now use `launch_mode = "opencode_web"`.
  - The task command is normalized to `opencode web` while the Docker launch path owns the resolved port/hostname command.

- Split OpenCode Web host helpers into `agents_runner/ui/opencode_web.py`.
  - Centralizes container port constants.
  - Provides local host port allocation.
  - Detects whether existing Docker publish specs already expose a container port.
  - Selects an alternate container port when the default OpenCode Web port `4096` would collide with environment/task publish specs.
  - Schedules browser opening after readiness.

- Reworked Docker interactive OpenCode Web launch in `agents_runner/ui/main_window_tasks_interactive_docker.py`.
  - Uses the shared OpenCode Web helper module instead of inline socket/browser code.
  - Stores `task.opencode_web_url` immediately after mapping the host port.
  - Logs the host-to-container OpenCode Web mapping.
  - Updates the dashboard/details/persistence after assigning the OpenCode Web URL.
  - Preserves Desktop/noVNC mapping when OpenCode Web is also active by extending Docker port args instead of replacing them.
  - Skips duplicate environment publish specs for whichever OpenCode Web container port is actually selected.
  - Runs `opencode web --port <resolved_container_port> --hostname 0.0.0.0` inside the container.

- Added shared external URL opening in `agents_runner/ui/url_open.py`.
  - Tries `QDesktopServices.openUrl()` first.
  - Falls back to Python `webbrowser`.
  - Falls back to platform openers such as `xdg-open` on Linux or `open` on macOS.
  - Returns a boolean so callers can log whether the host opener reported success.

- Updated Task Details UI in `agents_runner/ui/pages/task_details.py`.
  - Adds an `OpenCode Web` button for active tasks that have an OpenCode Web URL.
  - The OpenCode Web button is text-only, matching `Desktop`.
  - Adds an OpenCode Web URL row in runtime details.
  - Hides noVNC/OpenCode URL rows when no URL is available.
  - Uses the shared URL opener when the button is clicked.
  - Labels OpenCode Web task runs as `OpenCode Web`.
  - Tightens empty-prompt runtime layout so OpenCode Web runs show runtime details without a large blank prompt editor.

## Readiness behavior

The browser no longer opens just because a TCP socket accepts connections. `schedule_open_opencode_web_url()` now probes:

`GET http://127.0.0.1:<host_port>/`

Readiness rules:

- Transport failure, timeout, or curl-style `000` equivalent means "not ready".
- Any real HTTP status code from `100` through `599` means the server is ready enough to open.
- HTTP error statuses are still treated as real readiness because the web server is responding.
- The existing 10-minute retry timeout remains in place.
- Polling is faster after launch (`500ms`) so the browser opens soon after OpenCode Web starts serving.
- Logs now include:
  - waiting for HTTP readiness with the probed URL
  - the first real HTTP status code returned
  - timeout when no HTTP status is ever observed
  - whether opening the browser succeeded according to the host opener

## Empirical OpenCode check

Checked against PixelArch `opencode 1.15.3-1`:

- Installed with `yay -S --noconfirm --needed opencode`.
- `opencode --version` returned `1.15.3`.
- `opencode web --port <free_port> --hostname 127.0.0.1` stayed alive and logged a `Web interface: http://127.0.0.1:<port>/` URL.
- `GET /` returned `200 OK`.
- `HEAD /` also returned `200 OK`.
- The implementation uses `GET /` for readiness so it remains compatible if `HEAD` support changes.

## Verification

- `uv run ruff format .`
- `uv run ruff check .`
- `uv run python -m py_compile agents_runner/ui/opencode_web.py agents_runner/ui/pages/task_details.py`
- `git diff --check`
- Closed-port readiness helper probe returned `None`.
- Live `opencode web` readiness helper probe returned `200`.

## Files changed

- `agents_runner/persistence.py`
- `agents_runner/ui/main_window_tasks_interactive.py`
- `agents_runner/ui/main_window_tasks_interactive_docker.py`
- `agents_runner/ui/opencode_web.py`
- `agents_runner/ui/pages/task_details.py`
- `agents_runner/ui/task_model.py`
- `agents_runner/ui/url_open.py`

## Notes

- This PR intentionally does not attempt a broader Task Details visual redesign. The UI still has some rough edges, but the functional surface is now cleaner: persisted URL state, a text-only OpenCode Web button, narrower runtime rows, and HTTP readiness before browser launch.
- No task files were moved, so the project version was not bumped.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
