### PR TITLE
feat: Auto-set UV_PROJECT_ENVIRONMENT and UV_PYTHON_INSTALL_DIR in co...

### DIFF
--- a/.agents/tasks/done/uv-env-vars-container.md
+++ b/.agents/tasks/done/uv-env-vars-container.md
@@ -1,0 +1,9 @@
+# Auto-set UV_PROJECT_ENVIRONMENT and UV_PYTHON_INSTALL_DIR in containers
+
+**Status:** wip
+
+Add auto-set of `UV_PROJECT_ENVIRONMENT=/tmp/.uv-venv` and `UV_PYTHON_INSTALL_DIR=/tmp/.uv-python` environment variables in all container launches, with user-override guard.
+
+## Files changed
+- `agents_runner/docker/agent_worker_container.py` — `ContainerExecutor._build_env_args()`
+- `agents_runner/ui/main_window_tasks_interactive_docker.py` — `launch_docker_terminal_task()`

--- a/.agents/tasks/done/uv-env-vars-container.md
+++ b/.agents/tasks/done/uv-env-vars-container.md
@@ -1,9 +1,0 @@
-# Auto-set UV_PROJECT_ENVIRONMENT and UV_PYTHON_INSTALL_DIR in containers
-
-**Status:** wip
-
-Add auto-set of `UV_PROJECT_ENVIRONMENT=/tmp/.uv-venv` and `UV_PYTHON_INSTALL_DIR=/tmp/.uv-python` environment variables in all container launches, with user-override guard.
-
-## Files changed
-- `agents_runner/docker/agent_worker_container.py` — `ContainerExecutor._build_env_args()`
-- `agents_runner/ui/main_window_tasks_interactive_docker.py` — `launch_docker_terminal_task()`

--- a/agents_runner/docker/agent_worker_container.py
+++ b/agents_runner/docker/agent_worker_container.py
@@ -461,6 +461,10 @@ class ContainerExecutor:
             k = str(key).strip()
             if k:
                 env_args.extend(["-e", f"{k}={value}"])
+        if "UV_PROJECT_ENVIRONMENT" not in (self._config.env_vars or {}):
+            env_args.extend(["-e", "UV_PROJECT_ENVIRONMENT=/tmp/.uv-venv"])
+        if "UV_PYTHON_INSTALL_DIR" not in (self._config.env_vars or {}):
+            env_args.extend(["-e", "UV_PYTHON_INSTALL_DIR=/tmp/.uv-python"])
         env_args.extend(["-e", "MIDORI_AI_AGENTS_RUNNER_INTERACTIVE=false"])
 
         # Forward GitHub tokens if needed

--- a/agents_runner/ui/main_window_tasks_interactive_docker.py
+++ b/agents_runner/ui/main_window_tasks_interactive_docker.py
@@ -401,6 +401,10 @@ def launch_docker_terminal_task(
             if not k:
                 continue
             env_args.extend(["-e", f"{k}={value}"])
+        if "UV_PROJECT_ENVIRONMENT" not in ((env.env_vars or {}) if env else {}):
+            env_args.extend(["-e", "UV_PROJECT_ENVIRONMENT=/tmp/.uv-venv"])
+        if "UV_PYTHON_INSTALL_DIR" not in ((env.env_vars or {}) if env else {}):
+            env_args.extend(["-e", "UV_PYTHON_INSTALL_DIR=/tmp/.uv-python"])
         env_args.extend(["-e", "MIDORI_AI_AGENTS_RUNNER_INTERACTIVE=true"])
 
         # Check if we need to forward GH_TOKEN


### PR DESCRIPTION
Automatically sets `UV_PROJECT_ENVIRONMENT=/tmp/.uv-venv` and `UV_PYTHON_INSTALL_DIR=/tmp/.uv-python` in all container launches to work around a known uv bug where it writes to `~/.local`. User-defined values in environment `env_vars` take precedence and skip the auto-set.

Changes:
- `agents_runner/docker/agent_worker_container.py` — Non-interactive container path
- `agents_runner/ui/main_window_tasks_interactive_docker.py` — Interactive container path

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode TUI](https://github.com/anomalyco/opencode)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
