### PR TITLE
[CONFIG] Use basedpyright LSP server instead of pyright

### DIFF
--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,5 +1,12 @@
 {
   "$schema": "https://opencode.ai/config.json",
+  "lsp": {
+    "pyright": { "disabled": true },
+    "basedpyright": {
+      "command": ["uv", "run", "--with", "basedpyright", "basedpyright-langserver", "--stdio"],
+      "extensions": [".py", ".pyi"]
+    }
+  },
   "permission": {
     "external_directory": {
       "/etc/*": "allow",


### PR DESCRIPTION
Fix: Disable built-in pyright LSP and add custom basedpyright server via `uv run --with`.

The project uses `[tool.basedpyright]` for type checking (strict mode, Python 3.13),
but OpenCode's built-in pyright LSP server runs the standard `pyright-langserver`,
which ignores the basedpyright config section -- producing false/mismatched diagnostics.

- Disable the built-in `pyright` LSP server
- Add a custom `basedpyright` server: `uv run --with basedpyright basedpyright-langserver --stdio`
- Extensions: `.py`, `.pyi`

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode TUI](https://github.com/anomalyco/opencode)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
