### PR TITLE
[FIX] Stop async task prep from wiping New Task form prompt and env

### DIFF
--- a/agents_runner/ui/main_window_tasks_interactive_docker.py
+++ b/agents_runner/ui/main_window_tasks_interactive_docker.py
@@ -651,10 +651,7 @@ def launch_docker_terminal_task(
             )
 
         # Update settings
-        main_window._settings_data["host_workdir"] = host_workdir  # pyright: ignore[reportPrivateUsage]
-        main_window._settings_data["active_environment_id"] = env_id  # pyright: ignore[reportPrivateUsage]
         main_window._settings_data["interactive_terminal_id"] = str(getattr(terminal_opt, "terminal_id", ""))  # pyright: ignore[reportPrivateUsage]
-        main_window._apply_active_environment_to_new_task()  # pyright: ignore[reportPrivateUsage]
         main_window._schedule_save()  # pyright: ignore[reportPrivateUsage]
 
         # Update task status to running
@@ -693,7 +690,6 @@ def launch_docker_terminal_task(
                 host_port=opencode_web_host_port,
             )
         main_window._maybe_auto_navigate_on_task_start(interactive=True)  # pyright: ignore[reportPrivateUsage]
-        main_window._new_task.reset_for_new_run()  # pyright: ignore[reportPrivateUsage]
 
     except Exception as exc:
         _handle_launch_error(main_window, task, tmp_paths, stain, spinner, str(exc))


### PR DESCRIPTION
When an interactive task finishes preparing (docker pull, preflight) asynchronously, `launch_docker_terminal_task` would:

1. Call `reset_for_new_run()` clearing the prompt text the user was typing
2. Overwrite `_settings_data["active_environment_id"]` and call `_apply_active_environment_to_new_task()`, switching the env picker back to the old task's env

Removed the 4 lines (654, 655, 657, 696) from `agents_runner/ui/main_window_tasks_interactive_docker.py` that caused this race condition. The synchronous `reset_for_new_run()` calls on user submit are left intact.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode TUI](https://github.com/anomalyco/opencode)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
