### PR TITLE
Fix: Differentiate OpenCode TUI vs Web in PR attribution footer

### DIFF
--- a/agents_runner/agent_display.py
+++ b/agents_runner/agent_display.py
@@ -8,6 +8,8 @@ AGENT_DISPLAY_NAMES = {
     "copilot": "Github Copilot",
     "gemini": "Google Gemini",
     "opencode": "OpenCode",
+    "opencode-tui": "OpenCode TUI",
+    "opencode-web": "OpenCode Web",
     "qwen": "Qwen",
 }
 
@@ -17,6 +19,8 @@ AGENT_GITHUB_URLS = {
     "copilot": "https://github.com/github/copilot-cli",
     "gemini": "https://github.com/google-gemini/gemini-cli",
     "opencode": "https://github.com/anomalyco/opencode",
+    "opencode-tui": "https://github.com/anomalyco/opencode",
+    "opencode-web": "https://github.com/anomalyco/opencode",
     "qwen": "https://github.com/QwenLM/qwen-code",
 }
 

--- a/agents_runner/gh/task_plan.py
+++ b/agents_runner/gh/task_plan.py
@@ -7,6 +7,7 @@ from datetime import UTC
 from datetime import datetime
 
 from ..agent_display import format_agent_markdown_link
+from ..agent_display import get_agent_github_url
 from ..environments.model import GH_BRANCH_WORK_MODE_DIRECT_BASE
 from ..environments.model import GH_BRANCH_WORK_MODE_TASK_BRANCH
 from ..environments.model import GH_TASK_BRANCH_CUSTOM_TEMPLATE_DEFAULT
@@ -95,7 +96,10 @@ _BRANCH_THEME_TOKENS: dict[str, tuple[str, ...]] = {
 
 
 def _append_pr_attribution_footer(
-    body: str, agent_cli: str = "", agent_cli_args: str = ""
+    body: str,
+    agent_cli: str = "",
+    agent_cli_args: str = "",
+    agent_display_name: str | None = None,
 ) -> str:
     body = (body or "").rstrip()
     if _PR_ATTRIBUTION_MARKER in body:
@@ -105,7 +109,14 @@ def _append_pr_attribution_footer(
     agent_args = agent_cli_args.strip()
 
     if agent_cli_name:
-        agent_link = format_agent_markdown_link(agent_cli_name)
+        if agent_display_name:
+            github_url = get_agent_github_url(agent_cli_name)
+            if github_url:
+                agent_link = f"[{agent_display_name}]({github_url})"
+            else:
+                agent_link = agent_display_name
+        else:
+            agent_link = format_agent_markdown_link(agent_cli_name)
         if agent_args:
             agent_used = f"{agent_link} {agent_args}"
         else:
@@ -403,6 +414,7 @@ def commit_push_and_pr(
     use_gh: bool = True,
     agent_cli: str = "",
     agent_cli_args: str = "",
+    agent_display_name: str | None = None,
 ) -> str | None:
     repo_root = expand_dir(repo_root)
     branch = str(branch or "").strip()
@@ -414,7 +426,10 @@ def commit_push_and_pr(
             "current branch matches the base branch; PR creation is unavailable for direct-base tasks"
         )
     body = _append_pr_attribution_footer(
-        body, agent_cli=agent_cli, agent_cli_args=agent_cli_args
+        body,
+        agent_cli=agent_cli,
+        agent_cli_args=agent_cli_args,
+        agent_display_name=agent_display_name,
     )
 
     def _porcelain_status() -> str:

--- a/agents_runner/tests/test_pr_footer_attribution.py
+++ b/agents_runner/tests/test_pr_footer_attribution.py
@@ -34,3 +34,82 @@ def test_append_pr_attribution_footer_handles_empty_body() -> None:
 
     assert rendered.startswith("---\n<!-- midori-ai-agents-runner-pr-footer -->")
     assert "Agent Used: (unknown)" in rendered
+
+
+def _assert_agent_display(rendered: str, expected_text: str) -> None:
+    assert f"Agent Used: [{expected_text}]" in rendered
+
+
+def test_footer_opencode_tui() -> None:
+    rendered = _append_pr_attribution_footer(
+        "body",
+        agent_cli="opencode",
+        agent_display_name="OpenCode TUI",
+    )
+    _assert_agent_display(rendered, "OpenCode TUI")
+    assert "https://github.com/anomalyco/opencode" in rendered
+
+
+def test_footer_opencode_web() -> None:
+    rendered = _append_pr_attribution_footer(
+        "body",
+        agent_cli="opencode",
+        agent_display_name="OpenCode Web",
+    )
+    _assert_agent_display(rendered, "OpenCode Web")
+    assert "https://github.com/anomalyco/opencode" in rendered
+
+
+def test_footer_aider() -> None:
+    rendered = _append_pr_attribution_footer("body", agent_cli="aider")
+    assert "Agent Used: aider" in rendered
+
+
+def test_footer_claude_code() -> None:
+    rendered = _append_pr_attribution_footer("body", agent_cli="claude")
+    _assert_agent_display(rendered, "Claude Code")
+    assert "https://github.com/anthropics/claude-code" in rendered
+
+
+def test_footer_codex() -> None:
+    rendered = _append_pr_attribution_footer("body", agent_cli="codex")
+    _assert_agent_display(rendered, "OpenAI Codex")
+    assert "https://github.com/openai/codex" in rendered
+
+
+def test_footer_copilot() -> None:
+    rendered = _append_pr_attribution_footer("body", agent_cli="copilot")
+    _assert_agent_display(rendered, "Github Copilot")
+    assert "https://github.com/github/copilot-cli" in rendered
+
+
+def test_footer_gemini() -> None:
+    rendered = _append_pr_attribution_footer("body", agent_cli="gemini")
+    _assert_agent_display(rendered, "Google Gemini")
+    assert "https://github.com/google-gemini/gemini-cli" in rendered
+
+
+def test_footer_qwen() -> None:
+    rendered = _append_pr_attribution_footer("body", agent_cli="qwen")
+    _assert_agent_display(rendered, "Qwen")
+    assert "https://github.com/QwenLM/qwen-code" in rendered
+
+
+def test_footer_opencode_tui_with_args() -> None:
+    rendered = _append_pr_attribution_footer(
+        "body",
+        agent_cli="opencode",
+        agent_cli_args="--model gpt-5",
+        agent_display_name="OpenCode TUI",
+    )
+    _assert_agent_display(rendered, "OpenCode TUI")
+    assert "--model gpt-5" in rendered
+
+
+def test_footer_opencode_web_no_args() -> None:
+    rendered = _append_pr_attribution_footer(
+        "body",
+        agent_cli="opencode",
+        agent_display_name="OpenCode Web",
+    )
+    _assert_agent_display(rendered, "OpenCode Web")

--- a/agents_runner/ui/main_window_tasks_interactive_finalize.py
+++ b/agents_runner/ui/main_window_tasks_interactive_finalize.py
@@ -483,6 +483,14 @@ class MainWindowTasksInteractiveFinalizeMixin(_MainWindowHints):
                 ),
             )
             try:
