### PR TITLE
Fix: Remove sub-agent sleep pacing instruction

### DIFF
--- a/agents_runner/prompts/templates/subagentstemplate.md
+++ b/agents_runner/prompts/templates/subagentstemplate.md
@@ -15,7 +15,6 @@ You only dispatch sub-agents and pass along minimal routing signals.
   - Exception: you may list filenames under `<CONTROL_DIR>/tasks/` only to decide what to dispatch next and to enforce cleanup (do not open task contents).
 - **Do not write code, propose code changes, or debug.**
 - **Do not request that sub-agents report what they changed or how they did it.**
-- **Sleep to fight ratelimits**: require sub-agents to pace themselves by sleeping **5–10 seconds** (random jitter) after every **3–5 actions**.
 - **Do not specify output formats for sub-agents** (they already have their own prompts and know how to operate).
 - Keep your messages **short**: dispatch + the minimum coordination needed.
 


### PR DESCRIPTION
## Summary

- Remove the randomized sleep pacing requirement from the router prompt template.

## Verification

- Confirmed the removed instruction no longer appears in the repository.
- Committed as `beb2ad3`.
- No tests added or run; prompt-only change.

## Compliance

- Confirmed the PixelArch container environment and applicable repository instructions.
- Kept the change minimal, used repository-approved tooling, and stored temporary output under `/tmp/agents-artifacts`.
- Reviewed task and implementation directories at task start.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
