### PR TITLE
Fix: MCP transport deadlock — use read1() instead of read() on stdin...

### DIFF
--- a/agents_runner/mcp/transport.py
+++ b/agents_runner/mcp/transport.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 import sys
 
-from typing import Any
+from typing import Any, cast
 
 from rich.console import Console
 
@@ -36,7 +36,7 @@ class MCPTransport:
             stdout: Binary output stream (defaults to sys.stdout.buffer).
             stderr: Binary error stream (defaults to sys.stderr).
         """
-        self._stdin = stdin if stdin is not None else sys.stdin.buffer
+        self._stdin = stdin if stdin is not None else cast(Any, sys.stdin.buffer)
         self._stdout = stdout if stdout is not None else sys.stdout.buffer
         self._stderr = stderr if stderr is not None else sys.stderr
         self._buffer = bytearray()
@@ -47,7 +47,7 @@ class MCPTransport:
         loop = asyncio.get_running_loop()
         while len(self._buffer) < n:
             bytes_needed = n - len(self._buffer)
-            chunk = await loop.run_in_executor(None, self._stdin.read, bytes_needed)
+            chunk = await loop.run_in_executor(None, self._stdin.read1, bytes_needed)
             if not chunk:
                 msg = "stdin closed while reading message body"
                 raise ConnectionError(msg)
@@ -60,7 +60,7 @@ class MCPTransport:
         """Read one line (terminated by \\n) from stdin into the internal buffer."""
         loop = asyncio.get_running_loop()
         while b"\n" not in self._buffer:
-            chunk = await loop.run_in_executor(None, self._stdin.read, 4096)
+            chunk = await loop.run_in_executor(None, self._stdin.read1, 4096)
             if not chunk:
                 msg = "stdin closed while reading line"
                 raise ConnectionError(msg)


### PR DESCRIPTION
## Summary

Fix for [#257](https://github.com/Midori-AI-OSS/Agents-Runner/issues/257).

The MCP server's `initialize` handshake timed out because `BufferedReader.read(N)` on an open pipe loops internally calling `read()` until N bytes or EOF — causing a deadlock when the client sends a small frame (~200 bytes) and waits for a response.

## Root cause

`agents_runner/mcp/transport.py` used `self._stdin.read(4096)` in `_read_line()` (line 63) and `self._stdin.read(bytes_needed)` in `_read_n_bytes()` (line 50).

## Fix

Changed both to `self._stdin.read1(...)` — which issues exactly one raw `read()` syscall and returns immediately with whatever data is available. The existing `while` loops in both methods already handle partial reads correctly.

Also added `cast(Any, sys.stdin.buffer)` to the stdin assignment to satisfy strict type checking (`BinaryIO` in typeshed doesn't expose `read1` at the type level, but `BufferedReader` does at runtime).

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode TUI](https://github.com/anomalyco/opencode)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
