### PR TITLE
Interactive task upgrades: OpenCode Web/Ask, storage, port guard

### DIFF
--- a/agents_runner/tests/test_opencode_env_cli_flags.py
+++ b/agents_runner/tests/test_opencode_env_cli_flags.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from agents_runner.environments import Environment
+from agents_runner.environments import WORKSPACE_NONE
+from agents_runner.environments.model import AgentInstance
+from agents_runner.environments.model import AgentSelection
+from agents_runner.execution.supervisor import SupervisorConfig
+from agents_runner.execution.supervisor import TaskSupervisor
+from agents_runner.terminal_apps import TerminalOption
+from agents_runner.ui.main_window_environment import MainWindowEnvironmentMixin
+from agents_runner.ui.main_window_settings import MainWindowSettingsMixin
+from agents_runner.ui.main_window_tasks_agent import MainWindowTasksAgentMixin
+from agents_runner.ui.main_window_tasks_interactive import (
+    MainWindowTasksInteractiveMixin,
+)
+import agents_runner.ui.main_window_tasks_interactive as interactive_module
+
+
+class _FakeSignal:
+    def connect(self, *_args, **_kwargs) -> None:
+        return
+
+
+class _FakeThread:
+    def __init__(self, _parent=None) -> None:
+        self.started = _FakeSignal()
+        self.finished = _FakeSignal()
+
+    def start(self) -> None:
+        return
+
+    def quit(self) -> None:
+        return
+
+    def deleteLater(self) -> None:
+        return
+
+
+class _CapturingPrepWorker:
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = dict(kwargs)
+        self.stage = _FakeSignal()
+        self.log = _FakeSignal()
+        self.succeeded = _FakeSignal()
+        self.failed = _FakeSignal()
+
+    def moveToThread(self, _thread) -> None:
+        return
+
+    def run(self) -> None:
+        return
+
+    def deleteLater(self) -> None:
+        return
+
+
+class _FakePrepBridge:
+    def __init__(self, **_kwargs) -> None:
+        return
+
+    def on_stage(self, *_args, **_kwargs) -> None:
+        return
+
+    def on_log(self, *_args, **_kwargs) -> None:
+        return
+
+    def on_succeeded(self, *_args, **_kwargs) -> None:
+        return
+
+    def on_failed(self, *_args, **_kwargs) -> None:
+        return
+
+    def deleteLater(self) -> None:
+        return
+
+
+class _FakeMessageBox:
+    @staticmethod
+    def critical(*_args, **_kwargs) -> None:
+        return
+
+    @staticmethod
+    def warning(*_args, **_kwargs) -> None:
+        return
+
+    @staticmethod
+    def information(*_args, **_kwargs) -> None:
+        return
+
+
+@dataclass
+class _DummyDashboard:
+    last_task_id: str | None = None
+
+    def upsert_task(self, task, *, stain=None, spinner_color=None) -> None:
+        del stain, spinner_color
+        self.last_task_id = task.task_id
+
+    def remove_tasks(self, _task_ids) -> None:
+        return
+
+    def upsert_past_task(self, *_args, **_kwargs) -> None:
+        return
+
+
+class _DummyNewTask:
+    def reset_for_new_run(self) -> None:
+        return
+
+    def set_agent_info(self, agent: str, next_agent: str = "") -> None:
+        del agent, next_agent
+        return
+
+
+class _DummyMainWindowInteractive(
+    MainWindowEnvironmentMixin,
+    MainWindowSettingsMixin,
+    MainWindowTasksInteractiveMixin,
+):
+    def __init__(self, env: Environment, tmp_path: Path, workdir: Path) -> None:
+        self._settings_data = {
+            "use": "codex",
+            "append_pixelarch_context": False,
+            "preflight_enabled": False,
+            "preflight_script": "",
+        }
+        self._environments = {env.env_id: env}
+        self._tasks: dict[str, object] = {}
+        self._interactive_prep_context: dict[str, object] = {}
+        self._interactive_prep_workers: dict[str, object] = {}
+        self._interactive_prep_threads: dict[str, object] = {}
+        self._interactive_prep_bridges: dict[str, object] = {}
+        self._dashboard = _DummyDashboard()
+        self._new_task = _DummyNewTask()
+        self._state_path = str(tmp_path / "state.toml")
+        self._workdir = str(workdir)
+
+    def _active_environment_id(self) -> str:
+        return next(iter(self._environments.keys()))
+
+    def _new_task_workspace(self, _env, *, task_id: str) -> tuple[str, bool, str]:
+        del task_id
+        return self._workdir, True, ""
+
+    def _schedule_save(self) -> None:
+        return
+
+    def _maybe_auto_navigate_on_task_start(self, *, interactive: bool) -> None:
+        del interactive
+        return
+
+    def _on_task_log(self, _task_id: str, _line: str) -> None:
+        return
+
+    def _refresh_new_task_agent_info(self) -> None:
+        return
+
+    def _apply_environment_tints(self) -> None:
+        return
+
+
+class _DummyMainWindowAgent(
+    MainWindowEnvironmentMixin,
+    MainWindowSettingsMixin,
+    MainWindowTasksAgentMixin,
+):
+    def __init__(self, env: Environment, tmp_path: Path, workdir: Path) -> None:
+        self._settings_data = {
+            "use": "codex",
+            "append_pixelarch_context": False,
+            "preflight_enabled": False,
+            "preflight_script": "",
+        }
+        self._environments = {env.env_id: env}
+        self._tasks: dict[str, object] = {}
+        self._threads: dict[str, object] = {}
+        self._bridges: dict[str, object] = {}
+        self._run_started_s: dict[str, float] = {}
+        self._dashboard_log_refresh_s: dict[str, float] = {}
+        self._watch_states: dict[str, object] = {}
+        self._dashboard = _DummyDashboard()
+        self._new_task = _DummyNewTask()
+        self._state_path = str(tmp_path / "state.toml")
+        self._workdir = str(workdir)
+
+    def _active_environment_id(self) -> str:
+        return next(iter(self._environments.keys()))
+
+    def _new_task_workspace(self, _env, *, task_id: str) -> tuple[str, bool, str]:
+        del task_id
+        return self._workdir, True, ""
+
+    def _schedule_save(self) -> None:
+        return
+
+    def _maybe_auto_navigate_on_task_start(self, *, interactive: bool) -> None:
+        del interactive
+        return
+
+    def _on_task_log(self, _task_id: str, _line: str) -> None:
+        return
+
+    def _refresh_new_task_agent_info(self) -> None:
+        return
+
+    def _can_start_new_agent_for_env(self, _env_id: str | None) -> bool:
+        return False
+
+
+def test_selected_environment_agent_cli_flags_reach_interactive_launch(
+    monkeypatch, tmp_path
+) -> None:
+    workdir = tmp_path / "workspace"
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    env = Environment(
+        env_id="env-opencode",
+        name="OpenCode",
+        workspace_type=WORKSPACE_NONE,
+        workspace_target=str(workdir),
+    )
+    env.agent_selection = AgentSelection(
+        agents=[
+            AgentInstance(
+                agent_id="opencode-plan",
+                agent_cli="opencode",
+                config_dir="",
+                cli_flags="--agent plan",
+            ),
+            AgentInstance(
+                agent_id="codex-default",
+                agent_cli="codex",
+                config_dir="",
+                cli_flags="",
+            ),
+        ],
+        selection_mode="pinned",
+        pinned_agent_id="opencode-plan",
+        agent_fallbacks={},
+    )
+
+    window = _DummyMainWindowInteractive(env, tmp_path, workdir)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    terminal_option = TerminalOption(
+        terminal_id="test-terminal",
+        label="Test",
+        kind="linux-exe",
+        exe="/bin/true",
+    )
+
+    monkeypatch.setattr(
+        interactive_module,
+        "detect_terminal_options",
+        lambda: [terminal_option],
+    )
+    monkeypatch.setattr(
+        interactive_module.shutil,
+        "which",
+        lambda name: "/usr/bin/docker" if name == "docker" else None,
+    )
+    monkeypatch.setattr(interactive_module, "QMessageBox", _FakeMessageBox)
+    monkeypatch.setattr(
+        interactive_module, "InteractivePrepWorker", _CapturingPrepWorker
+    )
+    monkeypatch.setattr(interactive_module, "InteractivePrepBridge", _FakePrepBridge)
+    monkeypatch.setattr(interactive_module, "QThread", _FakeThread)
+    monkeypatch.setattr(interactive_module, "is_gh_available", lambda: False)
+
+    window._start_interactive_task_from_ui(
+        prompt="hello",
+        command="opencode",
+        host_config_dir="",
+        env_id=env.env_id,
+        terminal_id="test-terminal",
+        base_branch="",
+        agent_override=None,
+        extra_preflight_script="",
+    )
+
+    task_id = window._dashboard.last_task_id
+    assert task_id is not None
+    task = window._tasks[task_id]
+    assert task.agent_cli == "opencode"
+    assert task.agent_instance_id == "opencode-plan"
+    assert task.agent_cli_args == "--agent plan"
+
+    worker = window._interactive_prep_workers[task_id]
+    assert worker.kwargs.get("agent_cli") == "opencode"
+    assert worker.kwargs.get("agent_cli_args") == ["--agent", "plan"]
+
+
+def test_selected_environment_agent_cli_flags_reach_run_agent_launch(
+    monkeypatch, tmp_path
+) -> None:
+    workdir = tmp_path / "workspace"
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    env = Environment(
+        env_id="env-opencode",
+        name="OpenCode",
+        workspace_type=WORKSPACE_NONE,
+        workspace_target=str(workdir),
+    )
+    env.agent_selection = AgentSelection(
+        agents=[
+            AgentInstance(
+                agent_id="opencode-plan",
+                agent_cli="opencode",
+                config_dir="",
+                cli_flags="--agent plan",
+            )
+        ],
+        selection_mode="pinned",
+        pinned_agent_id="opencode-plan",
+        agent_fallbacks={},
+    )
+
+    window = _DummyMainWindowAgent(env, tmp_path, workdir)
+    monkeypatch.setattr(
+        "agents_runner.ui.main_window_tasks_agent.shutil.which",
+        lambda name: "/usr/bin/docker" if name == "docker" else None,
+    )
+    monkeypatch.setattr(
+        "agents_runner.ui.main_window_tasks_agent.QMessageBox",
+        _FakeMessageBox,
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    task_id = window._start_task_from_ui(
+        prompt="hello",
+        host_config_dir="",
+        env_id=env.env_id,
+        base_branch="",
+        pr_context=None,
+        agent_override=None,
+    )
+    assert task_id is not None
+    task = window._tasks[task_id]
+    assert task.agent_cli == "opencode"
+    assert task.agent_instance_id == "opencode-plan"
+    selection = getattr(task, "_agent_selection", None)
+    assert selection is not None
+    assert selection.agents[0].cli_flags == "--agent plan"
+
+    config = getattr(task, "_runner_config", None)
+    assert config is not None
+    supervisor = TaskSupervisor(
+        config=config,
+        prompt="hello",
+        agent_selection=selection,
+        supervisor_config=SupervisorConfig(
+            max_retries_per_agent=0,
+            enable_fallback=True,
+        ),
+        on_state=lambda _state: None,
+        on_log=lambda _line: None,
+        on_retry=lambda _attempt, _agent, _delay: None,
+        on_agent_switch=lambda _from_agent, _to_agent: None,
+        on_done=None,
+        watch_states={},
+    )
+
+    agent_config = supervisor._build_agent_config(selection.agents[0])
+    assert agent_config.agent_cli_args == ["--agent", "plan"]

--- a/agents_runner/ui/main_window_tasks_interactive.py
+++ b/agents_runner/ui/main_window_tasks_interactive.py
@@ -269,6 +269,26 @@ class MainWindowTasksInteractiveMixin(_MainWindowHints):
                     advance_round_robin=False,
                 )
             )
