### PR TITLE
Coalesce GitHub CLI auth checks into a single-flight monotonic snapshot

### DIFF
--- a/agents_runner/agent_systems/copilot/plugin.py
+++ b/agents_runner/agent_systems/copilot/plugin.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import os
-import subprocess
-
 from pathlib import Path
 
+from agents_runner.agent_systems.github_status import github_auth_status
 from agents_runner.agent_systems.models import (
     AgentSystemPlan,
     AgentSystemRequest,
@@ -16,10 +15,9 @@ from agents_runner.agent_systems.models import (
 )
 from agents_runner.agent_systems.interactive_command import move_flag_value_to_end
 from agents_runner.agent_systems.status import AgentStatus
-from agents_runner.agent_systems.status import StatusType
 from agents_runner.agent_systems.status import command_in_path
-from agents_runner.agent_systems.status import installed_status
 from agents_runner.agent_systems.status import not_installed_status
+from agents_runner.gh.auth import get_gh_auth_snapshot
 
 
 CONTAINER_HOME = Path("/home/midori-ai")
@@ -95,55 +93,7 @@ class CopilotAgentSystemPlugin:
         if not command_in_path("copilot"):
             return not_installed_status(agent=self.name)
 
-        try:
-            result = subprocess.run(
-                ["gh", "auth", "status"],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-        except subprocess.TimeoutExpired:
-            return installed_status(
-                agent=self.name,
-                logged_in=False,
-                status_text="Unknown (timeout)",
-                status_type=StatusType.UNKNOWN,
-            )
-        except (FileNotFoundError, OSError):
-            return installed_status(
-                agent=self.name,
-                logged_in=False,
-                status_text="Unknown (gh CLI not found)",
-                status_type=StatusType.UNKNOWN,
-            )
-
-        if result.returncode == 0 and "Logged in" in result.stdout:
-            username = None
-            for line in result.stdout.split("\n"):
-                if "Logged in to github.com account" not in line:
-                    continue
-                parts = line.split("account")
-                if len(parts) > 1:
-                    username = parts[1].split("(")[0].strip() or None
-                    break
-            if username:
-                return installed_status(
-                    agent=self.name,
-                    logged_in=True,
-                    status_text=f"Logged in as {username}",
-                    username=username,
-                )
-            return installed_status(
-                agent=self.name,
-                logged_in=True,
-                status_text="Logged in",
-            )
-
-        return installed_status(
-            agent=self.name,
-            logged_in=False,
-            status_text="Not logged in to GitHub",
-        )
+        return github_auth_status(agent=self.name, snapshot=get_gh_auth_snapshot(timeout_s=5.0, use_cache=True))
 
     def default_interactive_command(self) -> str:
         return f"--yolo --add-dir {WORKSPACE_DIR}"

--- a/agents_runner/agent_systems/github_status.py
+++ b/agents_runner/agent_systems/github_status.py
@@ -1,0 +1,23 @@
+"""GitHub authentication status presentation shared by setup integrations."""
+
+from agents_runner.agent_systems.status import AgentStatus
+from agents_runner.agent_systems.status import installed_status
+from agents_runner.agent_systems.status import unknown_installed_status
+from agents_runner.gh.auth import GhAuthError
+from agents_runner.gh.auth import GhAuthSnapshot
+
+
+def github_auth_status(*, agent: str, snapshot: GhAuthSnapshot) -> AgentStatus:
+    """Convert a shared GitHub authentication snapshot to UI status."""
+
+    if snapshot.error == GhAuthError.TIMEOUT:
+        return unknown_installed_status(agent=agent, message="Unknown (timeout)")
+    if snapshot.error == GhAuthError.UNAVAILABLE:
+        return unknown_installed_status(agent=agent, message="Unknown (gh CLI not found)")
+    if snapshot.authenticated and snapshot.login:
+        return installed_status(
+            agent=agent, logged_in=True, status_text=f"Logged in as {snapshot.login}", username=snapshot.login
+        )
+    if snapshot.authenticated:
+        return installed_status(agent=agent, logged_in=True, status_text="Logged in")
+    return installed_status(agent=agent, logged_in=False, status_text="Not logged in to GitHub")

--- a/agents_runner/gh/auth.py
+++ b/agents_runner/gh/auth.py
@@ -40,6 +40,7 @@ class GhAuthSnapshot:
 _cache_condition = threading.Condition()
 _cached_snapshot: GhAuthSnapshot | None = None
 _refreshing = False
+_invalidation_generation = 0
 _monotonic: Callable[[], float] = time.monotonic
 
 
@@ -83,7 +84,7 @@ def _refresh_snapshot(*, timeout_s: float) -> GhAuthSnapshot:
         proc = run_gh(["gh", "auth", "status"], timeout_s=timeout_s)
     except GhManagementError as exc:
         error = GhAuthError.TIMEOUT if "timed out" in str(exc).lower() else GhAuthError.UNAVAILABLE
-        return GhAuthSnapshot(authenticated=False, login="", expires_at=_monotonic() + _AUTH_CACHE_TTL_S, error=error)
+        return GhAuthSnapshot(authenticated=False, login="", expires_at=_monotonic(), error=error)
 
     authenticated = proc.returncode == 0
     login = ""
@@ -109,37 +110,44 @@ def get_gh_auth_snapshot(*, timeout_s: float = 10.0, use_cache: bool = True) -> 
             if _cached_snapshot is not None:
                 return _cached_snapshot
         _refreshing = True
+        refresh_generation = _invalidation_generation
 
-    try:
-        snapshot = _refresh_snapshot(timeout_s=timeout_s)
-    except BaseException:
+    while True:
+        try:
+            snapshot = _refresh_snapshot(timeout_s=timeout_s)
+        except BaseException:
+            with _cache_condition:
+                _refreshing = False
+                _cache_condition.notify_all()
+            raise
         with _cache_condition:
+            if refresh_generation != _invalidation_generation:
+                refresh_generation = _invalidation_generation
+                continue
+            _cached_snapshot = snapshot
             _refreshing = False
             _cache_condition.notify_all()
-        raise
-    with _cache_condition:
-        _cached_snapshot = snapshot
-        _refreshing = False
-        _cache_condition.notify_all()
-    return snapshot
+            return snapshot
 
 
 def invalidate_gh_auth_cache() -> None:
     """Expire the current snapshot so the next authentication query refreshes it."""
 
-    global _cached_snapshot
+    global _cached_snapshot, _invalidation_generation
     with _cache_condition:
         _cached_snapshot = None
+        _invalidation_generation += 1
 
 
 def reset_gh_auth_cache(*, monotonic: Callable[[], float] = time.monotonic) -> None:
     """Reset cached state and its clock for deterministic verification."""
 
-    global _cached_snapshot, _monotonic
+    global _cached_snapshot, _invalidation_generation, _monotonic
     with _cache_condition:
         if _refreshing:
             raise RuntimeError("cannot reset GitHub authentication cache during a refresh")
         _cached_snapshot = None
+        _invalidation_generation = 0
         _monotonic = monotonic
 
 

--- a/agents_runner/gh/auth.py
+++ b/agents_runner/gh/auth.py
@@ -1,3 +1,5 @@
+"""Shared, single-flight GitHub CLI authentication state."""
+
 from __future__ import annotations
 
 import json
@@ -5,18 +7,40 @@ import re
 import threading
 import time
 
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable
 from typing import cast
 
+from .errors import GhManagementError
 from .process import run_gh
 
 _AUTH_CACHE_TTL_S = 300.0
 _AUTH_LOGIN_PATTERN = re.compile(r"Logged in to .* account ([A-Za-z0-9-]+)")
 
-_cache_lock = threading.Lock()
-_cached_auth_ready = False
-_cached_auth_expires_at = 0.0
-_cached_login = ""
-_cached_login_expires_at = 0.0
+
+class GhAuthError(Enum):
+    """Failure state for an authentication status refresh."""
+
+    NONE = "none"
+    TIMEOUT = "timeout"
+    UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True)
+class GhAuthSnapshot:
+    """The authentication values produced by one ``gh auth status`` probe."""
+
+    authenticated: bool
+    login: str
+    expires_at: float
+    error: GhAuthError = GhAuthError.NONE
+
+
+_cache_condition = threading.Condition()
+_cached_snapshot: GhAuthSnapshot | None = None
+_refreshing = False
+_monotonic: Callable[[], float] = time.monotonic
 
 
 def _safe_text(value: object) -> str:
@@ -29,98 +53,99 @@ def _as_object_dict(value: object) -> dict[object, object] | None:
     return cast(dict[object, object], value)
 
 
-def _cache_auth_state(value: bool, *, now_s: float) -> None:
-    global _cached_auth_ready, _cached_auth_expires_at
-    _cached_auth_ready = bool(value)
-    _cached_auth_expires_at = now_s + _AUTH_CACHE_TTL_S
-
-
-def _cache_login(value: str, *, now_s: float) -> str:
-    global _cached_login, _cached_login_expires_at
-    _cached_login = _safe_text(value).lower()
-    _cached_login_expires_at = now_s + _AUTH_CACHE_TTL_S
-    return _cached_login
-
-
 def _parse_login_from_auth_status(text: str) -> str:
     for line in str(text or "").splitlines():
         match = _AUTH_LOGIN_PATTERN.search(line)
-        if not match:
-            continue
-        return _safe_text(match.group(1)).lower()
+        if match:
+            return _safe_text(match.group(1)).lower()
     return ""
 
 
-def is_gh_authenticated(*, timeout_s: float = 10.0, use_cache: bool = True) -> bool:
-    now_s = time.time()
-    if use_cache:
-        with _cache_lock:
-            if _cached_auth_expires_at > now_s:
-                return _cached_auth_ready
+def _resolve_login_from_api(*, timeout_s: float) -> str:
+    try:
+        api_proc = run_gh(["gh", "api", "user", "-H", "Accept: application/vnd.github+json"], timeout_s=timeout_s)
+    except GhManagementError:
+        return ""
+    if api_proc.returncode != 0:
+        return ""
+    try:
+        data = json.loads(_safe_text(api_proc.stdout))
+    except (TypeError, ValueError):
+        return ""
+    data_dict = _as_object_dict(data)
+    if data_dict is None:
+        return ""
+    return _safe_text(data_dict.get("login")).lower()
 
-    proc = run_gh(["gh", "auth", "status"], timeout_s=timeout_s)
-    ready = proc.returncode == 0
-    with _cache_lock:
-        _cache_auth_state(ready, now_s=now_s)
-    return ready
+
+def _refresh_snapshot(*, timeout_s: float) -> GhAuthSnapshot:
+    try:
+        proc = run_gh(["gh", "auth", "status"], timeout_s=timeout_s)
+    except GhManagementError as exc:
+        error = GhAuthError.TIMEOUT if "timed out" in str(exc).lower() else GhAuthError.UNAVAILABLE
+        return GhAuthSnapshot(authenticated=False, login="", expires_at=_monotonic() + _AUTH_CACHE_TTL_S, error=error)
+
+    authenticated = proc.returncode == 0
+    login = ""
+    if authenticated:
+        combined_output = "\n".join(part for part in (_safe_text(proc.stdout), _safe_text(proc.stderr)) if part)
+        login = _parse_login_from_auth_status(combined_output)
+        if not login:
+            login = _resolve_login_from_api(timeout_s=timeout_s)
+    return GhAuthSnapshot(authenticated=authenticated, login=login, expires_at=_monotonic() + _AUTH_CACHE_TTL_S)
+
+
+def get_gh_auth_snapshot(*, timeout_s: float = 10.0, use_cache: bool = True) -> GhAuthSnapshot:
+    """Return one shared snapshot, coalescing concurrent normal and forced refreshes."""
+
+    global _cached_snapshot, _refreshing
+    with _cache_condition:
+        now_s = _monotonic()
+        if use_cache and _cached_snapshot is not None and _cached_snapshot.expires_at > now_s:
+            return _cached_snapshot
+        if _refreshing:
+            while _refreshing:
+                _cache_condition.wait()
+            if _cached_snapshot is not None:
+                return _cached_snapshot
+        _refreshing = True
+
+    try:
+        snapshot = _refresh_snapshot(timeout_s=timeout_s)
+    except BaseException:
+        with _cache_condition:
+            _refreshing = False
+            _cache_condition.notify_all()
+        raise
+    with _cache_condition:
+        _cached_snapshot = snapshot
+        _refreshing = False
+        _cache_condition.notify_all()
+    return snapshot
+
+
+def invalidate_gh_auth_cache() -> None:
+    """Expire the current snapshot so the next authentication query refreshes it."""
+
+    global _cached_snapshot
+    with _cache_condition:
+        _cached_snapshot = None
+
+
+def reset_gh_auth_cache(*, monotonic: Callable[[], float] = time.monotonic) -> None:
+    """Reset cached state and its clock for deterministic verification."""
+
+    global _cached_snapshot, _monotonic
+    with _cache_condition:
+        if _refreshing:
+            raise RuntimeError("cannot reset GitHub authentication cache during a refresh")
+        _cached_snapshot = None
+        _monotonic = monotonic
+
+
+def is_gh_authenticated(*, timeout_s: float = 10.0, use_cache: bool = True) -> bool:
+    return get_gh_auth_snapshot(timeout_s=timeout_s, use_cache=use_cache).authenticated
 
 
 def resolve_authenticated_login(*, timeout_s: float = 10.0, use_cache: bool = True) -> str:
-    now_s = time.time()
-    if use_cache:
-        with _cache_lock:
-            if _cached_login_expires_at > now_s:
-                return _cached_login
-
-    status_proc = run_gh(["gh", "auth", "status"], timeout_s=timeout_s)
-    login = ""
-    if status_proc.returncode == 0:
-        combined = _safe_text(status_proc.stdout) or _safe_text(status_proc.stderr)
-        login = _parse_login_from_auth_status(combined)
-        with _cache_lock:
-            _cache_auth_state(True, now_s=now_s)
-    else:
-        with _cache_lock:
-            _cache_auth_state(False, now_s=now_s)
-        if use_cache:
-            with _cache_lock:
-                return _cache_login("", now_s=now_s)
-        return ""
-
-    if login:
-        with _cache_lock:
-            return _cache_login(login, now_s=now_s)
-
-    api_proc = run_gh(
-        [
-            "gh",
-            "api",
-            "user",
-            "-H",
-            "Accept: application/vnd.github+json",
-        ],
-        timeout_s=timeout_s,
-    )
-    if api_proc.returncode != 0:
-        with _cache_lock:
-            return _cache_login("", now_s=now_s)
-
-    payload = _safe_text(api_proc.stdout)
-    if not payload:
-        with _cache_lock:
-            return _cache_login("", now_s=now_s)
-
-    try:
-        data = json.loads(payload)
-    except Exception:
-        with _cache_lock:
-            return _cache_login("", now_s=now_s)
-
-    data_dict = _as_object_dict(data)
-    if data_dict is None:
-        with _cache_lock:
-            return _cache_login("", now_s=now_s)
-
-    parsed_login = _safe_text(data_dict.get("login")).lower()
-    with _cache_lock:
-        return _cache_login(parsed_login, now_s=now_s)
+    return get_gh_auth_snapshot(timeout_s=timeout_s, use_cache=use_cache).login

--- a/agents_runner/setup/agent_status.py
+++ b/agents_runner/setup/agent_status.py
@@ -2,15 +2,15 @@
 
 from __future__ import annotations
 
-import subprocess
-
 from agents_runner.agent_systems import available_agent_system_names
 from agents_runner.agent_systems import get_agent_system
+from agents_runner.agent_systems.github_status import github_auth_status
 from agents_runner.agent_systems.status import AgentStatus
 from agents_runner.agent_systems.status import StatusType
 from agents_runner.agent_systems.status import command_in_path
 from agents_runner.agent_systems.status import installed_status
 from agents_runner.agent_systems.status import not_installed_status
+from agents_runner.gh.auth import get_gh_auth_snapshot
 
 
 def detect_gh_status() -> AgentStatus:
@@ -19,55 +19,7 @@ def detect_gh_status() -> AgentStatus:
     if not command_in_path("gh"):
         return not_installed_status(agent="github")
 
-    try:
-        result = subprocess.run(
-            ["gh", "auth", "status"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-    except subprocess.TimeoutExpired:
-        return installed_status(
-            agent="github",
-            logged_in=False,
-            status_text="Unknown (timeout)",
-            status_type=StatusType.UNKNOWN,
-        )
-    except (FileNotFoundError, OSError):
-        return installed_status(
-            agent="github",
-            logged_in=False,
-            status_text="Unknown (gh CLI not found)",
-            status_type=StatusType.UNKNOWN,
-        )
-
-    if result.returncode == 0 and "Logged in" in result.stdout:
-        username = None
-        for line in result.stdout.split("\n"):
-            if "Logged in to github.com account" not in line:
-                continue
-            parts = line.split("account")
-            if len(parts) > 1:
-                username = parts[1].split("(")[0].strip() or None
-                break
-        if username:
-            return installed_status(
-                agent="github",
-                logged_in=True,
-                status_text=f"Logged in as {username}",
-                username=username,
-            )
-        return installed_status(
-            agent="github",
-            logged_in=True,
-            status_text="Logged in",
-        )
-
-    return installed_status(
-        agent="github",
-        logged_in=False,
-        status_text="Not logged in to GitHub",
-    )
+    return github_auth_status(agent="github", snapshot=get_gh_auth_snapshot(timeout_s=5.0, use_cache=True))
 
 
 def detect_all_agents() -> list[AgentStatus]:

--- a/agents_runner/setup/orchestrator.py
+++ b/agents_runner/setup/orchestrator.py
@@ -16,6 +16,7 @@ import tempfile
 from datetime import datetime
 from typing import Any, Callable
 
+from agents_runner.gh.auth import invalidate_gh_auth_cache
 from agents_runner.setup.commands import get_setup_command
 from agents_runner.terminal_apps import (
     detect_terminal_options,
@@ -208,7 +209,10 @@ def launch_agent_setup_terminal(agent: str, terminal: TerminalOption) -> bool:
 
     try:
         result = launch_terminal_and_wait(terminal, command, cwd=None)
-        return result.returncode == 0
+        succeeded = result.returncode == 0
+        if succeeded and agent in {"github", "copilot"}:
+            invalidate_gh_auth_cache()
+        return succeeded
     except Exception:
         return False
 

--- a/agents_runner/tests/test_gh_auth.py
+++ b/agents_runner/tests/test_gh_auth.py
@@ -101,6 +101,50 @@ def test_failed_refresh_wakes_waiters(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+def test_transient_failure_is_retried_without_normal_cache_delay(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    def run_gh(args: list[str], *, timeout_s: float) -> subprocess.CompletedProcess[str]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise GhManagementError("command timed out")
+        return _status_result(authenticated=True)
+
+    monkeypatch.setattr(auth, "run_gh", run_gh)
+    assert not auth.is_gh_authenticated()
+    assert auth.is_gh_authenticated()
+    assert calls == 2
+
+
+def test_invalidation_during_refresh_reprobes_before_publishing(monkeypatch: pytest.MonkeyPatch) -> None:
+    first_probe_started = threading.Event()
+    release_first_probe = threading.Event()
+    calls = 0
+
+    def run_gh(args: list[str], *, timeout_s: float) -> subprocess.CompletedProcess[str]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            first_probe_started.set()
+            assert release_first_probe.wait(timeout=2.0)
+            return _status_result(authenticated=True, login="stale-user")
+        return _status_result(authenticated=True, login="fresh-user")
+
+    monkeypatch.setattr(auth, "run_gh", run_gh)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first_result = executor.submit(auth.get_gh_auth_snapshot)
+        assert first_probe_started.wait(timeout=2.0)
+        waiting_result = executor.submit(auth.get_gh_auth_snapshot)
+        auth.invalidate_gh_auth_cache()
+        release_first_probe.set()
+
+    assert first_result.result().login == "fresh-user"
+    assert waiting_result.result().login == "fresh-user"
+    assert auth.resolve_authenticated_login() == "fresh-user"
+    assert calls == 2
+
+
 def test_forced_refresh_is_single_flight(monkeypatch: pytest.MonkeyPatch) -> None:
     calls = 0
 

--- a/agents_runner/tests/test_gh_auth.py
+++ b/agents_runner/tests/test_gh_auth.py
@@ -1,0 +1,153 @@
+"""Focused verification for the shared GitHub authentication snapshot."""
+
+from __future__ import annotations
+
+import subprocess
+import threading
+import time
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import Callable
+
+import pytest
+
+from agents_runner.gh import auth
+from agents_runner.gh.errors import GhManagementError
+
+
+@pytest.fixture(autouse=True)
+def _reset_auth_cache() -> None:
+    auth.reset_gh_auth_cache()
+    yield
+    auth.reset_gh_auth_cache()
+
+
+def _status_result(*, authenticated: bool, login: str = "octocat") -> subprocess.CompletedProcess[str]:
+    output = f"Logged in to github.com account {login} (keyring)" if authenticated else "not logged in"
+    return subprocess.CompletedProcess(["gh"], 0 if authenticated else 1, output, "")
+
+
+def _run_concurrently(call: Callable[[], object], *, count: int = 24) -> list[object]:
+    start = threading.Barrier(count)
+
+    def synchronized_call() -> object:
+        start.wait()
+        return call()
+
+    with ThreadPoolExecutor(max_workers=count) as executor:
+        return list(executor.map(lambda _: synchronized_call(), range(count)))
+
+
+def test_simultaneous_cold_cache_callers_launch_one_status_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    def run_gh(args: list[str], *, timeout_s: float) -> subprocess.CompletedProcess[str]:
+        nonlocal calls
+        calls += 1
+        time.sleep(0.05)
+        return _status_result(authenticated=True)
+
+    monkeypatch.setattr(auth, "run_gh", run_gh)
+    results = _run_concurrently(auth.get_gh_auth_snapshot)
+
+    assert calls == 1
+    assert all(isinstance(result, auth.GhAuthSnapshot) and result.authenticated for result in results)
+
+
+@pytest.mark.parametrize("authenticated", [True, False])
+def test_authentication_results_are_cached(monkeypatch: pytest.MonkeyPatch, authenticated: bool) -> None:
+    calls = 0
+
+    def run_gh(args: list[str], *, timeout_s: float) -> subprocess.CompletedProcess[str]:
+        nonlocal calls
+        calls += 1
+        return _status_result(authenticated=authenticated)
+
+    monkeypatch.setattr(auth, "run_gh", run_gh)
+    assert auth.is_gh_authenticated() is authenticated
+    assert auth.is_gh_authenticated() is authenticated
+    assert calls == 1
+
+
+def test_authentication_and_login_queries_share_one_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    def run_gh(args: list[str], *, timeout_s: float) -> subprocess.CompletedProcess[str]:
+        nonlocal calls
+        calls += 1
+        return _status_result(authenticated=True, login="OctoCat")
+
+    monkeypatch.setattr(auth, "run_gh", run_gh)
+    assert auth.is_gh_authenticated()
+    assert auth.resolve_authenticated_login() == "octocat"
+    assert calls == 1
+
+
+def test_failed_refresh_wakes_waiters(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    def run_gh(args: list[str], *, timeout_s: float) -> subprocess.CompletedProcess[str]:
+        nonlocal calls
+        calls += 1
+        time.sleep(0.05)
+        raise GhManagementError("command timed out")
+
+    monkeypatch.setattr(auth, "run_gh", run_gh)
+    results = _run_concurrently(auth.get_gh_auth_snapshot)
+
+    assert calls == 1
+    assert all(
+        isinstance(result, auth.GhAuthSnapshot) and result.error == auth.GhAuthError.TIMEOUT for result in results
+    )
+
+
+def test_forced_refresh_is_single_flight(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    def run_gh(args: list[str], *, timeout_s: float) -> subprocess.CompletedProcess[str]:
+        nonlocal calls
+        calls += 1
+        time.sleep(0.05)
+        return _status_result(authenticated=True)
+
+    monkeypatch.setattr(auth, "run_gh", run_gh)
+    results = _run_concurrently(lambda: auth.get_gh_auth_snapshot(use_cache=False))
+
+    assert calls == 1
+    assert all(isinstance(result, auth.GhAuthSnapshot) and result.authenticated for result in results)
+
+
+def test_expiry_uses_injected_monotonic_clock(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = [100.0]
+    calls = 0
+    auth.reset_gh_auth_cache(monotonic=lambda: now[0])
+
+    def run_gh(args: list[str], *, timeout_s: float) -> subprocess.CompletedProcess[str]:
+        nonlocal calls
+        calls += 1
+        return _status_result(authenticated=True)
+
+    monkeypatch.setattr(auth, "run_gh", run_gh)
+    auth.is_gh_authenticated()
+    now[0] += 299.0
+    auth.is_gh_authenticated()
+    now[0] += 2.0
+    auth.is_gh_authenticated()
+    assert calls == 2
+
+
+def test_api_fallback_runs_only_when_status_has_no_login(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def run_gh(args: list[str], *, timeout_s: float) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        if args[1:3] == ["auth", "status"]:
+            login = "" if len(calls) == 1 else "status-user"
+            return _status_result(authenticated=True, login=login)
+        return subprocess.CompletedProcess(args, 0, '{"login": "api-user"}', "")
+
+    monkeypatch.setattr(auth, "run_gh", run_gh)
+    assert auth.resolve_authenticated_login() == "api-user"
+    auth.invalidate_gh_auth_cache()
+    assert auth.resolve_authenticated_login() == "status-user"
+    assert [call[1] for call in calls] == ["auth", "api", "auth"]


### PR DESCRIPTION
### Motivation
- Prevent duplicate `gh auth status` subprocess probes from concurrent pollers by centralizing authentication state into one shared snapshot with monotonic expiry.
- Ensure `is_gh_authenticated()` and `resolve_authenticated_login()` reuse a single probe so login lookups do not trigger redundant status calls.
- Provide deterministic cache invalidation that callers can use after setup/login flows so credential changes become visible promptly.
- Preserve existing UI-visible semantics for setup and Copilot status detection while removing duplicated parsing logic.

### Description
- Introduced a frozen `GhAuthSnapshot` with `authenticated`, normalized `login`, monotonic `expires_at`, and an `error` enum, plus a condition-variable single-flight refresh in `agents_runner/gh/auth.py` that coalesces concurrent refreshes and supports `use_cache=False` forced refreshes and `reset_gh_auth_cache()` for deterministic tests.
- Parse authentication state and login from the same `gh auth status` output and run `gh api user` only as a narrow fallback when `auth status` indicates success but exposes no login.
- Exposed `get_gh_auth_snapshot()`, `is_gh_authenticated()`, `resolve_authenticated_login()`, and `invalidate_gh_auth_cache()` to callers; `get_gh_auth_snapshot()` uses `time.monotonic()` by default and accepts an injected monotonic clock for tests.
- Replaced direct `subprocess.run([

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a74d2192d548320a4adac3aaeb769ec)