### PR TITLE
Fix agent config defaults on state load + agent config list UX improv...

### DIFF
--- a/agents_runner/agent_configs/storage.py
+++ b/agents_runner/agent_configs/storage.py
@@ -3,60 +3,12 @@ import tempfile
 
 from typing import Any
 
-import tomli
 import tomli_w
 
-from agents_runner.persistence import STATE_VERSION
+from agents_runner.persistence import load_state
 from agents_runner.persistence import strip_none_for_toml
 
 from .model import AgentConfig
-
-
-def _load_state_payload(state_path: str) -> dict[str, Any]:
-    path = str(state_path or "").strip()
-    if not path or not os.path.exists(path):
-        return {
-            "version": STATE_VERSION,
-            "tasks": [],
-            "settings": {},
-            "environments": [],
-        }
-    try:
-        with open(path, "rb") as f:
-            payload = tomli.load(f)
-    except Exception:
-        return {
-            "version": STATE_VERSION,
-            "tasks": [],
-            "settings": {},
-            "environments": [],
-        }
-    if not isinstance(payload, dict):
-        return {
-            "version": STATE_VERSION,
-            "tasks": [],
-            "settings": {},
-            "environments": [],
-        }
-    version = payload.get("version")
-    if version != STATE_VERSION:
-        return {
-            "version": STATE_VERSION,
-            "tasks": [],
-            "settings": {},
-            "environments": [],
-        }
-    payload.setdefault("version", STATE_VERSION)
-    payload.setdefault("tasks", [])
-    payload.setdefault("settings", {})
-    payload.setdefault("environments", [])
-    if not isinstance(payload["tasks"], list):
-        payload["tasks"] = []
-    if not isinstance(payload["settings"], dict):
-        payload["settings"] = {}
-    if not isinstance(payload["environments"], list):
-        payload["environments"] = []
-    return payload
 
 
 def _atomic_write_state_payload(state_path: str, payload: dict[str, Any]) -> None:
@@ -86,7 +38,7 @@ def _as_dict(value: object) -> dict[str, object] | None:
 
 
 def load_agent_configs(state_path: str) -> list[AgentConfig]:
-    payload = _load_state_payload(state_path)
+    payload = load_state(state_path)
     raw = payload.get("agent_configs")
     if not isinstance(raw, list):
         return []
@@ -132,7 +84,7 @@ def save_agent_config(state_path: str, config: AgentConfig) -> None:
     if not config_id:
         return
 
-    payload = _load_state_payload(state_path)
+    payload = load_state(state_path)
     raw_configs = payload.get("agent_configs")
     items: list[dict[str, Any]] = []
     if isinstance(raw_configs, list):
@@ -162,7 +114,7 @@ def delete_agent_config(state_path: str, config_id: str) -> None:
     if not target:
         return
 
-    payload = _load_state_payload(state_path)
+    payload = load_state(state_path)
     raw_configs = payload.get("agent_configs")
     if not isinstance(raw_configs, list) or not raw_configs:
         return

--- a/agents_runner/ui/main_window.py
+++ b/agents_runner/ui/main_window.py
@@ -286,6 +286,9 @@ class MainWindow(
         self._envs_page.updated.connect(
             self._reload_environments, Qt.ConnectionType.QueuedConnection
         )
+        self._envs_page.updated.connect(
+            self.refresh_agent_config_usage_counts, Qt.ConnectionType.QueuedConnection
+        )
         self._envs_page.test_preflight_requested.connect(
             self._on_environment_test_preflight, Qt.ConnectionType.QueuedConnection
         )

--- a/agents_runner/ui/main_window_settings.py
+++ b/agents_runner/ui/main_window_settings.py
@@ -538,6 +538,11 @@ class MainWindowSettingsMixin(_MainWindowHints):
             if (config_id := str(getattr(config, "config_id", "") or "").strip())
         }
 
