### PR TITLE
Fix: Replace Python property() with Qt Property() in animated widgets

### DIFF
--- a/agents_runner/ui/widgets/animated_button.py
+++ b/agents_runner/ui/widgets/animated_button.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from PySide6.QtCore import QEasingCurve, QEvent, QPropertyAnimation, QSize
+from PySide6.QtCore import Property, QEasingCurve, QEvent, QPropertyAnimation, QSize
 from PySide6.QtGui import QEnterEvent, QMouseEvent
 from PySide6.QtWidgets import QGraphicsOpacityEffect, QPushButton, QToolButton, QWidget
 
@@ -52,7 +52,7 @@ class AnimatedPushButton(QPushButton):
         self._scale = value
         self.update()
 
-    scale = property(get_scale, set_scale)
+    scale = Property(float, get_scale, set_scale)
 
     def sizeHint(self) -> QSize:
         base = super().sizeHint()

--- a/agents_runner/ui/widgets/animated_checkbox.py
+++ b/agents_runner/ui/widgets/animated_checkbox.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from PySide6.QtCore import QEasingCurve, QPropertyAnimation, Qt
+from PySide6.QtCore import Property, QEasingCurve, QPropertyAnimation, Qt
 from PySide6.QtGui import QColor, QPainter, QPainterPath, QPaintEvent
 from PySide6.QtWidgets import QCheckBox, QWidget
 
@@ -35,7 +35,7 @@ class AnimatedCheckBox(QCheckBox):
         self._check_progress = max(0.0, min(1.0, value))
         self.update()
 
-    check_progress = property(get_check_progress, set_check_progress)
+    check_progress = Property(float, get_check_progress, set_check_progress)
 
     def paintEvent(self, event: QPaintEvent) -> None:
         super().paintEvent(event)


### PR DESCRIPTION
AnimatedPushButton.scale and AnimatedCheckBox.check_progress used Python's
built-in `property()` instead of PySide6's `Property()`, causing all
QPropertyAnimation-driven scale/check animations to silently fail. Qt's
meta-object system cannot see Python descriptors.

Changes:
- `animated_button.py`: `property(get_scale, set_scale)` → `Property(float, get_scale, set_scale)`
- `animated_checkbox.py`: `property(get_check_progress, set_check_progress)` → `Property(float, get_check_progress, set_check_progress)`

Both files also had `Property` added to their PySide6.QtCore imports.

Fixes #366

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode TUI](https://github.com/anomalyco/opencode)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
