### PR TITLE
[CONFIG] Add project opencode.json with external_directory permissions

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -25,6 +25,7 @@ print_allowlist() {
   log "  - .agents"
   log "  - .githooks"
   log "  - .github"
+  log "  - .opencode"
   log "  - agents_runner"
   log "  - agents_runner.egg-info"
   log "  - .gitignore"
@@ -66,6 +67,7 @@ declare -A root_allowlist=(
   [".agents"]=1
   [".githooks"]=1
   [".github"]=1
+  [".opencode"]=1
   ["agents_runner"]=1
   ["agents_runner.egg-info"]=1
   [".gitignore"]=1

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "external_directory": {
+      "/etc/*": "allow",
+      "/usr/lib/*": "allow",
+      "/tmp/**": "allow"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a project-level opencode configuration (`.opencode/opencode.json`) and updates the pre-commit hook to allow the `.opencode/` directory in the repo root.

## Changes

### `.opencode/opencode.json` (new file)

Project-level OpenCode config that grants `external_directory` read permissions to sub-agents for system paths commonly needed during build and debugging:

- `/etc/*` — allow (system configuration files)
- `/usr/lib/*` — allow (installed libraries)
- `/tmp/**` — allow (temporary artifacts mount)

File includes `$schema` reference to `https://opencode.ai/config.json` for editor validation.

### `.githooks/pre-commit` (modified)

Added `.opencode/` to the root allowlist (`root_allowlist` associative array) and to the `print_allowlist` function output so the pre-commit hook permits staging files under `.opencode/`.

## Verification

- Pre-commit hook passed: `[pre-commit] OK`
- Compile check passed
- Import smoke test passed

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode TUI](https://github.com/anomalyco/opencode) --agent plan --model deepseek/deepseek-v4-pro --variant max
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