+    def refresh_agent_config_usage_counts(self) -> None:
+        page = getattr(self, "_settings", None)
+        if page is not None and hasattr(page, "_refresh_agent_configs_list"):
+            page._refresh_agent_configs_list()
+
     @staticmethod
     def _find_agent_instance_by_id(
         env: Environment | None, agent_id: str

--- a/agents_runner/ui/pages/settings_form.py
+++ b/agents_runner/ui/pages/settings_form.py
@@ -245,6 +245,9 @@ class SettingsFormMixin:
         self._agent_configs_list.itemDoubleClicked.connect(
             lambda _item=None: self._on_agent_configs_edit_clicked()
         )
+        self._agent_configs_list.setStyleSheet(
+            "QListWidget::item:selected { background-color: rgba(148, 163, 184, 50); }"
+        )
 
         self._agent_configs_add = QToolButton()
         self._agent_configs_add.setText("Add")

--- a/agents_runner/ui/pages/settings_form.py
+++ b/agents_runner/ui/pages/settings_form.py
@@ -1009,10 +1009,27 @@ class SettingsFormMixin:
         layout.setContentsMargins(8, 6, 8, 6)
         layout.setSpacing(2)
 
+        title_row = QHBoxLayout()
+        title_row.setContentsMargins(0, 0, 0, 0)
+        title_row.setSpacing(0)
+
         title = QLabel(str(getattr(config, "config_id", "") or "").strip())
         title.setStyleSheet(
             "font-size: 12px; font-weight: 650; color: rgba(237, 239, 245, 230);"
         )
+
+        config_id = str(getattr(config, "config_id", "") or "").strip()
+        count = (usage_counts or {}).get(config_id, 0)
+        if count > 0:
+            usage = QLabel(f"{count} Env")
+            usage.setStyleSheet("font-size: 10px; color: rgba(129, 199, 132, 220);")
+        else:
+            usage = QLabel("0 Env")
+            usage.setStyleSheet("font-size: 10px; color: rgba(255, 183, 77, 220);")
+        usage.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+
+        title_row.addWidget(title)
+        title_row.addWidget(usage, 1)
 
         agent_cli = str(getattr(config, "agent_cli", "") or "").strip()
         config_dir = str(getattr(config, "config_dir", "") or "").strip()
@@ -1028,18 +1045,8 @@ class SettingsFormMixin:
         detail.setObjectName("SettingsPaneSubtitle")
         detail.setWordWrap(True)
 
-        layout.addWidget(title)
+        layout.addLayout(title_row)
         layout.addWidget(detail)
-
-        config_id = str(getattr(config, "config_id", "") or "").strip()
-        count = (usage_counts or {}).get(config_id, 0)
-        if count > 0:
-            usage = QLabel(f"{count} Env")
-            usage.setStyleSheet("font-size: 10px; color: rgba(129, 199, 132, 220);")
-        else:
-            usage = QLabel("0 Env")
-            usage.setStyleSheet("font-size: 10px; color: rgba(255, 183, 77, 220);")
-        layout.addWidget(usage)
 
         return row
 

--- a/agents_runner/ui/pages/settings_form.py
+++ b/agents_runner/ui/pages/settings_form.py
@@ -914,6 +914,24 @@ class SettingsFormMixin:
             return state_path
         return default_state_path()
 
+    def _agent_config_usage_counts(self) -> dict[str, int]:
+        state_path = self._resolve_state_path()
+        counts: dict[str, int] = {}
+        try:
+            configs = load_agent_configs(state_path)
+        except Exception:
+            configs = []
+        for cfg in configs:
+            config_id = str(getattr(cfg, "config_id", "") or "").strip()
+            if not config_id:
+                continue
+            try:
+                refs = find_envs_referencing_config(state_path, config_id)
+            except Exception:
+                refs = []
+            counts[config_id] = len(refs)
+        return counts
+
     def _refresh_agent_configs_list(self, *, select_config_id: str = "") -> None:
         if not hasattr(self, "_agent_configs_list"):
             return
@@ -935,6 +953,8 @@ class SettingsFormMixin:
             if str(getattr(cfg, "config_id", "") or "").strip()
         }
 
