### PR TITLE
Agent config dialog: live theme switch on CLI change

### DIFF
--- a/agents_runner/ui/dialogs/agent_config_dialog.py
+++ b/agents_runner/ui/dialogs/agent_config_dialog.py
@@ -24,6 +24,7 @@ from agents_runner.agent_systems.registry import available_agent_system_names
 from agents_runner.agent_systems.status import command_in_path
 from agents_runner.opencode_models import opencode_model_options_by_provider
 from agents_runner.persistence import default_state_path
+from agents_runner.ui.graphics import _theme_name_for_agent
 from agents_runner.ui.dialogs.themed_dialog import ThemedDialog
 
 
@@ -204,6 +205,9 @@ class AgentConfigDialog(ThemedDialog):
 
     def _on_agent_cli_changed(self, _index: int) -> None:
         self._update_opencode_fields_visibility()
+        agent_cli = str(self._agent_cli.currentData() or "").strip().lower()
+        if agent_cli:
+            self._root.set_theme_name(_theme_name_for_agent(agent_cli))
         if self._editing:
             return
         if str(self._config_id.text() or "").strip():


### PR DESCRIPTION
When the user changes the agent CLI in the agent config dialog, the
animated background now crossfades live to match that agent's theme.
Previously the dialog inherited the app's current theme unconditionally.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode](https://github.com/anomalyco/opencode) --agent plan --model deepseek/deepseek-v4-pro --variant max
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
