### PR TITLE
Fix: Enforce workspace cleanup size cap on selected workspace root

### DIFF
--- a/agents_runner/ui/main_window_task_recovery.py
+++ b/agents_runner/ui/main_window_task_recovery.py
@@ -147,6 +147,7 @@ class MainWindowTaskRecoveryMixin(_MainWindowHints):
         data_dir = os.path.dirname(self._state_path)
         location = str(self._settings_data.get("task_workspace_location", "app_data"))
         from agents_runner.environments.task_workspaces import task_workspaces_root
+
         workspace_root = task_workspaces_root(data_dir=data_dir, location=location)
         removed = cleanup_retained_task_workspaces(
             chain(active_payloads, iter_done_task_payloads(self._state_path)),
@@ -213,11 +214,14 @@ class MainWindowTaskRecoveryMixin(_MainWindowHints):
                     self._size_cleanup_popup_requested.emit(size_removed)
 
     def _on_force_cleanup_requested(self) -> None:
-        if QMessageBox.question(
-            self,
-            "Force cleanup?",
-            "This will immediately run retention and size-based cleanup on finished task workspaces.\n\nActive and finalizing workspaces are protected and will not be removed.",
-        ) != QMessageBox.StandardButton.Yes:
+        if (
+            QMessageBox.question(
+                self,
+                "Force cleanup?",
+                "This will immediately run retention and size-based cleanup on finished task workspaces.\n\nActive and finalizing workspaces are protected and will not be removed.",
+            )
+            != QMessageBox.StandardButton.Yes
+        ):
             return
 
         def _worker() -> None:


### PR DESCRIPTION
Runs `uv run ruff format .` to fix formatting issues across the codebase so `ruff format --check` passes.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode TUI](https://github.com/anomalyco/opencode)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
