### PR TITLE
Fix: move app_icon import to module scope

### DIFF
--- a/agents_runner/ui/desktop_viewer/app.py
+++ b/agents_runner/ui/desktop_viewer/app.py
@@ -22,6 +22,8 @@ from PySide6.QtWidgets import (
 )
 from midori_ai_logger import MidoriAiLogger
 
+from agents_runner.ui.icons import app_icon
+
 logger = MidoriAiLogger(channel=None, name=__name__)
 
 QWebEngineView = None
@@ -167,9 +169,6 @@ def run_desktop_viewer(args: list[str]) -> int:
     app = QApplication.instance()
     if app is None:
         app = QApplication(args)
-
-    from agents_runner.ui.icons import app_icon
-
     icon = app_icon()
     if icon is not None:
         app.setWindowIcon(icon)


### PR DESCRIPTION
Move `app_icon` import from function-local scope to module-level, as required by the repo's no-inline-imports convention per AGENTS.md.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode TUI](https://github.com/anomalyco/opencode)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
