### PR TITLE
Fix: Enforce workspace cleanup size cap on selected workspace root

### DIFF
--- a/agents_runner/environments/cleanup.py
+++ b/agents_runner/environments/cleanup.py
@@ -24,7 +24,36 @@ from .task_workspaces import task_workspace_path
 
 logger = MidoriAiLogger(channel=None, name=__name__)
 
-_FINISHED_STATUSES = {"done", "failed", "error", "cancelled", "killed"}
+_FINISHED_STATUSES = {"done", "failed", "error", "cancelled", "killed", "discarded"}
+
+
+def _discover_orphan_workspaces(
+    workspace_root: str,
+    known_task_ids: set[str],
+) -> list[tuple[str, str, float]]:
+    orphans: list[tuple[str, str, float]] = []
+    try:
+        for env_dir in os.listdir(workspace_root):
+            env_path = os.path.join(workspace_root, env_dir)
+            if not os.path.isdir(env_path):
+                continue
+            tasks_dir = os.path.join(env_path, "tasks")
+            if not os.path.isdir(tasks_dir):
+                continue
+            for task_dir in os.listdir(tasks_dir):
+                task_path = os.path.join(tasks_dir, task_dir)
+                if not os.path.isdir(task_path):
+                    continue
+                if task_dir in known_task_ids:
+                    continue
+                try:
+                    mtime = os.path.getmtime(task_path)
+                except OSError:
+                    continue
+                orphans.append((env_dir, task_dir, mtime))
+    except OSError:
+        pass
+    return orphans
 
 
 def _timestamp_from_iso(value: object) -> float | None:
@@ -59,13 +88,19 @@ def cleanup_retained_task_workspaces(
     active_task_ids: set[str],
     finalizing_task_ids: set[str],
     on_log: Callable[[str], None] | None = None,
+    workspace_root: str | None = None,
 ) -> int:
+    from .paths import safe_task_id
+
     cutoff_s = finished_cutoff_s(retention_days=retention_days)
     removed = 0
     seen: set[tuple[str, str]] = set()
+    known_task_ids: set[str] = set()
     for payload in task_payloads:
         task_id = str(payload.get("task_id") or "").strip()
         env_id = str(payload.get("environment_id") or "").strip()
+        if task_id:
+            known_task_ids.add(safe_task_id(task_id))
         if not task_id or not env_id:
             continue
         if task_id in active_task_ids or task_id in finalizing_task_ids:
@@ -91,6 +126,19 @@ def cleanup_retained_task_workspaces(
             removed += 1
         if scan_delay_seconds > 0:
             time.sleep(float(scan_delay_seconds))
+    if workspace_root:
+        for env_id, task_id, dir_mtime in _discover_orphan_workspaces(workspace_root, known_task_ids):
+            if dir_mtime > cutoff_s:
+                continue
+            if cleanup_task_workspace(
+                env_id=env_id,
+                task_id=task_id,
+                data_dir=data_dir,
+                on_log=on_log,
+            ):
+                removed += 1
+            if scan_delay_seconds > 0:
+                time.sleep(float(scan_delay_seconds))
     return removed
 
 
@@ -102,6 +150,7 @@ def cleanup_by_size(
     finalizing_task_ids: set[str],
     data_dir: str | None,
     on_log: Callable[[str], None] | None = None,
+    workspace_root: str | None = None,
 ) -> int:
     """
     Remove oldest finished workspaces until total workspace size falls under threshold.
@@ -113,6 +162,7 @@ def cleanup_by_size(
         finalizing_task_ids: Set of task IDs currently finalizing (will not be removed).
         data_dir: Optional data directory path.
         on_log: Optional callback for logging messages.
+        workspace_root: Optional workspace root path for size measurement and orphan discovery.
 
     Returns:
         Number of workspaces removed.
@@ -120,15 +170,20 @@ def cleanup_by_size(
     if threshold_gb <= 0:
         return 0
 
+    from .paths import safe_task_id
+
     threshold_bytes = threshold_gb * (1024**3)
 
     # Filter and deduplicate candidates
     seen: set[tuple[str, str]] = set()
     candidates: list[tuple[float, str, str]] = []
+    known_task_ids: set[str] = set()
 
     for payload in task_payloads:
         task_id = str(payload.get("task_id") or "").strip()
         env_id = str(payload.get("environment_id") or "").strip()
+        if task_id:
+            known_task_ids.add(safe_task_id(task_id))
         if not task_id or not env_id:
             continue
         if task_id in active_task_ids or task_id in finalizing_task_ids:
@@ -157,6 +212,10 @@ def cleanup_by_size(
 
         candidates.append((ts, env_id, task_id))
 
+    if workspace_root:
+        for env_id, task_id, dir_mtime in _discover_orphan_workspaces(workspace_root, known_task_ids):
+            candidates.append((dir_mtime, env_id, task_id))
+
     if not candidates:
         return 0
 
@@ -164,7 +223,12 @@ def cleanup_by_size(
     candidates.sort(key=lambda x: x[0])
 
     # Measure current total size
-    data_path = Path(data_dir) if data_dir else Path(".")
+    if workspace_root:
+        data_path = Path(workspace_root)
+    elif data_dir:
+        data_path = Path(data_dir)
+    else:
+        data_path = Path(".")
     total_size = get_workspace_tree_size(data_path)
 
     if total_size < threshold_bytes:

--- a/agents_runner/ui/main_window.py
+++ b/agents_runner/ui/main_window.py
@@ -285,6 +285,9 @@ class MainWindow(
         self._settings.move_task_workspaces_requested.connect(
             self._on_move_task_workspaces_requested, Qt.ConnectionType.QueuedConnection
         )
+        self._settings.force_cleanup_requested.connect(
+            self._on_force_cleanup_requested, Qt.ConnectionType.QueuedConnection
+        )
 
         self._stack = QWidget()
         self._stack_layout = QVBoxLayout(self._stack)

--- a/agents_runner/ui/main_window_navigation.py
+++ b/agents_runner/ui/main_window_navigation.py
@@ -159,6 +159,13 @@ class MainWindowNavigationMixin(_MainWindowHints):
         if hasattr(self, "_refresh_radio_channel_options"):
             self._refresh_radio_channel_options(disable_on_failure=True)
         self._transition_to_page(self._settings)
+        # Update force cleanup button state
+        has_active = any(t.is_active() for t in self._tasks.values())
+        has_finalizing = any(
+            str(getattr(t, "finalization_state", "") or "").strip().lower() in {"pending", "running"}
+            for t in self._tasks.values()
+        )
+        self._settings.set_force_cleanup_enabled(not has_active and not has_finalizing)
 
     def _try_autosave_before_navigation(self) -> bool:
         if self._envs_page.isVisible() and not self._envs_page.try_autosave():

--- a/agents_runner/ui/main_window_task_recovery.py
+++ b/agents_runner/ui/main_window_task_recovery.py
@@ -24,6 +24,7 @@ from agents_runner.environments.task_workspaces import scratch_drive_status
 from agents_runner.log_format import format_log, wrap_container_log
 from pathlib import Path
 from PySide6.QtCore import Signal
+from PySide6.QtWidgets import QMessageBox
 from agents_runner.persistence import iter_done_task_payloads
 from agents_runner.persistence import serialize_task
 from agents_runner.ui.task_model import Task
@@ -211,6 +212,19 @@ class MainWindowTaskRecoveryMixin(_MainWindowHints):
                     self._size_cleanup_popup_shown_this_session = True
                     self._size_cleanup_popup_requested.emit(size_removed)
 
+    def _on_force_cleanup_requested(self) -> None:
+        if QMessageBox.question(
+            self,
+            "Force cleanup?",
+            "This will immediately run retention and size-based cleanup on finished task workspaces.\n\nActive and finalizing workspaces are protected and will not be removed.",
+        ) != QMessageBox.StandardButton.Yes:
+            return
+
+        def _worker() -> None:
+            self._run_task_workspace_cleanup()
+
+        threading.Thread(target=_worker, daemon=True).start()
+
     def _tick_recovery_task(self, task: Task) -> None:
         """Process a single task for recovery/finalization.
 
@@ -271,6 +285,13 @@ class MainWindowTaskRecoveryMixin(_MainWindowHints):
         self._dashboard.upsert_task(task, stain=stain, spinner_color=spinner)
         self._details.update_task(task)
         self._schedule_save()
+        if self._settings.isVisible():
+            has_active = any(t.is_active() for t in self._tasks.values())
+            has_finalizing = any(
+                str(getattr(t, "finalization_state", "") or "").strip().lower() in {"pending", "running"}
+                for t in self._tasks.values()
+            )
+            self._settings.set_force_cleanup_enabled(not has_active and not has_finalizing)
 
     def _ensure_recovery_log_tail(self, task: Task) -> None:
         task_id = str(task.task_id or "").strip()

--- a/agents_runner/ui/main_window_task_recovery.py
+++ b/agents_runner/ui/main_window_task_recovery.py
@@ -171,7 +171,6 @@ class MainWindowTaskRecoveryMixin(_MainWindowHints):
         current_size = get_workspace_tree_size(Path(workspace_root))
         user_threshold_gb = int(self._settings_data.get("task_workspace_cleanup_size_threshold_gb", 50))
 
-        location = str(self._settings_data.get("task_workspace_location", "app_data"))
         status = scratch_drive_status()
         if status.is_ram_drive and location == "scratch_drive":
             mem_total_kb = 0

--- a/agents_runner/ui/main_window_task_recovery.py
+++ b/agents_runner/ui/main_window_task_recovery.py
@@ -147,6 +147,7 @@ class MainWindowTaskRecoveryMixin(_MainWindowHints):
         data_dir = os.path.dirname(self._state_path)
         location = str(self._settings_data.get("task_workspace_location", "app_data"))
         from agents_runner.environments.task_workspaces import task_workspaces_root
+
         workspace_root = task_workspaces_root(data_dir=data_dir, location=location)
         removed = cleanup_retained_task_workspaces(
             chain(active_payloads, iter_done_task_payloads(self._state_path)),
@@ -213,11 +214,14 @@ class MainWindowTaskRecoveryMixin(_MainWindowHints):
                     self._size_cleanup_popup_requested.emit(size_removed)
 
     def _on_force_cleanup_requested(self) -> None:
-        if QMessageBox.question(
-            self,
-            "Force cleanup?",
-            "This will immediately run retention and size-based cleanup on finished task workspaces.\n\nActive and finalizing workspaces are protected and will not be removed.",
-        ) != QMessageBox.StandardButton.Yes:
+        if (
+            QMessageBox.question(
+                self,
+                "Force cleanup?",
+                "This will immediately run retention and size-based cleanup on finished task workspaces.\n\nActive and finalizing workspaces are protected and will not be removed.",
+            )
+            != QMessageBox.StandardButton.Yes
+        ):
             return
 
         def _worker() -> None:

--- a/agents_runner/ui/main_window_task_recovery.py
+++ b/agents_runner/ui/main_window_task_recovery.py
@@ -144,6 +144,9 @@ class MainWindowTaskRecoveryMixin(_MainWindowHints):
             if finalization_state in {"pending", "running"}:
                 finalizing_task_ids.add(task_id)
         data_dir = os.path.dirname(self._state_path)
+        location = str(self._settings_data.get("task_workspace_location", "app_data"))
+        from agents_runner.environments.task_workspaces import task_workspaces_root
+        workspace_root = task_workspaces_root(data_dir=data_dir, location=location)
         removed = cleanup_retained_task_workspaces(
             chain(active_payloads, iter_done_task_payloads(self._state_path)),
             data_dir=data_dir,
@@ -151,6 +154,7 @@ class MainWindowTaskRecoveryMixin(_MainWindowHints):
             scan_delay_seconds=scan_delay_seconds,
             active_task_ids=active_task_ids,
             finalizing_task_ids=finalizing_task_ids,
+            workspace_root=workspace_root,
         )
         if removed:
             self.host_log.emit(
@@ -164,7 +168,7 @@ class MainWindowTaskRecoveryMixin(_MainWindowHints):
             )
 
         # --- Size-based cleanup ---
-        current_size = get_workspace_tree_size(Path(data_dir))
+        current_size = get_workspace_tree_size(Path(workspace_root))
         user_threshold_gb = int(self._settings_data.get("task_workspace_cleanup_size_threshold_gb", 50))
 
         location = str(self._settings_data.get("task_workspace_location", "app_data"))
@@ -191,6 +195,7 @@ class MainWindowTaskRecoveryMixin(_MainWindowHints):
                 active_task_ids=active_task_ids,
                 finalizing_task_ids=finalizing_task_ids,
                 data_dir=data_dir,
+                workspace_root=workspace_root,
             )
             if size_removed:
                 self.host_log.emit(

--- a/agents_runner/ui/pages/settings.py
+++ b/agents_runner/ui/pages/settings.py
@@ -43,6 +43,7 @@ class SettingsPage(QWidget, SettingsFormMixin):
     saved = Signal(dict)
     test_preflight_requested = Signal(dict)
     move_task_workspaces_requested = Signal(bool)
+    force_cleanup_requested = Signal()
 
     def __init__(
         self,
@@ -192,6 +193,8 @@ class SettingsPage(QWidget, SettingsFormMixin):
         self._preflight_script.textChanged.connect(self._queue_debounced_autosave)
         self._agentsnova_trusted_users_global.usernames_changed.connect(self._queue_debounced_autosave)
 
+        self._force_cleanup_button.clicked.connect(self.force_cleanup_requested.emit)
+
     def _on_back(self) -> None:
         self.try_autosave()
         self.back_requested.emit()
@@ -199,6 +202,9 @@ class SettingsPage(QWidget, SettingsFormMixin):
     def _on_test_preflight(self) -> None:
         self.try_autosave()
         self.test_preflight_requested.emit(self.get_settings())
+
+    def set_force_cleanup_enabled(self, enabled: bool) -> None:
+        self._force_cleanup_button.setEnabled(enabled)
 
     def _on_nav_button_clicked(self, key: str) -> None:
         self._navigate_to_pane(key, user_initiated=True)

--- a/agents_runner/ui/pages/settings_form.py
+++ b/agents_runner/ui/pages/settings_form.py
@@ -617,13 +617,8 @@ class SettingsFormMixin:
             QLabel(""),
             self._task_workspace_cleanup_size_ram_cap_label,
         )
+        add_grid_row(cleanup_grid, 5, QLabel("Force cleanup"), self._force_cleanup_button)
         cleanup_body.addLayout(cleanup_grid)
-        force_row = QWidget(cleanup_page)
-        force_layout = QHBoxLayout(force_row)
-        force_layout.setContentsMargins(0, 0, 0, 0)
-        force_layout.addStretch(1)
-        force_layout.addWidget(self._force_cleanup_button)
-        cleanup_body.addWidget(force_row)
         cleanup_body.addWidget(self._task_workspace_cleanup_note)
         cleanup_body.addStretch(1)
         self._register_page("cleanup", cleanup_page)

--- a/agents_runner/ui/pages/settings_form.py
+++ b/agents_runner/ui/pages/settings_form.py
@@ -22,6 +22,7 @@ from PySide6.QtWidgets import QMessageBox
 from PySide6.QtWidgets import QListWidget
 from PySide6.QtWidgets import QListWidgetItem
 from PySide6.QtWidgets import QPlainTextEdit
+from PySide6.QtWidgets import QPushButton
 from PySide6.QtWidgets import QSizePolicy
 from PySide6.QtWidgets import QSlider
 from PySide6.QtWidgets import QSpinBox
@@ -370,11 +371,13 @@ class SettingsFormMixin:
         self._task_workspace_cleanup_note = QLabel("")
         self._task_workspace_cleanup_note.setObjectName("SettingsPaneSubtitle")
         self._task_workspace_cleanup_note.setWordWrap(True)
+        self._force_cleanup_button = QPushButton("Force Clean Now")
         self._task_workspace_cleanup_controls: list[QWidget] = [
             self._task_workspace_cleanup_retention_days,
             self._task_workspace_cleanup_interval_minutes,
             self._task_workspace_cleanup_scan_delay_seconds,
             self._task_workspace_cleanup_size_threshold_gb,
+            self._force_cleanup_button,
         ]
         self._workspace_status_checking = False
         self._workspace_status_request_id = 0
@@ -615,6 +618,12 @@ class SettingsFormMixin:
             self._task_workspace_cleanup_size_ram_cap_label,
         )
         cleanup_body.addLayout(cleanup_grid)
+        force_row = QWidget(cleanup_page)
+        force_layout = QHBoxLayout(force_row)
+        force_layout.setContentsMargins(0, 0, 0, 0)
+        force_layout.addStretch(1)
+        force_layout.addWidget(self._force_cleanup_button)
+        cleanup_body.addWidget(force_row)
         cleanup_body.addWidget(self._task_workspace_cleanup_note)
         cleanup_body.addStretch(1)
         self._register_page("cleanup", cleanup_page)


### PR DESCRIPTION
Corrects the managed workspace cleanup system so `task_workspace_cleanup_size_threshold_gb` enforces the size limit against the selected task workspace folder (managed-repos or scratch-drive), not against the entire app-data directory.

Changes:
- Size measurement now targets the selected workspace root instead of the full `~/.midoriai/agents-runner/` directory
- Added `"discarded"` to finished statuses so discarded cloned workspaces are cleanup-eligible
- Added orphan workspace discovery and cleanup for directories under the workspace root with no matching task payload
- Orphaned workspaces participate in both retention and size-based cleanup using directory mtime as age
- Added a "Force Clean Now" button in Settings > Cleanup that runs cleanup immediately (with confirmation dialog, disabled when active/finalizing tasks exist)
- Scratch-drive RAM-aware threshold clamp logic preserved unchanged
- All existing safety protections (symlink rejection, `is_safe_task_workspace_path`, active/finalizing exclusion) remain intact

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode TUI](https://github.com/anomalyco/opencode)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