+                display_name = None
+                if task and str(task.agent_cli or "").strip().lower() == "opencode":
+                    launch_mode = str(task.launch_mode or "").strip().lower()
+                    if launch_mode == "opencode_web":
+                        display_name = "OpenCode Web"
+                    else:
+                        display_name = "OpenCode TUI"
+
                 pr_url = commit_push_and_pr(
                     repo_root,
                     branch=branch,
@@ -492,6 +500,7 @@ class MainWindowTasksInteractiveFinalizeMixin(_MainWindowHints):
                     use_gh=bool(use_gh),
                     agent_cli=agent_cli,
                     agent_cli_args=agent_cli_args,
+                    agent_display_name=display_name,
                 )
             except GhManagementError as exc:
                 self.host_log.emit(


### PR DESCRIPTION
The PR footer previously displayed "Agent Used: OpenCode" regardless
of whether the user ran opencode in TUI or Web mode. This fix reads the
`launch_mode` from the task model and passes "OpenCode TUI" or
"OpenCode Web" as the display name through to the footer generator.

Changes:
- Added `opencode-tui` / `opencode-web` entries to `agent_display.py`
- Added optional `agent_display_name` param to `commit_push_and_pr()`
  and `_append_pr_attribution_footer()` in `gh/task_plan.py`
- Finalize worker in `ui/main_window_tasks_interactive_finalize.py`
  now determines the display name from `task.launch_mode`
- 13 tests covering all 7 agent display names including both OpenCode
  variants with/without CLI args

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode](https://github.com/anomalyco/opencode) --agent plan --model deepseek/deepseek-v4-pro --variant max
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