+            if agent_instance_id:
+                selected_lower = agent_instance_id.lower()
+                selected_inst = next(
+                    (
+                        inst
+                        for inst in list(
+                            getattr(env.agent_selection, "agents", []) or []
+                        )
+                        if str(getattr(inst, "agent_id", "") or "").strip()
+                        == agent_instance_id
+                        or str(getattr(inst, "agent_id", "") or "").strip().lower()
+                        == selected_lower
+                    ),
+                    None,
+                )
+                selected_cli_flags = (
+                    str(getattr(selected_inst, "cli_flags", "") or "").strip()
+                    if selected_inst is not None
+                    else ""
+                )
         else:
             agent_cli, auto_config_dir = self._effective_agent_and_config(
                 env=env, advance_round_robin=True
@@ -281,7 +301,7 @@ class MainWindowTasksInteractiveMixin(_MainWindowHints):
         if override and not agent_instance_id:
             agent_instance_id = str(agent_cli or "").strip()
 
-        if override and selected_cli_flags:
+        if selected_cli_flags:
             try:
                 agent_cli_args = shlex.split(selected_cli_flags)
             except ValueError as exc:

--- a/agents_runner/ui/pages/environments_agents.py
+++ b/agents_runner/ui/pages/environments_agents.py
@@ -312,24 +312,20 @@ class AgentsTabWidget(QWidget):
 
     def _priority_widget(self, row_index: int) -> QWidget:
         w = QWidget()
-        layout = QHBoxLayout(w)
+        layout = QVBoxLayout(w)
         layout.setContentsMargins(4, 2, 4, 2)
-        layout.setSpacing(8)
+        layout.setSpacing(2)
 
         up_btn = QToolButton()
-        up_btn.setText("Up")
         up_btn.setArrowType(Qt.ArrowType.UpArrow)
-        up_btn.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
-        up_btn.setMinimumWidth(68)
+        up_btn.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
         up_btn.setEnabled(row_index > 0)
         up_btn.setToolTip("Move up (higher priority)")
         up_btn.clicked.connect(lambda: self._move_row(row_index, -1))
 
         down_btn = QToolButton()
-        down_btn.setText("Down")
         down_btn.setArrowType(Qt.ArrowType.DownArrow)
-        down_btn.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
-        down_btn.setMinimumWidth(68)
+        down_btn.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
         down_btn.setEnabled(row_index < len(self._rows) - 1)
         down_btn.setToolTip("Move down (lower priority)")
         down_btn.clicked.connect(lambda: self._move_row(row_index, 1))

--- a/agents_runner/ui/pages/environments_agents.py
+++ b/agents_runner/ui/pages/environments_agents.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import re
 
+from PySide6.QtCore import QSize
 from PySide6.QtCore import Qt
 from PySide6.QtCore import Signal
 from PySide6.QtWidgets import QCheckBox
@@ -314,19 +315,28 @@ class AgentsTabWidget(QWidget):
     def _priority_widget(self, row_index: int) -> QWidget:
         w = QWidget()
         layout = QVBoxLayout(w)
-        layout.setContentsMargins(4, 2, 4, 2)
+        layout.setContentsMargins(4, 1, 4, 1)
         layout.setSpacing(2)
 
+        btn_size = QSize(28, 26)
+        icon_size = QSize(18, 18)
+
         up_btn = QToolButton()
-        up_btn.setIcon(lucide_icon("arrow-up"))
+        up_btn.setIcon(lucide_icon("arrow-up", size=18))
         up_btn.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
+        up_btn.setFixedSize(btn_size)
+        up_btn.setIconSize(icon_size)
+        up_btn.setStyleSheet("padding: 0px;")
         up_btn.setEnabled(row_index > 0)
         up_btn.setToolTip("Move up (higher priority)")
         up_btn.clicked.connect(lambda: self._move_row(row_index, -1))
 
         down_btn = QToolButton()
-        down_btn.setIcon(lucide_icon("arrow-down"))
+        down_btn.setIcon(lucide_icon("arrow-down", size=18))
         down_btn.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
+        down_btn.setFixedSize(btn_size)
+        down_btn.setIconSize(icon_size)
+        down_btn.setStyleSheet("padding: 0px;")
         down_btn.setEnabled(row_index < len(self._rows) - 1)
         down_btn.setToolTip("Move down (lower priority)")
         down_btn.clicked.connect(lambda: self._move_row(row_index, 1))

--- a/agents_runner/ui/pages/environments_agents.py
+++ b/agents_runner/ui/pages/environments_agents.py
@@ -341,8 +341,10 @@ class AgentsTabWidget(QWidget):
         down_btn.setToolTip("Move down (lower priority)")
         down_btn.clicked.connect(lambda: self._move_row(row_index, 1))
 
-        layout.addWidget(up_btn)
-        layout.addWidget(down_btn)
+        layout.addStretch(1)
+        layout.addWidget(up_btn, 0, Qt.AlignmentFlag.AlignHCenter)
+        layout.addWidget(down_btn, 0, Qt.AlignmentFlag.AlignHCenter)
+        layout.addStretch(1)
         return w
 
     def _move_row(self, row_index: int, delta: int) -> None:

--- a/agents_runner/ui/pages/environments_agents.py
+++ b/agents_runner/ui/pages/environments_agents.py
@@ -32,6 +32,7 @@ from agents_runner.ui.constants import (
     AGENT_COMBO_WIDTH,
 )
 from agents_runner.ui.dialogs.test_chain_dialog import TestChainDialog
+from agents_runner.ui.lucide_icons import lucide_icon
 
 
 _ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
@@ -317,14 +318,14 @@ class AgentsTabWidget(QWidget):
         layout.setSpacing(2)
 
         up_btn = QToolButton()
-        up_btn.setArrowType(Qt.ArrowType.UpArrow)
+        up_btn.setIcon(lucide_icon("arrow-up"))
         up_btn.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
         up_btn.setEnabled(row_index > 0)
         up_btn.setToolTip("Move up (higher priority)")
         up_btn.clicked.connect(lambda: self._move_row(row_index, -1))
 
         down_btn = QToolButton()
-        down_btn.setArrowType(Qt.ArrowType.DownArrow)
+        down_btn.setIcon(lucide_icon("arrow-down"))
         down_btn.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
         down_btn.setEnabled(row_index < len(self._rows) - 1)
         down_btn.setToolTip("Move down (lower priority)")


### PR DESCRIPTION
This branch is a roll-up of multiple feature/fix PRs not yet on `main`.

Highlights

- Remove IDE run mode end-to-end
  - Drops the IDE systems/plugin registry and IDE-specific run plumbing.
  - Simplifies Docker worker/container setup while keeping desktop Agent + Interactive flows.

- OpenCode launch modes
  - Adds an OpenCode Web launch mode for interactive Docker tasks.
  - Fixes the OpenCode Web task UI and adds robust URL opening helpers.
  - Waits for the OpenCode Web HTTP endpoint to become ready before attempting to open.
  - Adds an OpenCode Ask launch mode.

- Pre-launch port conflict guard
  - Detects host port conflicts before launching tasks.
  - Provides a remap/cancel prompt flow (replacing the earlier modal dialog).

- Task workspace storage controls + cleanup
  - Adds configurable task workspace storage controls and a new task workspace manager.
  - Adds workspace migration support and improves retained-workspace cleanup handling.
  - Moves potentially expensive workspace checks off the UI thread.
  - Streams retained workspace cleanup work and softens Scratch storage status messaging.

- GitHub permissions/read-only handling
  - Detects whether PR operations are read-only and adapts task flows accordingly.
  - Introduces a GitHub permissions helper module and updates recommendation prompt handling.

- Task log stream performance
  - Normalizes task log streaming and batches UI appends to reduce overhead.

- UI/typing correctness + DX
  - Adds TYPE_CHECKING-only mixin “contracts” for UI mixins, reducing basedpyright unknown-attribute noise.
  - Updates PySide6 usage to scoped enums across the UI and fixes Qt event typing in overrides.
  - Cleans up typing issues in highlighters/third-party integrations.
  - Improves Environment Agents priority controls (stacked Lucide arrows, sizing, centering).
  - Adds a `.agents/scripts/test` wrapper to unset container `PYTHONOPTIMIZE=2` for correct pytest/assert behavior.
  - Updates `AGENTS.md` test command guidance and bumps version to `0.1.0.55`.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode](https://github.com/anomalyco/opencode)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