+        usage_counts = self._agent_config_usage_counts()
+
         self._agent_configs_list.clear()
         if not configs:
             empty = QListWidgetItem("No agent configs saved.")
@@ -947,7 +967,9 @@ class SettingsFormMixin:
         for index, cfg in enumerate(configs):
             item = QListWidgetItem()
             item.setData(Qt.ItemDataRole.UserRole, str(cfg.config_id or ""))
-            widget = self._create_agent_config_row_widget(cfg)
+            widget = self._create_agent_config_row_widget(
+                cfg, usage_counts=usage_counts
+            )
             item.setSizeHint(widget.sizeHint())
             self._agent_configs_list.addItem(item)
             self._agent_configs_list.setItemWidget(item, widget)
@@ -979,7 +1001,9 @@ class SettingsFormMixin:
         if hasattr(self, "_agent_configs_delete"):
             self._agent_configs_delete.setEnabled(selected)
 
-    def _create_agent_config_row_widget(self, config: AgentConfig) -> QWidget:
+    def _create_agent_config_row_widget(
+        self, config: AgentConfig, *, usage_counts: dict[str, int] | None = None
+    ) -> QWidget:
         row = QWidget(self._agent_configs_list)
         layout = QVBoxLayout(row)
         layout.setContentsMargins(8, 6, 8, 6)
@@ -1006,6 +1030,17 @@ class SettingsFormMixin:
 
         layout.addWidget(title)
         layout.addWidget(detail)
+
+        config_id = str(getattr(config, "config_id", "") or "").strip()
+        count = (usage_counts or {}).get(config_id, 0)
+        if count > 0:
+            usage = QLabel(f"{count} Env")
+            usage.setStyleSheet("font-size: 10px; color: rgba(129, 199, 132, 220);")
+        else:
+            usage = QLabel("0 Env")
+            usage.setStyleSheet("font-size: 10px; color: rgba(255, 183, 77, 220);")
+        layout.addWidget(usage)
+
         return row
 
     def _on_agent_configs_add_clicked(self) -> None:


### PR DESCRIPTION
### Summary
Four changes across 4 files (60 insertions, 55 deletions).

### What changed

#### 1. Fix duplicated state payload loading (storage.py)
- Replaced the private `_load_state_payload` function (48 lines) with a single call to the canonical `load_state` from `persistence.py`
- `_load_state_payload` was missing the `agent_configs` default (`payload.setdefault("agent_configs", [])`), which the canonical `load_state` correctly provides
- This caused agent configs to not be properly loaded/available in environments that hadn't been saved recently

#### 2. Agent config environment usage count (settings_form.py + main_window_settings.py + main_window.py)
- Added `_agent_config_usage_counts()` method that calls `find_envs_referencing_config` for each config to count how many environments reference it
- Modified `_create_agent_config_row_widget` to accept `usage_counts` and display a usage label:
  - `X Env` in green (rgba(129, 199, 132, 220)) when 1+ environments reference the config
  - `0 Env` in amber (rgba(255, 183, 77, 220)) when no environment references it
- Usage label is right-aligned in the title row (top-right of each config card)
- Added public `refresh_agent_config_usage_counts()` method to main_window_settings.py
- Wired `_envs_page.updated` signal in main_window.py to trigger usage count refresh whenever environments are saved

#### 3. Dark slate selection highlight for agent config list (settings_form.py)
- Added `QListWidget::item:selected { background-color: rgba(148, 163, 184, 50); }` stylesheet to `_agent_configs_list`
- Replaces the default white/light Qt palette highlight with a dark slate tint matching the app's slate accent color

### Diff stat
```
agents_runner/agent_configs/storage.py   | 56 +++-----------------------------
agents_runner/ui/main_window.py          |  3 ++
agents_runner/ui/main_window_settings.py |  5 +++
agents_runner/ui/pages/settings_form.py  | 51 +++++++++++++++++++++++++++--
4 files changed, 60 insertions(+), 55 deletions(-)
```

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode](https://github.com/anomalyco/opencode)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
